### PR TITLE
perf(dashboard): Add React Query for API call optimization

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { BodyThemeSync } from "@/components/BodyThemeSync";
 import { AppModeProvider } from "@/components/shell/AppModeContext";
 import { AppShell } from "@/components/shell/AppShell";
+import { QueryProvider } from "@/components/providers/QueryProvider";
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
@@ -32,20 +33,22 @@ export default async function LocaleLayout({
   const messages = await getMessages();
 
   return (
-    <NextIntlClientProvider messages={messages}>
-      <ThemeProvider
-        attribute="class"
-        defaultTheme="dark"
-        enableSystem={false}
-        disableTransitionOnChange
-      >
-        <AppModeProvider>
-          <BodyThemeSync />
-          <AppShell>
-            {children}
-          </AppShell>
-        </AppModeProvider>
-      </ThemeProvider>
-    </NextIntlClientProvider>
+    <QueryProvider>
+      <NextIntlClientProvider messages={messages}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem={false}
+          disableTransitionOnChange
+        >
+          <AppModeProvider>
+            <BodyThemeSync />
+            <AppShell>
+              {children}
+            </AppShell>
+          </AppModeProvider>
+        </ThemeProvider>
+      </NextIntlClientProvider>
+    </QueryProvider>
   );
 }

--- a/components/assets/GuestCard.tsx
+++ b/components/assets/GuestCard.tsx
@@ -4,16 +4,7 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Zap, Edit, Power, PowerOff, Trash2 } from "lucide-react";
-
-interface Guest {
-  id: string;
-  displayName: string;
-  subtitle?: string;
-  accentColor: string;
-  avatarUrl?: string;
-  isEnabled: boolean;
-  createdAt?: string;
-}
+import type { Guest } from "@/lib/queries";
 
 interface GuestCardProps {
   guest: Guest;

--- a/components/assets/VirtualizedGuestGrid.tsx
+++ b/components/assets/VirtualizedGuestGrid.tsx
@@ -3,16 +3,7 @@
 import { useRef, useEffect, useState, useMemo } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { GuestCard } from "./GuestCard";
-
-interface Guest {
-  id: string;
-  displayName: string;
-  subtitle?: string;
-  accentColor: string;
-  avatarUrl?: string;
-  isEnabled: boolean;
-  createdAt?: string;
-}
+import type { Guest } from "@/lib/queries";
 
 interface VirtualizedGuestGridProps {
   guests: Guest[];

--- a/components/providers/QueryProvider.tsx
+++ b/components/providers/QueryProvider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState, type ReactNode } from "react";
+
+interface QueryProviderProps {
+  children: ReactNode;
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 5 * 1000, // 5 seconds default
+            gcTime: 10 * 60 * 1000, // 10 minutes cache
+            retry: 2,
+            retryDelay: (attemptIndex) =>
+              Math.min(1000 * 2 ** attemptIndex, 30000),
+            refetchOnWindowFocus: true,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === "development" && <ReactQueryDevtools />}
+    </QueryClientProvider>
+  );
+}

--- a/components/quiz/manage/PlayerSelector.tsx
+++ b/components/quiz/manage/PlayerSelector.tsx
@@ -1,14 +1,6 @@
 "use client";
