### PR TITLE
feat(dashboard): Add Twitch chat moderation (delete, timeout, ban)

### DIFF
--- a/app/api/twitch/moderation/ban/route.ts
+++ b/app/api/twitch/moderation/ban/route.ts
@@ -1,0 +1,19 @@
+import { proxyToBackend } from "@/lib/utils/ProxyHelper";
+import { withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+
+const LOG_CONTEXT = "[TwitchAPI:Moderation:Ban]";
+
+/**
+ * POST /api/twitch/moderation/ban
+ * Ban a user (proxies to backend)
+ */
+export const POST = withSimpleErrorHandler(async (request: Request) => {
+  const body = await request.json();
+
+  return proxyToBackend("/api/twitch/moderation/ban", {
+    method: "POST",
+    body,
+    errorMessage: "Failed to ban user",
+    logPrefix: LOG_CONTEXT,
+  });
+}, LOG_CONTEXT);

--- a/app/api/twitch/moderation/message/route.ts
+++ b/app/api/twitch/moderation/message/route.ts
@@ -1,0 +1,23 @@
+import { proxyToBackend } from "@/lib/utils/ProxyHelper";
+import { withSimpleErrorHandler, ApiResponses } from "@/lib/utils/ApiResponses";
+
+const LOG_CONTEXT = "[TwitchAPI:Moderation:Message]";
+
+/**
+ * DELETE /api/twitch/moderation/message?messageId=...
+ * Delete a chat message (proxies to backend)
+ */
+export const DELETE = withSimpleErrorHandler(async (request: Request) => {
+  const url = new URL(request.url);
+  const messageId = url.searchParams.get("messageId");
+
+  if (!messageId) {
+    return ApiResponses.badRequest("messageId parameter is required");
+  }
+
+  return proxyToBackend(`/api/twitch/moderation/message?messageId=${encodeURIComponent(messageId)}`, {
+    method: "DELETE",
+    errorMessage: "Failed to delete message",
+    logPrefix: LOG_CONTEXT,
+  });
+}, LOG_CONTEXT);

--- a/app/api/twitch/moderation/timeout/route.ts
+++ b/app/api/twitch/moderation/timeout/route.ts
@@ -1,0 +1,19 @@
+import { proxyToBackend } from "@/lib/utils/ProxyHelper";
+import { withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+
+const LOG_CONTEXT = "[TwitchAPI:Moderation:Timeout]";
+
+/**
+ * POST /api/twitch/moderation/timeout
+ * Timeout a user (proxies to backend)
+ */
+export const POST = withSimpleErrorHandler(async (request: Request) => {
+  const body = await request.json();
+
+  return proxyToBackend("/api/twitch/moderation/timeout", {
+    method: "POST",
+    body,
+    errorMessage: "Failed to timeout user",
+    logPrefix: LOG_CONTEXT,
+  });
+}, LOG_CONTEXT);

--- a/components/presenter/panels/streamerbot-chat/types.ts
+++ b/components/presenter/panels/streamerbot-chat/types.ts
@@ -41,6 +41,8 @@ export interface StreamerbotChatToolbarProps {
   onUpdatePreferences: (updates: Partial<ChatUIPreferences>) => void;
 }
 
+export type ModerationAction = "delete" | "timeout" | "ban";
+
 export interface StreamerbotChatMessageListProps {
   messages: ChatMessage[];
   preferences: ChatUIPreferences;
@@ -51,6 +53,12 @@ export interface StreamerbotChatMessageListProps {
   onShowInOverlay?: (message: ChatMessage) => Promise<void>;
   showingInOverlayId?: string | null;
   currentlyDisplayedId?: string | null;
+  onModerate?: (
+    message: ChatMessage,
+    action: ModerationAction,
+    duration?: number
+  ) => Promise<void>;
+  moderateLoadingId?: string | null;
 }
 
 export interface SearchBarProps {

--- a/components/shell/panels/regie-public-chat/types.ts
+++ b/components/shell/panels/regie-public-chat/types.ts
@@ -9,6 +9,8 @@ import type {
 } from "@/lib/models/StreamerbotChat";
 import { StreamerbotConnectionStatus } from "@/lib/models/StreamerbotChat";
 
+export type ModerationAction = "delete" | "timeout" | "ban";
+
 export interface RegiePublicChatMessageListProps {
   messages: ChatMessage[];
   preferences: ChatUIPreferences;
@@ -21,6 +23,9 @@ export interface RegiePublicChatMessageListProps {
   onShowInOverlay: (message: ChatMessage) => Promise<void>;
   showingInOverlayId: string | null;
   currentlyDisplayedId: string | null;
+  // Moderation
+  onModerate?: (message: ChatMessage, action: ModerationAction, duration?: number) => Promise<void>;
+  moderateLoadingId?: string | null;
 }
 
 // Re-export for convenience

--- a/lib/models/TwitchAuth.ts
+++ b/lib/models/TwitchAuth.ts
@@ -19,6 +19,8 @@ import { z } from "zod";
  * - chat:edit - Send chat messages
  * - user:write:chat - Send chat messages via API
  * - user:read:chat - Read chat messages via API
+ * - moderator:manage:chat_messages - Delete chat messages (DELETE /helix/moderation/chat)
+ * - moderator:manage:banned_users - Ban/unban users (POST /helix/moderation/bans)
  */
 export const TWITCH_OAUTH_SCOPES = [
   "channel:manage:broadcast",
@@ -27,6 +29,8 @@ export const TWITCH_OAUTH_SCOPES = [
   "chat:edit",
   "user:write:chat",
   "user:read:chat",
+  "moderator:manage:chat_messages",
+  "moderator:manage:banned_users",
 ] as const;
 
 /**

--- a/lib/models/streamerbot/normalizers.ts
+++ b/lib/models/streamerbot/normalizers.ts
@@ -32,6 +32,16 @@ export function normalizeTwitchChatMessage(event: TwitchChatMessageEvent): ChatM
   const msg = data.message;
   const user = data.user;
 
+  // Debug logging for moderation IDs
+  console.log(`[Streamerbot] Twitch message received:`, {
+    "msg.msgId": msg.msgId,
+    "msg.userId": msg.userId,
+    "user?.id": user?.id,
+    "data.messageId": data.messageId,
+    username: msg.username,
+    displayName: msg.displayName,
+  });
+
   // Parse message parts from payload (text + emotes)
   const parts: MessagePart[] = msg.parts?.map((part) => {
     if (part.type === "emote") {
@@ -71,6 +81,8 @@ export function normalizeTwitchChatMessage(event: TwitchChatMessageEvent): ChatM
         username: msg.replyParentUserLogin || "",
         displayName: msg.replyParentDisplayName || "",
       } : undefined,
+      twitchMsgId: msg.msgId,
+      twitchUserId: msg.userId || user?.id,
     },
     rawPayload: event,
   };

--- a/lib/models/streamerbot/schemas.ts
+++ b/lib/models/streamerbot/schemas.ts
@@ -107,6 +107,10 @@ export const chatMessageMetadataSchema = z.object({
 
   // For events (raid, cheer, etc.)
   eventData: z.record(z.unknown()).optional(),
+
+  // Twitch moderation IDs
+  twitchMsgId: z.string().optional(),
+  twitchUserId: z.string().optional(),
 });
 
 export type ChatMessageMetadata = z.infer<typeof chatMessageMetadataSchema>;

--- a/lib/services/TwitchService.ts
+++ b/lib/services/TwitchService.ts
@@ -466,4 +466,54 @@ export class TwitchService {
       this.startPolling();
     }
   }
+
+  // ==========================================================================
+  // MODERATION
+  // ==========================================================================
+
+  /**
+   * Delete a chat message
+   */
+  async deleteMessage(messageId: string): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error("Twitch API not available");
+    }
+
+    const broadcasterId = await this.ensureBroadcasterId();
+    return this.apiClient.deleteMessage(broadcasterId, broadcasterId, messageId);
+  }
+
+  /**
+   * Timeout a user (temporary ban)
+   */
+  async timeoutUser(
+    userId: string,
+    durationSeconds: number,
+    reason?: string
+  ): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error("Twitch API not available");
+    }
+
+    const broadcasterId = await this.ensureBroadcasterId();
+    return this.apiClient.timeoutUser(
+      broadcasterId,
+      broadcasterId,
+      userId,
+      durationSeconds,
+      reason
+    );
+  }
+
+  /**
+   * Ban a user permanently
+   */
+  async banUser(userId: string, reason?: string): Promise<boolean> {
+    if (!this.isAvailable()) {
+      throw new Error("Twitch API not available");
+    }
+
+    const broadcasterId = await this.ensureBroadcasterId();
+    return this.apiClient.banUser(broadcasterId, broadcasterId, userId, reason);
+  }
 }

--- a/lib/utils/Logger.ts
+++ b/lib/utils/Logger.ts
@@ -18,12 +18,13 @@ let fsAppend: ((path: string, data: string, options?: { encoding: string }) => v
 let pathDirname: ((path: string) => string) | null = null;
 
 // Load fs module only on server-side
+// Use eval to hide the require from webpack static analysis
 if (!isBrowser) {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const fs = require("fs");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const path = require("path");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, no-eval
+    const dynamicRequire = eval("require");
+    const fs = dynamicRequire("fs");
+    const path = dynamicRequire("path");
     fsExists = fs.existsSync;
     fsMkdir = fs.mkdirSync;
     fsAppend = fs.appendFileSync;

--- a/messages/en.json
+++ b/messages/en.json
@@ -1170,7 +1170,14 @@
       "searchPlaceholder": "Search messages...",
       "sendPlaceholder": "Send a message to chat...",
       "newMessages": "New messages",
-      "replyingTo": "Replying to @{displayName}"
+      "replyingTo": "Replying to @{displayName}",
+      "moderation": {
+        "delete": "Delete message",
+        "timeout1m": "Timeout 1 min",
+        "timeout10m": "Timeout 10 min",
+        "timeout1h": "Timeout 1 hour",
+        "ban": "Ban"
+      }
     },
     "stats": {
       "viewers": "Viewers",
@@ -1227,6 +1234,17 @@
       "presenterOffline": "Presenter offline",
       "controlOnline": "Control room online",
       "controlOffline": "Control room offline"
+    },
+    "moderation": {
+      "deleteMessage": "Delete message",
+      "timeout1min": "Timeout 1 minute",
+      "timeout10min": "Timeout 10 minutes",
+      "timeout1hour": "Timeout 1 hour",
+      "banUser": "Ban user",
+      "messageDeleted": "Message deleted",
+      "userTimedOut": "User timed out",
+      "userBanned": "User banned",
+      "failed": "Moderation action failed"
     }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1171,7 +1171,14 @@
       "searchPlaceholder": "Rechercher des messages...",
       "sendPlaceholder": "Envoyer un message au chat...",
       "newMessages": "Nouveaux messages",
-      "replyingTo": "Réponse à @{displayName}"
+      "replyingTo": "Réponse à @{displayName}",
+      "moderation": {
+        "delete": "Supprimer le message",
+        "timeout1m": "Timeout 1 min",
+        "timeout10m": "Timeout 10 min",
+        "timeout1h": "Timeout 1 heure",
+        "ban": "Bannir"
+      }
     },
     "stats": {
       "viewers": "Viewers",
@@ -1228,6 +1235,17 @@
       "presenterOffline": "Présentateur hors ligne",
       "controlOnline": "Régie en ligne",
       "controlOffline": "Régie hors ligne"
+    },
+    "moderation": {
+      "deleteMessage": "Supprimer le message",
+      "timeout1min": "Timeout 1 minute",
+      "timeout10min": "Timeout 10 minutes",
+      "timeout1hour": "Timeout 1 heure",
+      "banUser": "Bannir",
+      "messageDeleted": "Message supprimé",
+      "userTimedOut": "Utilisateur mis en timeout",
+      "userBanned": "Utilisateur banni",
+      "failed": "Échec de l'action de modération"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add Twitch chat moderation capabilities to the dashboard regie chat panel
- Support delete message, timeout (1min/10min/1h), and ban actions
- Uses Twitch Helix API for moderation (requires re-authorization for new OAuth scopes)

## Changes
- Add OAuth scopes: `moderator:manage:chat_messages`, `moderator:manage:banned_users`
- Add moderation methods to `TwitchAPIClient` and `TwitchService`
- Add Next.js API routes proxying to backend moderation endpoints
- Add moderation dropdown UI to `RegiePublicChatPanel` (dashboard chat)
- Expose `twitchMsgId` and `twitchUserId` in Streamerbot chat normalizer
- Add French and English translations for moderation actions
- Fix Logger to use eval require for client-side compatibility

## Test plan
- [ ] Disconnect and reconnect Twitch in settings to get new OAuth scopes
- [ ] Open dashboard regie chat panel
- [ ] Hover over a Twitch message from a viewer (not broadcaster)
- [ ] Click the three-dot menu and test delete/timeout/ban actions
- [ ] Verify actions work via Twitch chat/moderation interface

## Notes
- Messages are deleted silently (no "[message deleted]" marker in chat)
- Broadcaster cannot delete their own messages
- Moderation dropdown only appears on Twitch messages with valid user IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)