### PR TITLE
Add persistent Streamerbot chat history (200 message rolling buffer)

### DIFF
--- a/components/presenter/hooks/useStreamerbotClient.ts
+++ b/components/presenter/hooks/useStreamerbotClient.ts
@@ -151,6 +151,22 @@ export function useStreamerbotClient({
         .catch((err) => {
           console.error("[Streamerbot] Failed to fetch status:", err);
         });
+
+        // Load chat history from database
+        fetch(`${getBackendUrl()}/api/streamerbot-chat/history`)
+        .then((res) => res.json())
+        .then((data: { messages: ChatMessage[]; count: number }) => {
+          if (mountedRef.current && data.messages && data.messages.length > 0) {
+            console.log(`[Streamerbot] Loaded ${data.count} historical messages`);
+            // Add historical messages to the message buffer
+            data.messages.forEach((msg) => {
+              onMessageRef.current?.(msg);
+            });
+          }
+        })
+        .catch((err) => {
+          console.error("[Streamerbot] Failed to fetch history:", err);
+        });
       };
 
       ws.onmessage = (event) => {

--- a/lib/models/Database.ts
+++ b/lib/models/Database.ts
@@ -1,4 +1,10 @@
-import type { StreamerbotConnectionSettings } from "./StreamerbotChat";
+import type {
+  StreamerbotConnectionSettings,
+  ChatPlatform,
+  ChatEventType,
+  MessagePart,
+  ChatMessageMetadata,
+} from "./StreamerbotChat";
 
 /**
  * Database model type definitions
@@ -251,4 +257,23 @@ export type DbCueMessageInput = Omit<DbCueMessage, 'createdAt' | 'updatedAt'> & 
 
 export type DbCueMessageUpdate = Partial<Omit<DbCueMessage, 'id' | 'roomId' | 'createdAt'>> & {
   updatedAt?: number;
+};
+
+// Streamerbot Chat Message (global rolling buffer)
+export interface DbStreamerbotChatMessage {
+  id: string;
+  timestamp: number;
+  platform: ChatPlatform;
+  eventType: ChatEventType;
+  channel: string | null;
+  username: string;
+  displayName: string;
+  message: string;
+  parts: MessagePart[] | null;
+  metadata: ChatMessageMetadata | null;
+  createdAt: number;
+}
+
+export type DbStreamerbotChatMessageInput = Omit<DbStreamerbotChatMessage, 'createdAt'> & {
+  createdAt?: number;
 };

--- a/server/api/streamerbot-chat.ts
+++ b/server/api/streamerbot-chat.ts
@@ -4,6 +4,7 @@
 import { Router } from "express";
 import { StreamerbotGateway } from "../../lib/adapters/streamerbot/StreamerbotGateway";
 import { SettingsService } from "../../lib/services/SettingsService";
+import { DatabaseService } from "../../lib/services/DatabaseService";
 import { chatPlatformSchema } from "../../lib/models/StreamerbotChat";
 
 const router = Router();
@@ -20,6 +21,26 @@ router.get("/status", async (req, res) => {
     res.json(status);
   } catch (error) {
     console.error("[StreamerbotGateway] Status error:", error);
+    res.status(500).json({ error: String(error) });
+  }
+});
+
+/**
+ * GET /api/streamerbot-chat/history
+ * Get recent chat messages from database (rolling buffer of 200 messages)
+ */
+router.get("/history", async (req, res) => {
+  try {
+    const db = DatabaseService.getInstance();
+    const messages = db.getStreamerbotChatMessages(200);
+
+    // Return in chronological order (oldest first) for frontend consumption
+    res.json({
+      messages: messages.reverse(),
+      count: messages.length,
+    });
+  } catch (error) {
+    console.error("[StreamerbotGateway] History fetch error:", error);
     res.status(500).json({ error: String(error) });
   }
 });


### PR DESCRIPTION
## Summary
- Persist Streamerbot chat messages to SQLite so they survive browser refresh
- Rolling buffer automatically trims to keep only the last 200 messages
- Messages are loaded when WebSocket connects, providing seamless history on page reload

## Changes
- `lib/models/Database.ts` - Added `DbStreamerbotChatMessage` types
- `lib/services/DatabaseService.ts` - Added table and CRUD methods
- `lib/adapters/streamerbot/StreamerbotGateway.ts` - Persist messages on receive
- `server/api/streamerbot-chat.ts` - Added `GET /history` endpoint
- `components/presenter/hooks/useStreamerbotClient.ts` - Load history on connect

## Test plan
- [ ] Receive chat messages and verify they appear in the panel
- [ ] Refresh the page and verify messages are restored from history
- [ ] Send 200+ messages and verify buffer trimming works (oldest removed)
- [ ] Verify no duplicate messages after reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)