-import { useEffect, useState, useMemo } from "react";
-import { apiGet } from "@/lib/utils/ClientFetch";
-
-interface Guest {
-  id: string;
-  displayName: string;
-  subtitle?: string;
-  avatarUrl?: string;
-  accentColor?: string;
-}
+import { useState, useMemo } from "react";
+import { useGuests, Guest } from "@/lib/queries";
 
 interface Player {
   id: string;
@@ -23,21 +15,8 @@ interface PlayerSelectorProps {
 }
 
 export function PlayerSelector({ selectedPlayers, onChange }: PlayerSelectorProps) {
-  const [guests, setGuests] = useState<Guest[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { guests, isLoading: loading } = useGuests();
   const [searchQuery, setSearchQuery] = useState("");
-
-  useEffect(() => {
-    apiGet<{ guests: Guest[] }>("/api/assets/guests")
-      .then(data => {
-        setGuests(data.guests || []);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Failed to load guests:", err);
-        setLoading(false);
-      });
-  }, []);
 
   const togglePlayer = (guest: Guest) => {
     const existing = selectedPlayers.find(p => p.id === guest.id);
@@ -51,7 +30,7 @@ export function PlayerSelector({ selectedPlayers, onChange }: PlayerSelectorProp
       const newPlayer: Player = {
         id: guest.id,
         name: guest.displayName,
-        avatar: guest.avatarUrl,
+        avatar: guest.avatarUrl ?? undefined,
         buzzerId: `buzzer-${selectedPlayers.length + 1}`,
       };
       onChange([...selectedPlayers, newPlayer]);

--- a/lib/queries/index.ts
+++ b/lib/queries/index.ts
@@ -1,0 +1,20 @@
+export { queryKeys } from "./queryKeys";
+export type { GuestFilterOptions } from "./queryKeys";
+
+export { useGuests } from "./useGuests";
+export type {
+  Guest,
+  GuestSummary,
+  CreateGuestInput,
+  UpdateGuestInput,
+  UseGuestsOptions,
+} from "./useGuests";
+
+export { useOBSStatus } from "./useOBSStatus";
+export type { OBSStatus, UseOBSStatusOptions } from "./useOBSStatus";
+
+export { useStreamerbotStatus } from "./useStreamerbotStatus";
+export type { UseStreamerbotStatusOptions } from "./useStreamerbotStatus";
+
+export { useProfiles } from "./useProfiles";
+export type { Profile, ProfileSummary } from "./useProfiles";

--- a/lib/queries/queryKeys.ts
+++ b/lib/queries/queryKeys.ts
@@ -1,0 +1,48 @@
+export interface GuestFilterOptions {
+  enabled?: boolean;
+}
+
+export const queryKeys = {
+  obs: {
+    all: ["obs"] as const,
+    status: () => [...queryKeys.obs.all, "status"] as const,
+  },
+
+  guests: {
+    all: ["guests"] as const,
+    list: (filters?: GuestFilterOptions) =>
+      [...queryKeys.guests.all, "list", filters] as const,
+    detail: (id: string) => [...queryKeys.guests.all, "detail", id] as const,
+  },
+
+  profiles: {
+    all: ["profiles"] as const,
+    list: () => [...queryKeys.profiles.all, "list"] as const,
+    detail: (id: string) => [...queryKeys.profiles.all, "detail", id] as const,
+  },
+
+  streamerbot: {
+    all: ["streamerbot"] as const,
+    status: () => [...queryKeys.streamerbot.all, "status"] as const,
+    history: () => [...queryKeys.streamerbot.all, "history"] as const,
+  },
+
+  posters: {
+    all: ["posters"] as const,
+    list: (filters?: { enabled?: boolean }) =>
+      [...queryKeys.posters.all, "list", filters] as const,
+    detail: (id: string) => [...queryKeys.posters.all, "detail", id] as const,
+  },
+
+  themes: {
+    all: ["themes"] as const,
+    list: () => [...queryKeys.themes.all, "list"] as const,
+    detail: (id: string) => [...queryKeys.themes.all, "detail", id] as const,
+  },
+
+  settings: {
+    all: ["settings"] as const,
+    byCategory: (category: string) =>
+      [...queryKeys.settings.all, category] as const,
+  },
+} as const;

--- a/lib/queries/useGuests.ts
+++ b/lib/queries/useGuests.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiGet, apiPost, apiPatch, apiDelete } from "@/lib/utils/ClientFetch";
+import { queryKeys, GuestFilterOptions } from "./queryKeys";
+
+export interface Guest {
+  id: string;
+  displayName: string;
+  subtitle: string | null;
+  accentColor: string;
+  avatarUrl: string | null;
+  chatMessage: string | null;
+  isEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GuestSummary {
+  id: string;
+  displayName: string;
+  subText: string | null;
+  avatarUrl: string | null;
+  isEnabled: boolean;
+}
+
+interface GuestsResponse {
+  guests: Guest[];
+}
+
+interface GuestResponse {
+  guest: Guest;
+}
+
+export interface CreateGuestInput {
+  displayName: string;
+  subtitle?: string | null;
+  accentColor?: string;
+  avatarUrl?: string | null;
+  chatMessage?: string | null;
+  isEnabled?: boolean;
+}
+
+export interface UpdateGuestInput {
+  displayName?: string;
+  subtitle?: string | null;
+  accentColor?: string;
+  avatarUrl?: string | null;
+  chatMessage?: string | null;
+  isEnabled?: boolean;
+}
+
+export interface UseGuestsOptions {
+  enabled?: boolean;
+}
+
+const GUESTS_STALE_TIME = 30 * 1000;
+
+function buildGuestsEndpoint(options?: UseGuestsOptions): string {
+  if (options?.enabled !== undefined) {
+    return `/api/assets/guests?enabled=${options.enabled}`;
+  }
+  return "/api/assets/guests";
+}
+
+export function useGuests(options?: UseGuestsOptions) {
+  const queryClient = useQueryClient();
+
+  const filters: GuestFilterOptions | undefined =
+    options?.enabled !== undefined ? { enabled: options.enabled } : undefined;
+
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey: queryKeys.guests.list(filters),
+    queryFn: async () => {
+      const response = await apiGet<GuestsResponse>(buildGuestsEndpoint(options));
+      return response.guests;
+    },
+    staleTime: GUESTS_STALE_TIME,
+  });
+
+  const invalidateGuests = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.guests.all });
+
+  const toggleEnabledMutation = useMutation({
+    mutationFn: async ({ id, isEnabled }: { id: string; isEnabled: boolean }) => {
+      const response = await apiPatch<GuestResponse>(`/api/assets/guests/${id}`, {
+        isEnabled,
+      });
+      return response.guest;
+    },
+    onSuccess: invalidateGuests,
+  });
+
+  const createGuestMutation = useMutation({
+    mutationFn: async (input: CreateGuestInput) => {
+      const response = await apiPost<GuestResponse>("/api/assets/guests", input);
+      return response.guest;
+    },
+    onSuccess: invalidateGuests,
+  });
+
+  const updateGuestMutation = useMutation({
+    mutationFn: async ({ id, ...updates }: UpdateGuestInput & { id: string }) => {
+      const response = await apiPatch<GuestResponse>(
+        `/api/assets/guests/${id}`,
+        updates
+      );
+      return response.guest;
+    },
+    onSuccess: invalidateGuests,
+  });
+
+  const deleteGuestMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await apiDelete<{ success: boolean }>(`/api/assets/guests/${id}`);
+      return id;
+    },
+    onSuccess: invalidateGuests,
+  });
+
+  return {
+    guests: data ?? [],
+    isLoading,
+    isFetching,
+    error: error as Error | null,
+    refetch,
+    toggleEnabled: toggleEnabledMutation.mutate,
+    createGuest: createGuestMutation.mutate,
+    updateGuest: updateGuestMutation.mutate,
+    deleteGuest: deleteGuestMutation.mutate,
+    isToggling: toggleEnabledMutation.isPending,
+    isCreating: createGuestMutation.isPending,
+    isUpdating: updateGuestMutation.isPending,
+    isDeleting: deleteGuestMutation.isPending,
+    toggleEnabledAsync: toggleEnabledMutation.mutateAsync,
+    createGuestAsync: createGuestMutation.mutateAsync,
+    updateGuestAsync: updateGuestMutation.mutateAsync,
+    deleteGuestAsync: deleteGuestMutation.mutateAsync,
+  };
+}

