### PR TITLE
perf(api): Add server-side filtering for guests and posters

### DIFF
--- a/app/api/assets/guests/route.ts
+++ b/app/api/assets/guests/route.ts
@@ -1,20 +1,28 @@
 import { DatabaseService } from "@/lib/services/DatabaseService";
 import { guestSchema } from "@/lib/models/Guest";
 import { randomUUID } from "crypto";
-import { ApiResponses } from "@/lib/utils/ApiResponses";
+import {
+  ApiResponses,
+  withSimpleErrorHandler,
+} from "@/lib/utils/ApiResponses";
+import { parseBooleanQueryParam } from "@/lib/utils/queryParams";
+
+const LOG_CONTEXT = "[GuestsAPI]";
+
 /**
  * GET /api/assets/guests
  * List all guests
+ * Query params:
+ *   - enabled: "true" for enabled only, "false" for disabled only, omit for all
  */
-export async function GET() {
-  try {
-    const db = DatabaseService.getInstance();
-    const guests = db.getAllGuests();
-    return ApiResponses.ok({ guests });
-  } catch (error) {
-    return ApiResponses.serverError("Failed to fetch guests");
-  }
-}
+export const GET = withSimpleErrorHandler(async (request: Request) => {
+  const url = new URL(request.url);
+  const enabled = parseBooleanQueryParam(url.searchParams.get("enabled"));
+
+  const db = DatabaseService.getInstance();
+  const guests = db.getAllGuests(enabled);
+  return ApiResponses.ok({ guests });
+}, LOG_CONTEXT);
 /**
  * POST /api/assets/guests
  * Create a new guest

--- a/app/api/assets/posters/route.ts
+++ b/app/api/assets/posters/route.ts
@@ -5,16 +5,22 @@ import {
   ApiResponses,
   withSimpleErrorHandler,
 } from "@/lib/utils/ApiResponses";
+import { parseBooleanQueryParam } from "@/lib/utils/queryParams";
 
 const LOG_CONTEXT = "[PostersAPI]";
 
 /**
  * GET /api/assets/posters
  * List all posters
+ * Query params:
+ *   - enabled: "true" for enabled only, "false" for disabled only, omit for all
  */
