### PR TITLE
fix: wire macro API endpoint to MacroEngine for actual execution

### DIFF
--- a/__tests__/api/actions-macro.test.ts
+++ b/__tests__/api/actions-macro.test.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from "crypto";
+import { MacroActionType } from "@/lib/models/Macro";
+
+// Mock MacroRepository
+const mockGetById = jest.fn();
+jest.mock("@/lib/repositories/MacroRepository", () => ({
+  MacroRepository: {
+    getInstance: jest.fn(() => ({
+      getById: mockGetById,
+    })),
+  },
+}));
+
+// Mock MacroEngine
+const mockExecute = jest.fn();
+const mockGetIsExecuting = jest.fn();
+jest.mock("@/lib/services/MacroEngine", () => ({
+  MacroEngine: {
+    getInstance: jest.fn(() => ({
+      execute: mockExecute,
+      getIsExecuting: mockGetIsExecuting,
+    })),
+  },
+}));
+
+// Import after mocks
+import { POST } from "@/app/api/actions/macro/route";
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/actions/macro", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const MACRO_ID = randomUUID();
+
+function makeDbMacro() {
+  return {
+    id: MACRO_ID,
+    name: "Test Macro",
+    description: null,
+    actions: [
+      { type: MacroActionType.LOWER_SHOW, params: { title: "Hello" }, delayAfter: 0 },
+    ],
+    hotkey: null,
+    profileId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe("POST /api/actions/macro", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetIsExecuting.mockReturnValue(false);
+    mockExecute.mockResolvedValue(undefined);
+  });
+
+  it("should return 400 when macroId is missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("macroId is required");
+  });
+
+  it("should return 404 when macro does not exist", async () => {
+    mockGetById.mockReturnValue(null);
+
+    const res = await POST(makeRequest({ macroId: randomUUID() }));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("not found");
+  });
+
+  it("should return 409 when another macro is already executing", async () => {
+    mockGetById.mockReturnValue(makeDbMacro());
+    mockGetIsExecuting.mockReturnValue(true);
+
+    const res = await POST(makeRequest({ macroId: MACRO_ID }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain("already executing");
+  });
+
+  it("should execute macro and return success", async () => {
+    const dbMacro = makeDbMacro();
+    mockGetById.mockReturnValue(dbMacro);
+
+    const res = await POST(makeRequest({ macroId: MACRO_ID }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, macroId: MACRO_ID });
+
+    expect(mockGetById).toHaveBeenCalledWith(MACRO_ID);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    // Verify the macro passed to execute has the right structure
+    const executedMacro = mockExecute.mock.calls[0][0];
+    expect(executedMacro.id).toBe(MACRO_ID);
+    expect(executedMacro.name).toBe("Test Macro");
+    expect(executedMacro.actions).toHaveLength(1);
+    expect(executedMacro.actions[0].type).toBe(MacroActionType.LOWER_SHOW);
+  });
+
+  it("should return 500 when execution throws", async () => {
+    mockGetById.mockReturnValue(makeDbMacro());
+    mockExecute.mockRejectedValue(new Error("OBS connection failed"));
+
+    const res = await POST(makeRequest({ macroId: MACRO_ID }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/actions/macro/route.ts
+++ b/app/api/actions/macro/route.ts
@@ -2,6 +2,9 @@ import {
   ApiResponses,
   withSimpleErrorHandler,
 } from "@/lib/utils/ApiResponses";
+import { MacroRepository } from "@/lib/repositories/MacroRepository";
+import { MacroEngine } from "@/lib/services/MacroEngine";
+import { macroSchema } from "@/lib/models/Macro";
 
 const LOG_CONTEXT = "[ActionsAPI:Macro]";
 
@@ -17,9 +20,25 @@ export const POST = withSimpleErrorHandler(async (request: Request) => {
     return ApiResponses.badRequest("macroId is required");
   }
 
-  // TODO: Implement macro execution via MacroEngine
-  console.log(`${LOG_CONTEXT} Execute macro:`, macroId);
+  const dbMacro = MacroRepository.getInstance().getById(macroId);
+  if (!dbMacro) {
+    return ApiResponses.notFound("Macro");
+  }
+
+  // Parse DB record into validated Macro type (converts null → undefined for optional fields)
+  const macro = macroSchema.parse({
+    ...dbMacro,
+    description: dbMacro.description ?? undefined,
+    hotkey: dbMacro.hotkey ?? undefined,
+    profileId: dbMacro.profileId ?? undefined,
+  });
+
+  const engine = MacroEngine.getInstance();
+  if (engine.getIsExecuting()) {
+    return ApiResponses.conflict("Another macro is already executing");
+  }
+
+  await engine.execute(macro);
 
   return ApiResponses.ok({ success: true, macroId });
 }, LOG_CONTEXT);
-

--- a/lib/repositories/MacroRepository.ts
+++ b/lib/repositories/MacroRepository.ts
@@ -1,0 +1,56 @@
+import { BaseRepository, ColumnTransformConfig } from "./BaseRepository";
+import type { DbMacro } from "@/lib/models/Database";
+
+/**
+ * Raw macro row type as stored in SQLite database.
+ */
+type DbMacroRow = Omit<DbMacro, "actions" | "createdAt" | "updatedAt"> & {
+  actions: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * MacroRepository handles macro database operations.
+ * Read-only for now — macros are created/edited via the macro management UI.
+ */
+export class MacroRepository extends BaseRepository<
+  DbMacro,
+  DbMacroRow,
+  never,
+  never
+> {
+  private static instance: MacroRepository;
+
+  protected readonly tableName = "macros";
+  protected readonly loggerName = "MacroRepository";
+  protected readonly transformConfig: ColumnTransformConfig = {
+    dateColumns: ["createdAt", "updatedAt"],
+    jsonColumns: [
+      { column: "actions", defaultValue: [] },
+    ],
+  };
+
+  private constructor() {
+    super();
+  }
+
+  static getInstance(): MacroRepository {
+    if (!MacroRepository.instance) {
+      MacroRepository.instance = new MacroRepository();
+    }
+    return MacroRepository.instance;
+  }
+
+  protected override getOrderBy(): string {
+    return "name ASC";
+  }
+
+  create(_input: never): void {
+    throw new Error("Not implemented");
+  }
+
+  update(_id: string, _updates: never): void {
+    throw new Error("Not implemented");
+  }
+}


### PR DESCRIPTION
## Summary
- Wire `POST /api/actions/macro` to actually execute macros via `MacroEngine` instead of returning fake success
- Add `MacroRepository` to fetch macros from the database by ID
- Validate macro data with Zod schema before execution
- Return proper HTTP errors: 404 (macro not found), 409 (concurrent execution)

Closes #57

## Test plan
- [x] Unit tests cover: missing macroId (400), macro not found (404), concurrent execution (409), successful execution (200), engine failure (500)
- [x] All 5 tests pass
- [ ] Manual test: trigger macro from Stream Deck or API call with a valid macro in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)