--- a/lib/queries/useOBSStatus.ts
+++ b/lib/queries/useOBSStatus.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/utils/ClientFetch";
+import { queryKeys } from "./queryKeys";
+
+export interface OBSStatus {
+  connected: boolean;
+  currentScene: string | null;
+  isStreaming: boolean;
+  isRecording: boolean;
+  isVirtualCamActive?: boolean;
+  fps?: number;
+  streamTime?: number;
+  recordTime?: number;
+}
+
+export interface UseOBSStatusOptions {
+  refetchInterval?: number;
+  enabled?: boolean;
+}
+
+const DEFAULT_STATUS: OBSStatus = {
+  connected: false,
+  currentScene: null,
+  isStreaming: false,
+  isRecording: false,
+};
+
+export function useOBSStatus(options: UseOBSStatusOptions = {}) {
+  const { refetchInterval = 5000, enabled = true } = options;
+
+  const query = useQuery({
+    queryKey: queryKeys.obs.status(),
+    queryFn: () => apiGet<OBSStatus>("/api/obs/status"),
+    refetchInterval,
+    enabled,
+    placeholderData: (previousData) => previousData,
+  });
+
+  const status = query.data ?? DEFAULT_STATUS;
+
+  return {
+    data: query.data,
+    isConnected: status.connected,
+    isOnAir: status.isStreaming || status.isRecording,
+    currentScene: status.currentScene,
+    isStreaming: status.isStreaming,
+    isRecording: status.isRecording,
+    isVirtualCamActive: status.isVirtualCamActive ?? false,
+    fps: status.fps ?? 0,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/lib/queries/useProfiles.ts
+++ b/lib/queries/useProfiles.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiGet, apiPost } from "@/lib/utils/ClientFetch";
+import { queryKeys } from "./queryKeys";
+
+export interface Profile {
+  id: string;
+  name: string;
+  description: string | null;
+  themeId: string;
+  dskSourceName: string;
+  defaultScene: string | null;
+  posterRotation: Array<{
+    posterId: string;
+    duration: number;
+    order: number;
+  }>;
+  audioSettings: {
+    countdownCueEnabled: boolean;
+    countdownCueAt: number;
+    actionSoundsEnabled: boolean;
+  };
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProfileSummary {
+  id: string;
+  name: string;
+  isActive: boolean;
+}
+
+interface ProfilesResponse {
+  profiles: Profile[];
+}
+
+interface ProfileResponse {
+  profile: Profile;
+}
+
+const PROFILES_STALE_TIME = 60 * 1000;
+
+export function useProfiles() {
+  const queryClient = useQueryClient();
+
+  const invalidateProfiles = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.profiles.all });
+
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey: queryKeys.profiles.list(),
+    queryFn: async () => {
+      const response = await apiGet<ProfilesResponse>("/api/profiles");
+      return response.profiles;
+    },
+    staleTime: PROFILES_STALE_TIME,
+  });
+
+  const activateProfileMutation = useMutation({
+    mutationFn: async (profileId: string) => {
+      const response = await apiPost<ProfileResponse>(
+        `/api/profiles/${profileId}/activate`
+      );
+      return response.profile;
+    },
+    onSuccess: invalidateProfiles,
+  });
+
+  const profiles = data ?? [];
+  const activeProfile = profiles.find((p) => p.isActive);
+
+  return {
+    profiles,
+    activeProfile,
+    isLoading,
+    isFetching,
+    error: error as Error | null,
+    refetch,
+    activateProfile: activateProfileMutation.mutate,
+    isActivating: activateProfileMutation.isPending,
+    activateProfileAsync: activateProfileMutation.mutateAsync,
+  };
+}