-export const GET = withSimpleErrorHandler(async () => {
+export const GET = withSimpleErrorHandler(async (request: Request) => {
+  const url = new URL(request.url);
+  const enabled = parseBooleanQueryParam(url.searchParams.get("enabled"));
+
   const db = DatabaseService.getInstance();
-  const posters = db.getAllPosters();
+  const posters = db.getAllPosters(enabled);
 
   return ApiResponses.ok({ posters });
 }, LOG_CONTEXT);

--- a/components/dashboard/cards/GuestsCard.tsx
+++ b/components/dashboard/cards/GuestsCard.tsx
@@ -136,9 +136,9 @@ export function GuestsCard({ size, className, settings }: GuestsCardProps = {}) 
 
   const fetchGuests = async () => {
     try {
-      const data = await apiGet<{ guests: Guest[] }>("/api/assets/guests");
-      // Filter to show only enabled guests
-      const allEnabledGuests = (data.guests || []).filter((g: Guest) => g.isEnabled);
+      const data = await apiGet<{ guests: Guest[] }>("/api/assets/guests?enabled=true");
+      // API returns only enabled guests via server-side filtering
+      const allEnabledGuests = data.guests || [];
       setTotalEnabledGuests(allEnabledGuests.length);
       // Limit to 10 for keyboard shortcuts (1-0)
       setGuests(allEnabledGuests.slice(0, 10));

--- a/components/dashboard/cards/PosterCard.tsx
+++ b/components/dashboard/cards/PosterCard.tsx
@@ -252,10 +252,9 @@ export function PosterContent({ className }: PosterContentProps) {
 
   const fetchPosters = async () => {
     try {
-      const data = await apiGet<{ posters: Poster[] }>("/api/assets/posters");
-      // Filter to show only enabled posters
-      const enabledPosters = (data.posters || []).filter((p: Poster) => p.isEnabled);
-      setPosters(enabledPosters);
+      // Server-side filtering: only fetch enabled posters
+      const data = await apiGet<{ posters: Poster[] }>("/api/assets/posters?enabled=true");
+      setPosters(data.posters || []);
     } catch (error) {
       console.error("Failed to fetch posters:", error);
     } finally {

--- a/components/shell/panels/GuestsPanel.tsx
+++ b/components/shell/panels/GuestsPanel.tsx
@@ -66,8 +66,9 @@ export function GuestsPanel(_props: IDockviewPanelProps) {
 
   const fetchGuests = async () => {
     try {
-      const data = await apiGet<{ guests: Guest[] }>("/api/assets/guests");
-      const allEnabledGuests = (data.guests || []).filter((g: Guest) => g.isEnabled);
+      const data = await apiGet<{ guests: Guest[] }>("/api/assets/guests?enabled=true");
+      // API returns only enabled guests via server-side filtering
+      const allEnabledGuests = data.guests || [];
       setGuests(allEnabledGuests.slice(0, 10));
     } catch (error) {
       console.error("Failed to fetch guests:", error);

--- a/lib/repositories/PosterRepository.ts
+++ b/lib/repositories/PosterRepository.ts
@@ -62,10 +62,21 @@ export class PosterRepository {
 
   /**
    * Get all posters
+   * @param enabled - If true, return only enabled posters. If false, return only disabled posters. If undefined, return all.
    */
-  getAll(): DbPoster[] {
-    const stmt = this.db.getDb().prepare("SELECT * FROM posters ORDER BY createdAt DESC");
-    const rows = stmt.all() as DbPosterRow[];
+  getAll(enabled?: boolean): DbPoster[] {
+    let rows: DbPosterRow[];
+
+    if (enabled === undefined) {
+      const stmt = this.db.getDb().prepare("SELECT * FROM posters ORDER BY createdAt DESC");
+      rows = stmt.all() as DbPosterRow[];
+    } else {
+      const stmt = this.db.getDb().prepare(
+        "SELECT * FROM posters WHERE isEnabled = ? ORDER BY createdAt DESC"
+      );
+      rows = stmt.all(enabled ? 1 : 0) as DbPosterRow[];
+    }
+
     return rows.map((row) => this.transformRow(row));
   }
 

--- a/lib/services/DatabaseService.ts
+++ b/lib/services/DatabaseService.ts
@@ -729,9 +729,10 @@ export class DatabaseService {
 
   /**
    * Get all guests
+   * @param enabled - Optional filter: true for enabled only, false for disabled only, undefined for all
    */
-  getAllGuests(): DbGuest[] {
-    return GuestRepository.getInstance().getAll();
+  getAllGuests(enabled?: boolean): DbGuest[] {
+    return GuestRepository.getInstance().getAll(enabled);
   }
 
   /**
@@ -766,9 +767,10 @@ export class DatabaseService {
 
   /**
    * Get all posters
+   * @param enabled - If true, return only enabled posters. If false, return only disabled posters. If undefined, return all.
    */
-  getAllPosters(): DbPoster[] {
-    return PosterRepository.getInstance().getAll();
+  getAllPosters(enabled?: boolean): DbPoster[] {
+    return PosterRepository.getInstance().getAll(enabled);
   }
 
   /**

--- a/lib/utils/queryParams.ts
+++ b/lib/utils/queryParams.ts
@@ -1,0 +1,31 @@
+/**
+ * Query Parameter Parsing Utilities
+ *
+ * Provides standardized parsing for common query parameter patterns.
+ *
+ * @module lib/utils/queryParams
+ */
+
+/**
+ * Parse a string query parameter to a boolean or undefined.
+ *
+ * @param value - The query parameter value (or null if not present)
+ * @returns true if "true", false if "false", undefined otherwise
+ *
+ * @example
+ * ```typescript
+ * const enabled = parseBooleanQueryParam(searchParams.get("enabled"));
+ * // "true" -> true
+ * // "false" -> false
+ * // null or any other value -> undefined
+ * ```
+ */
+export function parseBooleanQueryParam(value: string | null): boolean | undefined {
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Add optional `enabled` query parameter to `/api/assets/guests` and `/api/assets/posters`
- Dashboard components now fetch only enabled assets via `?enabled=true`
- Reduces data transfer by filtering at the database level instead of client-side

## Test plan
- [ ] Verify `GET /api/assets/guests` returns all guests
- [ ] Verify `GET /api/assets/guests?enabled=true` returns only enabled guests
- [ ] Verify `GET /api/assets/guests?enabled=false` returns only disabled guests
- [ ] Same tests for `/api/assets/posters`
- [ ] Verify dashboard displays only enabled guests/posters
- [ ] Verify GuestManager/PosterManager still shows all assets for management

🤖 Generated with [Claude Code](https://claude.com/claude-code)