### PR TITLE
Add customizable panel colors for deckview dashboard

### DIFF
--- a/app/api/panel-colors/[panelId]/route.ts
+++ b/app/api/panel-colors/[panelId]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { DatabaseService } from "@/lib/services/DatabaseService";
+import { PANEL_IDS } from "@/lib/models/PanelColor";
+
+/**
+ * GET a single panel color by panel ID
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ panelId: string }> }
+) {
+  try {
+    const { panelId } = await params;
+    const db = DatabaseService.getInstance();
+    const panelColor = db.getPanelColorByPanelId(panelId);
+
+    if (!panelColor) {
+      return NextResponse.json({ panelColor: null }, { status: 200 });
+    }
+
+    return NextResponse.json({ panelColor }, { status: 200 });
+  } catch (error) {
+    console.error("[API] Failed to get panel color:", error);
+    return NextResponse.json(
+      { error: "Failed to get panel color" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE a panel color (reset to default)
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ panelId: string }> }
+) {
+  try {
+    const { panelId } = await params;
+
+    // Validate panelId
+    if (!PANEL_IDS.includes(panelId as typeof PANEL_IDS[number])) {
+      return NextResponse.json(
+        { error: `Invalid panelId. Must be one of: ${PANEL_IDS.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    const db = DatabaseService.getInstance();
+    db.deletePanelColor(panelId);
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error("[API] Failed to delete panel color:", error);
+    return NextResponse.json(
+      { error: "Failed to delete panel color" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/panel-colors/route.ts
+++ b/app/api/panel-colors/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { DatabaseService } from "@/lib/services/DatabaseService";
+import { panelColorUpdateSchema, PANEL_IDS } from "@/lib/models/PanelColor";
+
+/**
+ * GET all panel colors
+ */
+export async function GET() {
+  try {
+    const db = DatabaseService.getInstance();
+    const colors = db.getAllPanelColors();
+    return NextResponse.json({ colors }, { status: 200 });
+  } catch (error) {
+    console.error("[API] Failed to get panel colors:", error);
+    return NextResponse.json(
+      { error: "Failed to get panel colors" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST upsert a panel color
+ * Body: { panelId: string, ...colors }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { panelId, ...colorUpdates } = body;
+
+    // Validate panelId
+    if (!panelId || !PANEL_IDS.includes(panelId)) {
+      return NextResponse.json(
+        { error: `Invalid panelId. Must be one of: ${PANEL_IDS.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    // Validate color updates
+    const validated = panelColorUpdateSchema.parse(colorUpdates);
+
+    const db = DatabaseService.getInstance();
+    const panelColor = db.upsertPanelColor(panelId, validated);
+
+    return NextResponse.json({ panelColor }, { status: 200 });
+  } catch (error) {
+    console.error("[API] Failed to upsert panel color:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to upsert panel color" },
+      { status: 400 }
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -66,7 +66,7 @@
   body {
     @apply bg-background text-foreground text-sm;
   }
-  
+
   /* Refined UI - more compact spacing and typography */
   h1 {
     @apply text-xl font-semibold;
@@ -77,5 +77,16 @@
   h3 {
     @apply text-base font-semibold;
   }
+}
+
+/* Panel Color Customization - Dynamic styles injected by PanelColorStyles component */
+/* Base styles to ensure panel content inherits background colors */
+[data-panel-id] {
+  transition: background-color 0.2s ease;
+}
+
+/* Dockview tab transition for smooth color changes */
+.dv-tab[data-panel-id] {
+  transition: background-color 0.2s ease;
 }
 

--- a/components/shell/DashboardShell.tsx
+++ b/components/shell/DashboardShell.tsx
@@ -28,6 +28,8 @@ import { LayoutPresetsProvider, LayoutPreset } from "./LayoutPresetsContext";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { LiveModeRail } from "./LiveModeRail";
 import { useAppMode } from "./AppModeContext";
+import { PanelColorsProvider } from "./PanelColorsContext";
+import { PanelColorStyles } from "./PanelColorStyles";
 
 const LAYOUT_KEY = "obs-live-suite-dockview-layout";
 const PRESET_KEY = "obs-live-suite-layout-preset";
@@ -299,19 +301,22 @@ export function DashboardShell() {
   }, []);
 
   return (
-    <LayoutPresetsProvider applyPreset={applyPreset}>
-      <DockviewContext.Provider value={{ api }}>
-        <div style={{ height: "100vh", width: "100vw", display: "flex" }}>
-          {mode === "LIVE" && !isFullscreenMode && <LiveModeRail />}
-          <div style={{ flex: 1 }}>
-            <DockviewReact
-              components={components}
-              onReady={onReady}
-              theme={!mounted || theme === "dark" ? themeDark : themeLight}
-            />
+    <PanelColorsProvider>
+      <LayoutPresetsProvider applyPreset={applyPreset}>
+        <DockviewContext.Provider value={{ api }}>
+          <PanelColorStyles />
+          <div style={{ height: "100vh", width: "100vw", display: "flex" }}>
+            {mode === "LIVE" && !isFullscreenMode && <LiveModeRail />}
+            <div style={{ flex: 1 }}>
+              <DockviewReact
+                components={components}
+                onReady={onReady}
+                theme={!mounted || theme === "dark" ? themeDark : themeLight}
+              />
+            </div>
           </div>
-        </div>
-      </DockviewContext.Provider>
-    </LayoutPresetsProvider>
+        </DockviewContext.Provider>
+      </LayoutPresetsProvider>
+    </PanelColorsProvider>
   );
 }

--- a/components/shell/PanelColorMenu.tsx
+++ b/components/shell/PanelColorMenu.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { ReactNode, useState, useCallback } from "react";
+import { useTheme } from "next-themes";
+import { Palette, RotateCcw, Sun, Moon } from "lucide-react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+  ContextMenuLabel,
+} from "@/components/ui/context-menu";
+import { usePanelColors } from "./PanelColorsContext";
+import type { PanelId } from "@/lib/models/PanelColor";
+import { PANEL_DISPLAY_NAMES } from "@/lib/models/PanelColor";
+
+interface ColorPickerItemProps {
+  label: string;
+  value: string | null;
+  onChange: (color: string) => void;
+}
+
+function ColorPickerItem({ label, value, onChange }: ColorPickerItemProps) {
+  return (
+    <div className="flex items-center gap-2 px-2 py-1.5">
+      <span className="text-sm flex-1">{label}</span>
+      <input
+        type="color"
+        value={value || "#3b82f6"}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-8 h-6 cursor-pointer rounded border border-border"
+      />
+    </div>
+  );
+}
+
+interface PanelColorMenuProps {
+  panelId: PanelId;
+  children: ReactNode;
+}
+
+export function PanelColorMenu({ panelId, children }: PanelColorMenuProps) {
+  const { colors, updateColor, resetColor } = usePanelColors();
+  const { theme, systemTheme } = useTheme();
+  const panelColors = colors[panelId];
+
+  const isDark = theme === "dark" || (theme === "system" && systemTheme === "dark");
+  const displayName = PANEL_DISPLAY_NAMES[panelId] || panelId;
+
+  const handleBackgroundChange = useCallback((color: string) => {
+    if (isDark) {
+      updateColor(panelId, { darkBackground: color });
+    } else {
+      updateColor(panelId, { lightBackground: color });
+    }
+  }, [panelId, updateColor, isDark]);
+
+  const handleHeaderChange = useCallback((color: string) => {
+    if (isDark) {
+      updateColor(panelId, { darkHeader: color });
+    } else {
+      updateColor(panelId, { lightHeader: color });
+    }
+  }, [panelId, updateColor, isDark]);
+
+  const handleReset = useCallback(() => {
+    resetColor(panelId);
+  }, [panelId, resetColor]);
+
+  const currentBackground = isDark
+    ? panelColors?.darkBackground
+    : panelColors?.lightBackground;
+  const currentHeader = isDark
+    ? panelColors?.darkHeader
+    : panelColors?.lightHeader;
+
+  const hasCustomColors = currentBackground || currentHeader;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <ContextMenuLabel className="flex items-center gap-2">
+          <Palette className="h-4 w-4" />
+          {displayName} Colors
+          {isDark ? (
+            <Moon className="h-3 w-3 ml-auto text-muted-foreground" />
+          ) : (
+            <Sun className="h-3 w-3 ml-auto text-muted-foreground" />
+          )}
+        </ContextMenuLabel>
+        <ContextMenuSeparator />
+
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <div className="flex items-center gap-2">
+              <div
+                className="w-4 h-4 rounded border border-border"
+                style={{ backgroundColor: currentBackground || "transparent" }}
+              />
+              Background
+            </div>
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent>
+            <ColorPickerItem
+              label={isDark ? "Dark Mode" : "Light Mode"}
+              value={currentBackground}
+              onChange={handleBackgroundChange}
+            />
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <div className="flex items-center gap-2">
+              <div
+                className="w-4 h-4 rounded border border-border"
+                style={{ backgroundColor: currentHeader || "transparent" }}
+              />
+              Header/Tab
+            </div>
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent>
+            <ColorPickerItem
+              label={isDark ? "Dark Mode" : "Light Mode"}
+              value={currentHeader}
+              onChange={handleHeaderChange}
+            />
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+
+        {hasCustomColors && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem onClick={handleReset}>
+              <RotateCcw className="h-4 w-4 mr-2" />
+              Reset to Default
+            </ContextMenuItem>
+          </>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/components/shell/PanelColorStyles.tsx
+++ b/components/shell/PanelColorStyles.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTheme } from "next-themes";
+import { usePanelColors } from "./PanelColorsContext";
+import type { DbPanelColor } from "@/lib/models/Database";
+
+/**
+ * Generate CSS rules for a single panel's colors
+ */
+function generatePanelCSS(panelId: string, colors: DbPanelColor, isDark: boolean): string {
+  const bg = isDark ? colors.darkBackground : colors.lightBackground;
+  const header = isDark ? colors.darkHeader : colors.lightHeader;
+
+  let css = "";
+
+  // Panel content background
+  if (bg) {
+    css += `[data-panel-id="${panelId}"] { background-color: ${bg} !important; }\n`;
+  }
+
+  // Panel tab/header background
+  // Dockview uses data-dv-panel-id attribute on tabs
+  if (header) {
+    css += `.dv-tab[data-panel-id="${panelId}"] { background-color: ${header} !important; }\n`;
+    css += `.dv-tab[data-panel-id="${panelId}"].dv-tab-active { background-color: ${header} !important; }\n`;
+  }
+
+  return css;
+}
+
+/**
+ * Component that injects dynamic CSS for panel colors
+ * Renders a <style> element with rules targeting panel IDs
+ */
+export function PanelColorStyles() {
+  const { colors } = usePanelColors();
+  const { theme, systemTheme } = useTheme();
+
+  // Determine if we're in dark mode
+  const isDark = theme === "dark" || (theme === "system" && systemTheme === "dark");
+
+  // Generate all CSS rules
+  const cssContent = useMemo(() => {
+    const rules: string[] = [];
+
+    for (const [panelId, panelColors] of Object.entries(colors)) {
+      const panelCSS = generatePanelCSS(panelId, panelColors, isDark);
+      if (panelCSS) {
+        rules.push(panelCSS);
+      }
+    }
+
+    return rules.join("\n");
+  }, [colors, isDark]);
+
+  // Only render if there are custom colors
+  if (!cssContent) {
+    return null;
+  }
+
+  return (
+    <style
+      id="panel-color-styles"
+      dangerouslySetInnerHTML={{ __html: cssContent }}
+    />
+  );
+}

--- a/components/shell/PanelColorsContext.tsx
+++ b/components/shell/PanelColorsContext.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from "react";
+import type { DbPanelColor } from "@/lib/models/Database";
+import type { PanelId, PanelColorUpdate } from "@/lib/models/PanelColor";
+
+interface PanelColorsContextValue {
+  colors: Record<string, DbPanelColor>;
+  updateColor: (panelId: PanelId, updates: PanelColorUpdate) => Promise<void>;
+  resetColor: (panelId: PanelId) => Promise<void>;
+  isLoading: boolean;
+}
+
+const PanelColorsContext = createContext<PanelColorsContextValue | null>(null);
+
+export function usePanelColors() {
+  const context = useContext(PanelColorsContext);
+  if (!context) {
+    throw new Error("usePanelColors must be used within a PanelColorsProvider");
+  }
+  return context;
+}
+
+interface PanelColorsProviderProps {
+  children: ReactNode;
+}
+
+export function PanelColorsProvider({ children }: PanelColorsProviderProps) {
+  const [colors, setColors] = useState<Record<string, DbPanelColor>>({});
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Fetch all panel colors on mount
+  useEffect(() => {
+    async function fetchColors() {
+      try {
+        const response = await fetch("/api/panel-colors");
+        if (response.ok) {
+          const data = await response.json();
+          const colorMap: Record<string, DbPanelColor> = {};
+          for (const color of data.colors) {
+            colorMap[color.panelId] = color;
+          }
+          setColors(colorMap);
+        }
+      } catch (error) {
+        console.error("Failed to fetch panel colors:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchColors();
+  }, []);
+
+  const updateColor = useCallback(async (panelId: PanelId, updates: PanelColorUpdate) => {
+    try {
+      const response = await fetch("/api/panel-colors", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ panelId, ...updates }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setColors((prev) => ({
+          ...prev,
+          [panelId]: data.panelColor,
+        }));
+      }
+    } catch (error) {
+      console.error("Failed to update panel color:", error);
+    }
+  }, []);
+
+  const resetColor = useCallback(async (panelId: PanelId) => {
+    try {
+      const response = await fetch(`/api/panel-colors/${panelId}`, {
+        method: "DELETE",
+      });
+
+      if (response.ok) {
+        setColors((prev) => {
+          const next = { ...prev };
+          delete next[panelId];
+          return next;
+        });
+      }
+    } catch (error) {
+      console.error("Failed to reset panel color:", error);
+    }
+  }, []);
+
+  return (
+    <PanelColorsContext.Provider value={{ colors, updateColor, resetColor, isLoading }}>
+      {children}
+    </PanelColorsContext.Provider>
+  );
+}

--- a/components/shell/panels/CountdownPanel.tsx
+++ b/components/shell/panels/CountdownPanel.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Play, Pause, RotateCcw, Plus, Settings } from "lucide-react";
+import { PanelColorMenu } from "../PanelColorMenu";
 
 /**
  * Countdown panel for Dockview - displays countdown controls without Card wrapper
@@ -207,9 +208,10 @@ export function CountdownPanel(props: IDockviewPanelProps) {
   };
 
   return (
-    <div style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
-      <div className="space-y-4">
-        <div className="grid grid-cols-4 gap-2">
+    <PanelColorMenu panelId="countdown">
+      <div data-panel-id="countdown" style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
+        <div className="space-y-4">
+          <div className="grid grid-cols-4 gap-2">
           {presets.map((preset) => (
             <Button
               key={preset.value}
@@ -447,7 +449,8 @@ export function CountdownPanel(props: IDockviewPanelProps) {
             </div>
           </div>
         )}
+        </div>
       </div>
-    </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/CueComposerPanel.tsx
+++ b/components/shell/panels/CueComposerPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { type IDockviewPanelProps } from "dockview-react";
 import { Send, Pin, AlertCircle, Info, AlertTriangle, Clock, FileText } from "lucide-react";
+import { PanelColorMenu } from "../PanelColorMenu";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -230,8 +231,10 @@ function CueComposerContent() {
 
 export function CueComposerPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ height: "100%", overflow: "auto" }}>
-      <CueComposerContent />
-    </div>
+    <PanelColorMenu panelId="cueComposer">
+      <div data-panel-id="cueComposer" style={{ height: "100%", overflow: "auto" }}>
+        <CueComposerContent />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/EventLogPanel.tsx
+++ b/components/shell/panels/EventLogPanel.tsx
@@ -1,5 +1,6 @@
 import { type IDockviewPanelProps } from "dockview-react";
 import { EventLog } from "@/components/dashboard/EventLog";
+import { PanelColorMenu } from "../PanelColorMenu";
 
 /**
  * Event Log panel for Dockview
@@ -7,8 +8,10 @@ import { EventLog } from "@/components/dashboard/EventLog";
  */
 export function EventLogPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
-      <EventLog />
-    </div>
+    <PanelColorMenu panelId="eventLog">
+      <div data-panel-id="eventLog" style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
+        <EventLog />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/GuestsPanel.tsx
+++ b/components/shell/panels/GuestsPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useRef } from "react";
 import { Zap } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { getWebSocketUrl } from "@/lib/utils/websocket";
+import { PanelColorMenu } from "../PanelColorMenu";
 
 interface Guest {
   id: string;
@@ -148,8 +149,9 @@ export function GuestsPanel(props: IDockviewPanelProps) {
   };
 
   return (
-    <div style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
-      {loading ? (
+    <PanelColorMenu panelId="guests">
+      <div data-panel-id="guests" style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
+        {loading ? (
         <div className="text-sm text-muted-foreground">Loading...</div>
       ) : guests.length === 0 ? (
         <div className="text-sm text-muted-foreground text-center py-4">
@@ -213,7 +215,8 @@ export function GuestsPanel(props: IDockviewPanelProps) {
             );
           })}
         </div>
-      )}
-    </div>
+        )}
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/LowerThirdPanel.tsx
+++ b/components/shell/panels/LowerThirdPanel.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Eye, EyeOff, Timer, Loader2, ExternalLink, FileText, X, Search, Sparkles } from "lucide-react";
 import { PosterQuickAdd } from "@/components/assets/PosterQuickAdd";
 import { toast } from "sonner";
+import { PanelColorMenu } from "../PanelColorMenu";
 
 interface WikipediaPreview {
   title: string;
@@ -275,8 +276,9 @@ export function LowerThirdPanel(props: IDockviewPanelProps) {
   };
 
   return (
-    <div style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
-      <div className="space-y-4">
+    <PanelColorMenu panelId="lowerThird">
+      <div data-panel-id="lowerThird" style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
+        <div className="space-y-4">
         <div className="flex gap-2">
           <Button
             variant={mode === "guest" ? "default" : "outline"}
@@ -549,7 +551,8 @@ export function LowerThirdPanel(props: IDockviewPanelProps) {
             <Timer className="w-4 h-4" />
           </Button>
         </div>
+        </div>
       </div>
-    </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/MacrosPanel.tsx
+++ b/components/shell/panels/MacrosPanel.tsx
@@ -1,5 +1,6 @@
 import { type IDockviewPanelProps } from "dockview-react";
 import { MacrosBar } from "@/components/dashboard/MacrosBar";
+import { PanelColorMenu } from "../PanelColorMenu";
 
 /**
  * Macros panel for Dockview
@@ -7,8 +8,10 @@ import { MacrosBar } from "@/components/dashboard/MacrosBar";
  */
 export function MacrosPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
-      <MacrosBar />
-    </div>
+    <PanelColorMenu panelId="macros">
+      <div data-panel-id="macros" style={{ padding: "1rem", height: "100%", overflow: "auto" }}>
+        <MacrosBar />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/PosterPanel.tsx
+++ b/components/shell/panels/PosterPanel.tsx
@@ -1,5 +1,6 @@
 import { type IDockviewPanelProps } from "dockview-react";
 import { PosterCard } from "@/components/dashboard/cards/PosterCard";
+import { PanelColorMenu } from "../PanelColorMenu";
 
 /**
  * Poster panel for Dockview
@@ -7,8 +8,10 @@ import { PosterCard } from "@/components/dashboard/cards/PosterCard";
  */
 export function PosterPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ padding: "0", height: "100%", overflow: "auto" }}>
-      <PosterCard className="border-0 shadow-none" />
-    </div>
+    <PanelColorMenu panelId="poster">
+      <div data-panel-id="poster" style={{ padding: "0", height: "100%", overflow: "auto" }}>
+        <PosterCard className="border-0 shadow-none" />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/PresenceStatusPanel.tsx
+++ b/components/shell/panels/PresenceStatusPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { type IDockviewPanelProps } from "dockview-react";
 import { Wifi, WifiOff, User, Users, AlertCircle, ExternalLink, RefreshCw } from "lucide-react";
+import { PanelColorMenu } from "../PanelColorMenu";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -216,8 +217,10 @@ function PresenceStatusContent() {
 
 export function PresenceStatusPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ height: "100%", overflow: "auto" }}>
-      <PresenceStatusContent />
-    </div>
+    <PanelColorMenu panelId="presenceStatus">
+      <div data-panel-id="presenceStatus" style={{ height: "100%", overflow: "auto" }}>
+        <PresenceStatusContent />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/RegieInternalChatPanel.tsx
+++ b/components/shell/panels/RegieInternalChatPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { type IDockviewPanelProps } from "dockview-react";
 import { Send, Pin, AlertCircle, Info, AlertTriangle, Clock, FileText, Megaphone, Tv, Wrench } from "lucide-react";
+import { PanelColorMenu } from "../PanelColorMenu";
 import { Button } from "@/components/ui/button";
 import { CueType, CueSeverity, CueFrom } from "@/lib/models/Cue";
 import { DEFAULT_ROOM_ID } from "@/lib/models/Room";
@@ -224,8 +225,10 @@ function RegieInternalChatContent() {
 
 export function RegieInternalChatPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ height: "100%", overflow: "hidden" }}>
-      <RegieInternalChatContent />
-    </div>
+    <PanelColorMenu panelId="regieInternalChat">
+      <div data-panel-id="regieInternalChat" style={{ height: "100%", overflow: "hidden" }}>
+        <RegieInternalChatContent />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/RegieInternalChatViewPanel.tsx
+++ b/components/shell/panels/RegieInternalChatViewPanel.tsx
@@ -2,6 +2,7 @@
 
 import { type IDockviewPanelProps } from "dockview-react";
 import { MessageSquare, Wifi, WifiOff, Trash2 } from "lucide-react";
+import { PanelColorMenu } from "../PanelColorMenu";
 import { Button } from "@/components/ui/button";
 import { usePresenterWebSocket } from "@/components/presenter/hooks/usePresenterWebSocket";
 import { CueFeedPanel } from "@/components/presenter/panels/CueFeedPanel";
@@ -70,8 +71,10 @@ function RegieInternalChatViewContent() {
 
 export function RegieInternalChatViewPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ height: "100%", overflow: "hidden" }}>
-      <RegieInternalChatViewContent />
-    </div>
+    <PanelColorMenu panelId="regieInternalChatView">
+      <div data-panel-id="regieInternalChatView" style={{ height: "100%", overflow: "hidden" }}>
+        <RegieInternalChatViewContent />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/shell/panels/RegiePublicChatPanel.tsx
+++ b/components/shell/panels/RegiePublicChatPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { type IDockviewPanelProps } from "dockview-react";
 import { MessageSquare, Loader2 } from "lucide-react";
+import { PanelColorMenu } from "../PanelColorMenu";
 import { useStreamerbotClient } from "@/components/presenter/hooks/useStreamerbotClient";
 import { useStreamerbotMessages } from "@/components/presenter/hooks/useStreamerbotMessages";
 import { useStreamerbotChatSettings } from "@/components/presenter/hooks/useStreamerbotChatSettings";
@@ -199,8 +200,10 @@ function RegiePublicChatContent() {
 
 export function RegiePublicChatPanel(props: IDockviewPanelProps) {
   return (
-    <div style={{ height: "100%", overflow: "hidden" }}>
-      <RegiePublicChatContent />
-    </div>
+    <PanelColorMenu panelId="regiePublicChat">
+      <div data-panel-id="regiePublicChat" style={{ height: "100%", overflow: "hidden" }}>
+        <RegiePublicChatContent />
+      </div>
+    </PanelColorMenu>
   );
 }

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import * as React from "react"
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const ContextMenu = ContextMenuPrimitive.Root
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger
+
+const ContextMenuGroup = ContextMenuPrimitive.Group
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal
+
+const ContextMenuSub = ContextMenuPrimitive.Sub
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+))
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+))
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+))
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+))
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName
+
+const ContextMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+ContextMenuShortcut.displayName = "ContextMenuShortcut"
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}

--- a/lib/models/Database.ts
+++ b/lib/models/Database.ts
@@ -277,3 +277,24 @@ export interface DbStreamerbotChatMessage {
 export type DbStreamerbotChatMessageInput = Omit<DbStreamerbotChatMessage, 'createdAt'> & {
   createdAt?: number;
 };
+
+// Panel Colors (dashboard panel customization)
+export interface DbPanelColor {
+  id: string;
+  panelId: string;
+  lightBackground: string | null;
+  lightHeader: string | null;
+  darkBackground: string | null;
+  darkHeader: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type DbPanelColorInput = Omit<DbPanelColor, 'createdAt' | 'updatedAt'> & {
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+export type DbPanelColorUpdate = Partial<Omit<DbPanelColor, 'id' | 'panelId' | 'createdAt'>> & {
+  updatedAt?: Date;
+};

--- a/lib/models/PanelColor.ts
+++ b/lib/models/PanelColor.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+/**
+ * Panel IDs for the dashboard dockview panels
+ */
+export const PANEL_IDS = [
+  "lowerThird",
+  "countdown",
+  "guests",
+  "poster",
+  "macros",
+  "eventLog",
+  "cueComposer",
+  "presenceStatus",
+  "regieInternalChat",
+  "regieInternalChatView",
+  "regiePublicChat",
+] as const;
+
+export type PanelId = (typeof PANEL_IDS)[number];
+
+/**
+ * Hex color validation regex
+ */
+const hexColorRegex = /^#[0-9A-Fa-f]{6}$/;
+
+/**
+ * Zod schema for panel color configuration
+ */
+export const panelColorSchema = z.object({
+  id: z.string().uuid(),
+  panelId: z.enum(PANEL_IDS),
+  lightBackground: z.string().regex(hexColorRegex).nullable(),
+  lightHeader: z.string().regex(hexColorRegex).nullable(),
+  darkBackground: z.string().regex(hexColorRegex).nullable(),
+  darkHeader: z.string().regex(hexColorRegex).nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export type PanelColor = z.infer<typeof panelColorSchema>;
+
+/**
+ * Schema for creating/updating panel colors (partial, for API requests)
+ */
+export const panelColorUpdateSchema = z.object({
+  lightBackground: z.string().regex(hexColorRegex).nullable().optional(),
+  lightHeader: z.string().regex(hexColorRegex).nullable().optional(),
+  darkBackground: z.string().regex(hexColorRegex).nullable().optional(),
+  darkHeader: z.string().regex(hexColorRegex).nullable().optional(),
+});
+
+export type PanelColorUpdate = z.infer<typeof panelColorUpdateSchema>;
+
+/**
+ * Panel display names for UI
+ */
+export const PANEL_DISPLAY_NAMES: Record<PanelId, string> = {
+  lowerThird: "Lower Third",
+  countdown: "Countdown",
+  guests: "Guests",
+  poster: "Poster",
+  macros: "Macros",
+  eventLog: "Event Log",
+  cueComposer: "Cue Composer",
+  presenceStatus: "Presence Status",
+  regieInternalChat: "Regie Internal Chat",
+  regieInternalChatView: "Regie Internal Chat View",
+  regiePublicChat: "Regie Public Chat",
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.16
+        version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1241,6 +1244,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -6736,6 +6752,20 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.7)(react@19.2.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- Add per-panel background and header color customization via right-click context menu
- Support separate color schemes for light and dark themes
- Persist color settings to SQLite database with automatic sync

## Features
- Right-click any panel to open color picker context menu
- Choose background color and header/tab color independently
- Colors automatically adapt to current theme (light/dark)
- "Reset to Default" option to remove custom colors
- Smooth 0.2s color transitions

## Implementation
- New `panel_colors` database table with CRUD operations
- API endpoints: `GET/POST /api/panel-colors`, `DELETE /api/panel-colors/[panelId]`
- `PanelColorsContext` for React state management
- `PanelColorStyles` component for dynamic CSS injection
- `PanelColorMenu` wrapper component with Radix UI ContextMenu
- All 11 dashboard panels updated with `data-panel-id` attributes

## Test plan
- [ ] Right-click on a panel and verify context menu appears
- [ ] Set a background color and verify it applies immediately
- [ ] Set a header color and verify the tab changes color
- [ ] Switch between light/dark themes and verify colors are separate
- [ ] Refresh the page and verify colors persist
- [ ] Click "Reset to Default" and verify color is removed
- [ ] Test on multiple panels simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)