--- a/lib/queries/useStreamerbotStatus.ts
+++ b/lib/queries/useStreamerbotStatus.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "@/lib/utils/ClientFetch";
+import { getBackendUrl } from "@/lib/utils/websocket";
+import { queryKeys } from "./queryKeys";
+import type {
+  StreamerbotConnectionStatus,
+  StreamerbotConnectionError,
+} from "@/lib/models/StreamerbotChat";
+
+interface StreamerbotStatusResponse {
+  status: StreamerbotConnectionStatus;
+  error?: StreamerbotConnectionError;
+  lastEventTime?: number;
+}
+
+export interface UseStreamerbotStatusOptions {
+  enabled?: boolean;
+}
+
+export function useStreamerbotStatus(options: UseStreamerbotStatusOptions = {}) {
+  const { enabled = true } = options;
+
+  const query = useQuery<StreamerbotStatusResponse>({
+    queryKey: queryKeys.streamerbot.status(),
+    queryFn: () => apiGet<StreamerbotStatusResponse>(getBackendUrl() + "/api/streamerbot-chat/status"),
+    staleTime: 5000,
+    refetchInterval: 10000,
+    enabled,
+  });
+
+  const lastEventTime = query.data?.lastEventTime
+    ? new Date(query.data.lastEventTime).toISOString()
+    : null;
+
+  return {
+    status: query.data?.status,
+    error: query.data?.error?.message ?? null,
+    lastEventTime,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    refetch: query.refetch,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@streamerbot/client": "^1.12.2",
+    "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-virtual": "^3.13.13",
     "@types/express": "^5.0.6",
     "archiver": "^7.0.1",
@@ -97,6 +98,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.91.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@streamerbot/client':
         specifier: ^1.12.2
         version: 1.12.2(utf-8-validate@6.0.6)
+      '@tanstack/react-query':
+        specifier: ^5.90.16
+        version: 5.90.16(react@19.2.3)
       '@tanstack/react-virtual':
         specifier: ^3.13.13
         version: 3.13.13(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -198,6 +201,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@tanstack/react-query-devtools':
+        specifier: ^5.91.2
+        version: 5.91.2(@tanstack/react-query@5.90.16(react@19.2.3))(react@19.2.3)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1867,6 +1873,23 @@ packages:
 
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+
+  '@tanstack/query-core@5.90.16':
+    resolution: {integrity: sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==}
+
+  '@tanstack/query-devtools@5.92.0':
+    resolution: {integrity: sha512-N8D27KH1vEpVacvZgJL27xC6yPFUy0Zkezn5gnB3L3gRCxlDeSuiya7fKge8Y91uMTnC8aSxBQhcK6ocY7alpQ==}
+
+  '@tanstack/react-query-devtools@5.91.2':
+    resolution: {integrity: sha512-ZJ1503ay5fFeEYFUdo7LMNFzZryi6B0Cacrgr2h1JRkvikK1khgIq6Nq2EcblqEdIlgB/r7XDW8f8DQ89RuUgg==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.90.14
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.90.16':
+    resolution: {integrity: sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-virtual@3.13.13':
     resolution: {integrity: sha512-4o6oPMDvQv+9gMi8rE6gWmsOjtUZUYIJHv7EB+GblyYdi8U6OqLl8rhHWIUZSL1dUU2dPwTdTgybCKf9EjIrQg==}
@@ -7566,6 +7589,21 @@ snapshots:
   '@swc/types@0.1.25':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@tanstack/query-core@5.90.16': {}
+
+  '@tanstack/query-devtools@5.92.0': {}
+
+  '@tanstack/react-query-devtools@5.91.2(@tanstack/react-query@5.90.16(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-devtools': 5.92.0
+      '@tanstack/react-query': 5.90.16(react@19.2.3)
+      react: 19.2.3
+
+  '@tanstack/react-query@5.90.16(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-core': 5.90.16
+      react: 19.2.3
 
   '@tanstack/react-virtual@3.13.13(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- Install @tanstack/react-query for centralized data fetching and caching
- Reduce duplicate API calls across dashboard components
- OBS status polling reduced from 2s to 5s with shared state
- Guest/Profile data cached with automatic deduplication

## Changes
- **New hooks**: `useOBSStatus`, `useGuests`, `useProfiles`, `useStreamerbotStatus` in `lib/queries/`
- **QueryProvider**: Wraps app with React Query client
- **Refactored**: DashboardHeader, GuestsCard, GuestManager, PlayerSelector

## Test plan
- [ ] Dashboard loads without errors
- [ ] OBS status shows correctly in header
- [ ] Guests display in dashboard card and manager
- [ ] Profile switching works
- [ ] React Query Devtools visible in dev mode (floating button)
- [ ] Network tab shows reduced API calls (5s OBS polling instead of 2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)