### PR TITLE
refactor: deduplicate poster route notification logic

### DIFF
--- a/app/api/overlays/poster-bigpicture/route.ts
+++ b/app/api/overlays/poster-bigpicture/route.ts
@@ -1,39 +1,8 @@
-import { PosterRepository } from "@/lib/repositories/PosterRepository";
-import { SettingsService } from "@/lib/services/SettingsService";
-import { sendPresenterNotification } from "@/lib/utils/presenterNotifications";
-import { sendChatMessageIfEnabled } from "@/lib/utils/chatMessaging";
+import { sendPosterShowNotification } from "@/lib/utils/posterShowNotification";
 import { fetchFromBackend, parseBackendResponse } from "@/lib/utils/ProxyHelper";
 import { ApiResponses, withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
 
 const LOG_CONTEXT = "[OverlaysAPI:PosterBigPicture]";
-
-/**
- * Extract YouTube video ID from various URL formats
- */
-function extractYoutubeVideoId(url: string): string | null {
-  if (!url) return null;
-
-  // youtube.com/watch?v=VIDEO_ID
-  const watchMatch = url.match(/youtube\.com\/watch\?v=([^&]+)/);
-  if (watchMatch) return watchMatch[1];
-
-  // youtu.be/VIDEO_ID
-  const shortMatch = url.match(/youtu\.be\/([^?]+)/);
-  if (shortMatch) return shortMatch[1];
-
-  // youtube.com/embed/VIDEO_ID
-  const embedMatch = url.match(/youtube\.com\/embed\/([^?]+)/);
-  if (embedMatch) return embedMatch[1];
-
-  return null;
-}
-
-/**
- * Get YouTube thumbnail URL from video ID
- */
-function getYoutubeThumbnailUrl(videoId: string): string {
-  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-}
 
 /**
  * POST /api/overlays/poster-bigpicture
@@ -58,70 +27,7 @@ export const POST = withSimpleErrorHandler(async (request: Request) => {
 
   // Send notification to presenter when showing a big picture poster (non-blocking)
   if (body.action === 'show' && body.payload) {
-    try {
-      const { posterId, fileUrl, type, source } = body.payload;
-      const posterRepo = PosterRepository.getInstance();
-
-      // Get title and description from database if posterId is provided
-      let title = 'Sans titre';
-      let description = undefined;
-      if (posterId) {
-        const poster = posterRepo.getById(posterId);
-        if (poster) {
-          title = poster.title;
-          description = poster.description;
-        }
-      }
-
-      // Build bullets with only useful context
-      const bullets = [];
-      if (source) {
-        bullets.push(`Source: ${source}`);
-      }
-
-      // Build links
-      const links = [];
-      if (type === 'youtube') {
-        links.push({ url: fileUrl, title: 'Voir sur YouTube' });
-      } else if (type === 'image') {
-        links.push({ url: fileUrl, title: 'Voir l\'image en grand' });
-      } else if (type === 'video') {
-        links.push({ url: fileUrl, title: 'Voir la vidéo' });
-      }
-
-      // Determine imageUrl based on type
-      let imageUrl: string | undefined;
-      if (type === 'image') {
-        imageUrl = fileUrl;
-      } else if (type === 'youtube') {
-        const videoId = extractYoutubeVideoId(fileUrl);
-        if (videoId) {
-          imageUrl = getYoutubeThumbnailUrl(videoId);
-        }
-      }
-
-      await sendPresenterNotification({
-        type: 'poster',
-        title: `Poster: ${title}`,
-        body: description || undefined,
-        imageUrl: imageUrl || undefined,
-        bullets: bullets.length > 0 ? bullets : undefined,
-        links: links.length > 0 ? links : undefined,
-        posterId: posterId, // Include poster ID for tracking
-      });
-
-      // Send chat message if enabled and defined (non-blocking)
-      if (posterId) {
-        const poster = posterRepo.getById(posterId);
-        if (poster?.chatMessage) {
-          const settingsService = SettingsService.getInstance();
-          const chatSettings = settingsService.getChatMessageSettings();
-          sendChatMessageIfEnabled({ enabled: chatSettings.posterChatMessageEnabled }, poster.chatMessage);
-        }
-      }
-    } catch (error) {
-      console.error(`${LOG_CONTEXT} Failed to send presenter notification:`, error);
-    }
+    sendPosterShowNotification(body.payload, LOG_CONTEXT);
   }
 
   return ApiResponses.ok(data);

--- a/app/api/overlays/poster/route.ts
+++ b/app/api/overlays/poster/route.ts
@@ -1,40 +1,9 @@
-import { PosterRepository } from "@/lib/repositories/PosterRepository";
-import { SettingsService } from "@/lib/services/SettingsService";
 import { enrichPosterPayload } from "@/lib/utils/themeEnrichment";
-import { sendPresenterNotification } from "@/lib/utils/presenterNotifications";
-import { sendChatMessageIfEnabled } from "@/lib/utils/chatMessaging";
+import { sendPosterShowNotification } from "@/lib/utils/posterShowNotification";
 import { fetchFromBackend, parseBackendResponse } from "@/lib/utils/ProxyHelper";
 import { ApiResponses, withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
 
 const LOG_CONTEXT = "[OverlaysAPI:Poster]";
-
-/**
- * Extract YouTube video ID from various URL formats
- */
-function extractYoutubeVideoId(url: string): string | null {
-  if (!url) return null;
-
-  // youtube.com/watch?v=VIDEO_ID
-  const watchMatch = url.match(/youtube\.com\/watch\?v=([^&]+)/);
-  if (watchMatch) return watchMatch[1];
-
-  // youtu.be/VIDEO_ID
-  const shortMatch = url.match(/youtu\.be\/([^?]+)/);
-  if (shortMatch) return shortMatch[1];
-
-  // youtube.com/embed/VIDEO_ID
-  const embedMatch = url.match(/youtube\.com\/embed\/([^?]+)/);
-  if (embedMatch) return embedMatch[1];
-
-  return null;
-}
-
-/**
- * Get YouTube thumbnail URL from video ID
- */
-function getYoutubeThumbnailUrl(videoId: string): string {
-  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-}
 
 /**
  * POST /api/overlays/poster
@@ -69,72 +38,8 @@ export const POST = withSimpleErrorHandler(async (request: Request) => {
 
   // Send notification to presenter when showing a poster (non-blocking)
   if (action === 'show' && payload) {
-    try {
-      const { posterId, fileUrl, type, source } = payload;
-      const posterRepo = PosterRepository.getInstance();
-
-      // Get title and description from database if posterId is provided
-      let title = 'Sans titre';
-      let description = undefined;
-      if (posterId) {
-        const poster = posterRepo.getById(posterId);
-        if (poster) {
-          title = poster.title;
-          description = poster.description;
-        }
-      }
-
-      // Build bullets with only useful context
-      const bullets = [];
-      if (source) {
-        bullets.push(`Source: ${source}`);
-      }
-
-      // Build links
-      const links = [];
-      if (type === 'youtube') {
-        links.push({ url: fileUrl, title: 'Voir sur YouTube' });
-      } else if (type === 'image') {
-        links.push({ url: fileUrl, title: 'Voir l\'image en grand' });
-      } else if (type === 'video') {
-        links.push({ url: fileUrl, title: 'Voir la vidéo' });
-      }
-
-      // Determine imageUrl based on type
-      let imageUrl: string | undefined;
-      if (type === 'image') {
-        imageUrl = fileUrl;
-      } else if (type === 'youtube') {
-        const videoId = extractYoutubeVideoId(fileUrl);
-        if (videoId) {
-          imageUrl = getYoutubeThumbnailUrl(videoId);
-        }
-      }
-
-      await sendPresenterNotification({
-        type: 'poster',
-        title: `Poster: ${title}`,
-        body: description || undefined,
-        imageUrl: imageUrl || undefined,
-        bullets: bullets.length > 0 ? bullets : undefined,
-        links: links.length > 0 ? links : undefined,
-        posterId: posterId, // Include poster ID for tracking
-      });
-
-      // Send chat message if enabled and defined (non-blocking)
-      if (posterId) {
-        const poster = posterRepo.getById(posterId);
-        if (poster?.chatMessage) {
-          const settingsService = SettingsService.getInstance();
-          const chatSettings = settingsService.getChatMessageSettings();
-          sendChatMessageIfEnabled({ enabled: chatSettings.posterChatMessageEnabled }, poster.chatMessage);
-        }
-      }
-    } catch (error) {
-      console.error(`${LOG_CONTEXT} Failed to send presenter notification:`, error);
-    }
+    sendPosterShowNotification(payload, LOG_CONTEXT);
   }
 
   return ApiResponses.ok(data);
 }, LOG_CONTEXT);
-

--- a/lib/utils/posterShowNotification.ts
+++ b/lib/utils/posterShowNotification.ts
@@ -1,0 +1,62 @@
+import { PosterRepository } from "@/lib/repositories/PosterRepository";
+import { SettingsService } from "@/lib/services/SettingsService";
+import { buildPosterNotification, sendPresenterNotification } from "@/lib/utils/presenterNotifications";
+import { sendChatMessageIfEnabled } from "@/lib/utils/chatMessaging";
+import type { PosterMediaType } from "@/lib/utils/presenterNotifications";
+
+interface PosterShowPayload {
+  posterId?: string;
+  fileUrl: string;
+  type: PosterMediaType;
+  source?: string;
+}
+
+/**
+ * Send presenter notification and chat message when a poster is shown.
+ * Shared by both poster and poster-bigpicture routes.
+ *
+ * Non-blocking: errors are caught and logged, never thrown.
+ */
+export async function sendPosterShowNotification(
+  payload: PosterShowPayload,
+  logContext: string
+): Promise<void> {
+  try {
+    const { posterId, fileUrl, type, source } = payload;
+    const posterRepo = PosterRepository.getInstance();
+
+    // Get title and description from database if posterId is provided
+    let title = 'Sans titre';
+    let description: string | undefined;
+    if (posterId) {
+      const poster = posterRepo.getById(posterId);
+      if (poster) {
+        title = poster.title;
+        description = poster.description ?? undefined;
+      }
+    }
+
+    const notification = buildPosterNotification({
+      title,
+      description,
+      fileUrl,
+      type,
+      source,
+      posterId,
+    });
+
+    await sendPresenterNotification(notification);
+
+    // Send chat message if enabled and defined (non-blocking)
+    if (posterId) {
+      const poster = posterRepo.getById(posterId);
+      if (poster?.chatMessage) {
+        const settingsService = SettingsService.getInstance();
+        const chatSettings = settingsService.getChatMessageSettings();
+        sendChatMessageIfEnabled({ enabled: chatSettings.posterChatMessageEnabled }, poster.chatMessage);
+      }
+    }
+  } catch (error) {
+    console.error(`${logContext} Failed to send presenter notification:`, error);
+  }
+}


### PR DESCRIPTION
## Summary
- Extracted duplicated YouTube URL parsing and presenter notification logic from `poster/route.ts` and `poster-bigpicture/route.ts` into a shared `lib/utils/posterShowNotification.ts` helper
- Reuses existing `buildPosterNotification` from `presenterNotifications.ts` instead of inline duplication
- Removed ~130 lines of copy-pasted code across both routes

Closes #52

## Test plan
- [ ] Verify poster overlay show action still triggers presenter notification
- [ ] Verify poster-bigpicture overlay show action still triggers presenter notification
- [ ] Verify YouTube thumbnail appears in presenter notification for YouTube posters
- [ ] Verify chat message is sent when enabled for poster show actions
- [ ] Run `pnpm type-check` — no new errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)