### PR TITLE
Add configurable overlay timeout settings

### DIFF
--- a/app/api/actions/lower/guest/[id]/route.ts
+++ b/app/api/actions/lower/guest/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { DatabaseService } from "@/lib/services/DatabaseService";
+import { SettingsService } from "@/lib/services/SettingsService";
 import { BackendClient } from "@/lib/utils/BackendClient";
 import { LowerThirdEventType, OverlayChannel } from "@/lib/models/OverlayEvents";
 import { enrichLowerThirdPayload } from "@/lib/utils/themeEnrichment";
@@ -26,9 +27,11 @@ export async function POST(
       );
     }
 
-    // Optional: override duration from request body
+    // Optional: override duration from request body, fallback to settings
     const body = await request.json().catch(() => ({}));
-    const duration = body.duration || 8;
+    const settingsService = SettingsService.getInstance();
+    const overlaySettings = settingsService.getOverlaySettings();
+    const duration = body.duration || overlaySettings.lowerThirdDuration;
 
     // Build base payload and enrich with theme data using shared utility
     const basePayload = {

--- a/app/api/settings/overlay/route.ts
+++ b/app/api/settings/overlay/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { SettingsService } from "@/lib/services/SettingsService";
+
+/**
+ * GET /api/settings/overlay
+ * Get overlay settings (timeouts, auto-hide)
+ */
+export async function GET() {
+  try {
+    const settingsService = SettingsService.getInstance();
+    const settings = settingsService.getOverlaySettings();
+
+    return NextResponse.json({ settings });
+  } catch (error) {
+    console.error("Failed to get overlay settings:", error);
+    return NextResponse.json(
+      { error: "Failed to get overlay settings" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/settings/overlay
+ * Save overlay settings
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { lowerThirdDuration, chatHighlightDuration, chatHighlightAutoHide } = body;
+
+    // Validate durations (1-60 seconds)
+    if (lowerThirdDuration !== undefined) {
+      if (typeof lowerThirdDuration !== "number" || lowerThirdDuration < 1 || lowerThirdDuration > 60) {
+        return NextResponse.json(
+          { error: "lowerThirdDuration must be a number between 1 and 60" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (chatHighlightDuration !== undefined) {
+      if (typeof chatHighlightDuration !== "number" || chatHighlightDuration < 1 || chatHighlightDuration > 60) {
+        return NextResponse.json(
+          { error: "chatHighlightDuration must be a number between 1 and 60" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (chatHighlightAutoHide !== undefined && typeof chatHighlightAutoHide !== "boolean") {
+      return NextResponse.json(
+        { error: "chatHighlightAutoHide must be a boolean" },
+        { status: 400 }
+      );
+    }
+
+    const settingsService = SettingsService.getInstance();
+    settingsService.saveOverlaySettings({
+      lowerThirdDuration,
+      chatHighlightDuration,
+      chatHighlightAutoHide,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "Overlay settings saved successfully",
+    });
+  } catch (error) {
+    console.error("Failed to save overlay settings:", error);
+    return NextResponse.json(
+      { error: "Failed to save overlay settings" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/settings/overlays/page.tsx
+++ b/app/settings/overlays/page.tsx
@@ -5,8 +5,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Separator } from "@/components/ui/separator";
 import { Copy, ExternalLink, Info, MonitorPlay } from "lucide-react";
 import { APP_URL } from "@/lib/config/urls";
+import { OverlaySettings } from "@/components/settings/OverlaySettings";
 
 interface Overlay {
   id: string;
@@ -169,6 +171,11 @@ export default function OverlaysPage() {
           Browser sources disponibles pour OBS Studio. Copiez les URLs ci-dessous pour configurer vos sources.
         </p>
       </div>
+
+      {/* Overlay Timeout Settings */}
+      <OverlaySettings />
+
+      <Separator className="my-6" />
 
       {/* OBS Instructions */}
       <Alert>

--- a/components/dashboard/cards/GuestsCard.tsx
+++ b/components/dashboard/cards/GuestsCard.tsx
@@ -30,11 +30,25 @@ export function GuestsCard({ size, className, settings }: GuestsCardProps = {}) 
   const [loading, setLoading] = useState(true);
   const [totalEnabledGuests, setTotalEnabledGuests] = useState(0);
   const [activeGuestId, setActiveGuestId] = useState<string | null>(null);
+  const [lowerThirdDuration, setLowerThirdDuration] = useState(8); // Default, will be updated from settings
   const wsRef = useRef<WebSocket | null>(null);
   const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     fetchGuests();
+    // Fetch overlay settings
+    const fetchSettings = async () => {
+      try {
+        const res = await fetch("/api/settings/overlay");
+        const data = await res.json();
+        if (data.settings?.lowerThirdDuration) {
+          setLowerThirdDuration(data.settings.lowerThirdDuration);
+        }
+      } catch (error) {
+        console.error("Failed to fetch overlay settings:", error);
+      }
+    };
+    fetchSettings();
   }, []);
 
   // WebSocket connection to track active lower third
@@ -171,7 +185,7 @@ export function GuestsCard({ size, className, settings }: GuestsCardProps = {}) 
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          duration: 8, // Auto-hide after 8 seconds
+          duration: lowerThirdDuration,
         }),
       });
     } catch (error) {

--- a/components/overlays/ChatHighlightRenderer.tsx
+++ b/components/overlays/ChatHighlightRenderer.tsx
@@ -71,15 +71,19 @@ export function ChatHighlightRenderer() {
             theme: data.payload.theme,
           });
 
-          // Auto-hide after duration
-          const duration = data.payload.duration || 10;
-          hideTimeout.current = setTimeout(() => {
-            setState((prev) => ({ ...prev, animating: false }));
-            // Wait for animation to complete before hiding
-            setTimeout(() => {
-              setState((prev) => ({ ...prev, visible: false }));
-            }, 500);
-          }, duration * 1000);
+          // Auto-hide after duration (if duration > 0)
+          // duration=0 means auto-hide is disabled - stay visible until manual hide
+          const duration = data.payload.duration;
+          if (duration && duration > 0) {
+            hideTimeout.current = setTimeout(() => {
+              setState((prev) => ({ ...prev, animating: false }));
+              // Wait for animation to complete before hiding
+              setTimeout(() => {
+                setState((prev) => ({ ...prev, visible: false }));
+              }, 500);
+            }, duration * 1000);
+          }
+          // If duration is 0 or undefined/null, no auto-hide timeout is set
         }
         break;
 

--- a/components/settings/OverlaySettings.tsx
+++ b/components/settings/OverlaySettings.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { CheckCircle2, Loader2, Timer, MessageSquare } from "lucide-react";
+
+interface OverlaySettingsData {
+  lowerThirdDuration: number;
+  chatHighlightDuration: number;
+  chatHighlightAutoHide: boolean;
+}
+
+/**
+ * Overlay settings for configuring auto-hide timeouts
+ */
+export function OverlaySettings() {
+  const [settings, setSettings] = useState<OverlaySettingsData>({
+    lowerThirdDuration: 8,
+    chatHighlightDuration: 10,
+    chatHighlightAutoHide: true,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState<{
+    success: boolean;
+    message: string;
+  } | null>(null);
+
+  useEffect(() => {
+    loadSettings();
+  }, []);
+
+  const loadSettings = async () => {
+    try {
+      const res = await fetch("/api/settings/overlay");
+      const data = await res.json();
+      if (data.settings) {
+        setSettings(data.settings);
+      }
+    } catch (error) {
+      console.error("Failed to load overlay settings:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveResult(null);
+
+    try {
+      const res = await fetch("/api/settings/overlay", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+
+      const data = await res.json();
+
+      if (data.success) {
+        setSaveResult({
+          success: true,
+          message: "Settings saved successfully!",
+        });
+      } else {
+        setSaveResult({
+          success: false,
+          message: data.error || "Failed to save settings",
+        });
+      }
+    } catch (error) {
+      setSaveResult({
+        success: false,
+        message: error instanceof Error ? error.message : "Failed to save settings",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-6 h-6 animate-spin mr-2" />
+        Loading settings...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold mb-2">Overlay Settings</h2>
+        <p className="text-sm text-muted-foreground">
+          Configure auto-hide timeouts for overlays
+        </p>
+      </div>
+
+      {/* Lower Third Duration */}
+      <div className="space-y-4 p-4 border rounded-lg">
+        <div className="flex items-center gap-2">
+          <Timer className="w-4 h-4" />
+          <Label className="text-base font-medium">Lower Third</Label>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Duration before the lower third overlay automatically hides.
+        </p>
+        <div className="flex items-center gap-4">
+          <Slider
+            value={[settings.lowerThirdDuration]}
+            onValueChange={(value) =>
+              setSettings((prev) => ({ ...prev, lowerThirdDuration: value[0] }))
+            }
+            min={1}
+            max={60}
+            step={1}
+            className="flex-1"
+          />
+          <span className="w-16 text-right font-mono">{settings.lowerThirdDuration}s</span>
+        </div>
+      </div>
+
+      {/* Chat Highlight Duration */}
+      <div className="space-y-4 p-4 border rounded-lg">
+        <div className="flex items-center gap-2">
+          <MessageSquare className="w-4 h-4" />
+          <Label className="text-base font-medium">Chat Highlight (Twitch)</Label>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Settings for the chat highlight overlay that displays Twitch messages.
+        </p>
+
+        {/* Auto-hide toggle */}
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor="auto-hide">Auto-hide</Label>
+            <p className="text-xs text-muted-foreground">
+              Automatically hide chat messages after the specified duration
+            </p>
+          </div>
+          <Switch
+            id="auto-hide"
+            checked={settings.chatHighlightAutoHide}
+            onCheckedChange={(checked) =>
+              setSettings((prev) => ({ ...prev, chatHighlightAutoHide: checked }))
+            }
+          />
+        </div>
+
+        {/* Duration slider - disabled when auto-hide is off */}
+        <div className={`flex items-center gap-4 ${!settings.chatHighlightAutoHide ? "opacity-50" : ""}`}>
+          <Slider
+            value={[settings.chatHighlightDuration]}
+            onValueChange={(value) =>
+              setSettings((prev) => ({ ...prev, chatHighlightDuration: value[0] }))
+            }
+            min={1}
+            max={60}
+            step={1}
+            className="flex-1"
+            disabled={!settings.chatHighlightAutoHide}
+          />
+          <span className="w-16 text-right font-mono">
+            {settings.chatHighlightAutoHide ? `${settings.chatHighlightDuration}s` : "--"}
+          </span>
+        </div>
+
+        {!settings.chatHighlightAutoHide && (
+          <Alert>
+            <AlertDescription className="text-sm">
+              Auto-hide is disabled. Chat messages will stay visible until manually hidden.
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
+
+      {/* Save Result */}
+      {saveResult && (
+        <Alert variant={saveResult.success ? "default" : "destructive"}>
+          <AlertDescription className="flex items-center gap-2">
+            {saveResult.success && <CheckCircle2 className="w-4 h-4" />}
+            {saveResult.message}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Save Button */}
+      <Button onClick={handleSave} disabled={saving}>
+        {saving ? (
+          <>
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            Saving...
+          </>
+        ) : (
+          "Save Settings"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/components/shell/panels/LowerThirdPanel.tsx
+++ b/components/shell/panels/LowerThirdPanel.tsx
@@ -1,5 +1,5 @@
 import { type IDockviewPanelProps } from "dockview-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -38,6 +38,23 @@ export function LowerThirdPanel(props: IDockviewPanelProps) {
   const [wikipediaPreview, setWikipediaPreview] = useState<WikipediaPreview | null>(null);
   const [wikipediaOptions, setWikipediaOptions] = useState<WikipediaSearchOption[]>([]);
   const [showWikipediaOptions, setShowWikipediaOptions] = useState(false);
+  const [lowerThirdDuration, setLowerThirdDuration] = useState(8); // Default, will be updated from settings
+
+  // Fetch overlay settings on mount
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const res = await fetch("/api/settings/overlay");
+        const data = await res.json();
+        if (data.settings?.lowerThirdDuration) {
+          setLowerThirdDuration(data.settings.lowerThirdDuration);
+        }
+      } catch (error) {
+        console.error("Failed to fetch overlay settings:", error);
+      }
+    };
+    fetchSettings();
+  }, []);
 
   const handleShow = async () => {
     try {
@@ -100,14 +117,14 @@ export function LowerThirdPanel(props: IDockviewPanelProps) {
               imageUrl: imageUrl || undefined,
               imageAlt: imageAlt || undefined,
               side,
-              duration: 5,
+              duration: lowerThirdDuration,
             }
           : {
               contentType: "guest",
               title,
               subtitle,
               side,
-              duration: 5,
+              duration: lowerThirdDuration,
             };
 
       const response = await fetch("/api/actions/lower/show", {
@@ -121,7 +138,7 @@ export function LowerThirdPanel(props: IDockviewPanelProps) {
       }
 
       setIsVisible(true);
-      setTimeout(() => setIsVisible(false), 5000);
+      setTimeout(() => setIsVisible(false), lowerThirdDuration * 1000);
     } catch (error) {
       console.error("Error showing lower third:", error);
     }

--- a/lib/services/SettingsService.ts
+++ b/lib/services/SettingsService.ts
@@ -19,6 +19,24 @@ export interface StreamerbotSettings extends StreamerbotConnectionSettings {
 }
 
 /**
+ * Overlay settings interface
+ */
+export interface OverlaySettings {
+  lowerThirdDuration: number;      // seconds
+  chatHighlightDuration: number;   // seconds
+  chatHighlightAutoHide: boolean;  // toggle on/off
+}
+
+/**
+ * Default overlay settings
+ */
+export const DEFAULT_OVERLAY_SETTINGS: OverlaySettings = {
+  lowerThirdDuration: 8,
+  chatHighlightDuration: 10,
+  chatHighlightAutoHide: true,
+};
+
+/**
  * SettingsService manages application settings with fallback to environment variables
  */
 export class SettingsService {
@@ -191,6 +209,43 @@ export class SettingsService {
     this.db.deleteSetting("streamerbot.password");
     this.db.deleteSetting("streamerbot.autoConnect");
     this.logger.info("Streamerbot settings cleared from database");
+  }
+
+  /**
+   * Get overlay settings
+   */
+  getOverlaySettings(): OverlaySettings {
+    const lowerThirdDuration = this.db.getSetting("overlay.lowerThird.defaultDuration");
+    const chatHighlightDuration = this.db.getSetting("overlay.chatHighlight.defaultDuration");
+    const chatHighlightAutoHide = this.db.getSetting("overlay.chatHighlight.autoHideEnabled");
+
+    return {
+      lowerThirdDuration: lowerThirdDuration
+        ? parseInt(lowerThirdDuration, 10)
+        : DEFAULT_OVERLAY_SETTINGS.lowerThirdDuration,
+      chatHighlightDuration: chatHighlightDuration
+        ? parseInt(chatHighlightDuration, 10)
+        : DEFAULT_OVERLAY_SETTINGS.chatHighlightDuration,
+      chatHighlightAutoHide: chatHighlightAutoHide !== null
+        ? chatHighlightAutoHide === "true"
+        : DEFAULT_OVERLAY_SETTINGS.chatHighlightAutoHide,
+    };
+  }
+
+  /**
+   * Save overlay settings to database
+   */
+  saveOverlaySettings(settings: Partial<OverlaySettings>): void {
+    if (settings.lowerThirdDuration !== undefined) {
+      this.db.setSetting("overlay.lowerThird.defaultDuration", settings.lowerThirdDuration.toString());
+    }
+    if (settings.chatHighlightDuration !== undefined) {
+      this.db.setSetting("overlay.chatHighlight.defaultDuration", settings.chatHighlightDuration.toString());
+    }
+    if (settings.chatHighlightAutoHide !== undefined) {
+      this.db.setSetting("overlay.chatHighlight.autoHideEnabled", settings.chatHighlightAutoHide.toString());
+    }
+    this.logger.info("Overlay settings saved to database");
   }
 }
 


### PR DESCRIPTION
## Summary
- Add settings UI in **Settings > Overlays** to configure:
  - **Lower Third Duration** (1-60s, default 8s)
  - **Chat Highlight Duration** (1-60s, default 10s)
  - **Chat Highlight Auto-Hide** toggle (on/off)
- When auto-hide is disabled, chat messages stay visible until manually hidden

## Changes
- `lib/services/SettingsService.ts` - Add `OverlaySettings` interface and get/save methods
- `app/api/settings/overlay/route.ts` - New API route for overlay settings
- `components/settings/OverlaySettings.tsx` - New settings UI component
- `app/settings/overlays/page.tsx` - Integrate settings component
- `components/shell/panels/LowerThirdPanel.tsx` - Use configured duration
- `components/dashboard/cards/GuestsCard.tsx` - Use configured duration
- `app/api/actions/lower/guest/[id]/route.ts` - Use settings as default
- `server/api/overlays.ts` - Inject duration/autoHide for chat-highlight
- `components/overlays/ChatHighlightRenderer.tsx` - Handle duration=0 as no auto-hide

## Test plan
- [ ] Go to Settings > Overlays and verify new settings section appears
- [ ] Change lower third duration and verify it applies when using Auto button
- [ ] Change chat highlight duration and verify it applies
- [ ] Disable chat highlight auto-hide and verify messages stay visible
- [ ] Re-enable auto-hide and verify messages hide after configured duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)