### PR TITLE
feat: Sommaire AI tool + bottom-anchored overlay, and Windows port hardening

### DIFF
--- a/components/overlays/SommaireDisplay.tsx
+++ b/components/overlays/SommaireDisplay.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import type { SommaireShowPayload } from "@/lib/models/OverlayEvents";
 
@@ -13,6 +14,9 @@ const COLORS = {
   active: "#F5A623",
   dimmed: "#7B8DB5",
 };
+
+/** Minimum gap (px) kept above and below the block once it can no longer be centered. */
+const MARGIN = 60;
 
 const TEXT_SHADOW = "0 0 12px rgba(0,0,0,0.9), 0 0 24px rgba(0,0,0,0.7), 0 2px 6px rgba(0,0,0,0.8)";
 const HEADER_SHADOW = "0 0 16px rgba(0,0,0,0.9), 0 0 32px rgba(0,0,0,0.6), 0 2px 8px rgba(0,0,0,0.9)";
@@ -61,9 +65,25 @@ const itemVariants = {
  */
 export function SommaireDisplay({ categories, activeIndex, activeSubIndex }: SommaireDisplayProps) {
   const hasHighlight = activeIndex !== -1;
+  const ref = useRef<HTMLDivElement>(null);
+  // Anchor by the bottom edge: centered while it fits, then stuck to the bottom
+  // (growing upward) once it would overflow. bottom = max(MARGIN, (vh - h) / 2)
+  // gives both behaviours in one expression.
+  const [bottomPx, setBottomPx] = useState(MARGIN);
+
+  useLayoutEffect(() => {
+    const measure = () => {
+      const height = ref.current?.offsetHeight ?? 0;
+      setBottomPx(Math.max(MARGIN, (window.innerHeight - height) / 2));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [categories]);
 
   return (
     <motion.div
+      ref={ref}
       variants={containerVariants}
       initial="hidden"
       animate="visible"
@@ -71,8 +91,7 @@ export function SommaireDisplay({ categories, activeIndex, activeSubIndex }: Som
       style={{
         position: "absolute",
         left: 50,
-        top: "50%",
-        transform: "translateY(-50%)",
+        bottom: bottomPx,
         fontFamily: "'Permanent Marker', cursive",
       }}
     >

--- a/components/shell/panels/SommairePanel.tsx
+++ b/components/shell/panels/SommairePanel.tsx
@@ -11,6 +11,13 @@ import { parseSommaireMarkdown, type SommaireCategory } from "@/lib/models/Somma
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { apiGet, apiPost } from "@/lib/utils/ClientFetch";
+import { useWebSocketChannel } from "@/hooks/useWebSocketChannel";
+
+/** Event shape broadcast on the sommaire channel. */
+interface SommaireChannelEvent {
+  type: string;
+  payload?: { markdown?: string };
+}
 
 const config: PanelConfig = { id: "sommaire", context: "dashboard" };
 
@@ -41,6 +48,22 @@ export function SommairePanel(_props: IDockviewPanelProps) {
   const saveMarkdown = useCallback((md: string) => {
     apiPost("/api/settings/sommaire", { markdown: md }).catch(() => {});
   }, []);
+
+  // Live-refresh: the AI assistant fills the panel via the set-sommaire tool,
+  // which broadcasts a set-markdown event on the sommaire channel.
+  const handleChannelEvent = useCallback(
+    (data: SommaireChannelEvent) => {
+      if (data.type === "set-markdown" && data.payload?.markdown) {
+        setMarkdown(data.payload.markdown);
+        toast.success(t("aiUpdated"));
+      }
+    },
+    [t]
+  );
+
+  useWebSocketChannel<SommaireChannelEvent>("sommaire", handleChannelEvent, {
+    logPrefix: "SommairePanel",
+  });
 
   const sendAction = useCallback(async (action: string, payload?: Record<string, unknown>) => {
     try {

--- a/docs/superpowers/specs/2026-05-31-sommaire-ai-tool-bottom-anchor-design.md
+++ b/docs/superpowers/specs/2026-05-31-sommaire-ai-tool-bottom-anchor-design.md
@@ -1,0 +1,112 @@
+# Sommaire — AI tool `set-sommaire` + ancrage bas de l'overlay
+
+Date: 2026-05-31
+
+## Contexte
+
+Le système Sommaire affiche une table des matières en overlay (catégories `#`,
+sous-items `##`). Il se pilote depuis le `SommairePanel` (dashboard) qui contient
+une zone de texte markdown persistée en base (`/api/settings/sommaire`), avec
+boutons Show/Hide et navigation de highlight. L'overlay (`SommaireDisplay`) écoute
+le canal WebSocket `sommaire` (SHOW / HIDE / HIGHLIGHT).
+
+Deux besoins :
+
+1. **Tool IA** — permettre à l'assistant IA intégré de transformer une liste de
+   titres/sections collée en texte brut en sommaire structuré `#`/`##` et de
+   **remplir le panel** (sans afficher à l'antenne — l'opérateur garde la main).
+2. **Débordement** — un sommaire long déborde du bas de l'écran car l'overlay est
+   centré verticalement. Il faut qu'il reste centré quand il est court mais
+   s'ancre en bas (et s'empile vers le haut) quand il est long.
+
+## Décisions
+
+| Sujet | Choix |
+|-------|-------|
+| Destination du résultat | Remplit le panel (persiste), n'affiche PAS à l'antenne |
+| Mise à jour du panel | Live (broadcast WebSocket), pas de rechargement manuel |
+| Ancrage overlay | Centré quand court, bascule en ancrage bas quand long |
+| Nom du tool MCP | `set-sommaire` |
+
+La **transformation** texte brut → structure `#`/`##` est faite par le LLM
+(l'agent IA), pas par un parseur déterministe : décider qu'une ligne est un titre
+ou un sous-titre est interprétatif. Le tool ne fait que valider, persister et
+diffuser le markdown déjà structuré par l'IA.
+
+## Partie A — Tool IA `set-sommaire`
+
+### Comportement
+
+`set-sommaire({ markdown })` :
+
+1. Valide qu'il y a ≥ 1 catégorie (réutilise `parseSommaireMarkdown`), sinon
+   renvoie une erreur explicite.
+2. **Persiste** le markdown : `frontendFetch('POST /api/settings/sommaire', { markdown })`.
+3. **Diffuse** pour live-refresh du panel :
+   `backendFetch('POST /api/overlays/sommaire', { action: 'set-markdown', payload: { markdown } })`.
+4. Renvoie un résumé texte (nb de catégories / sous-items, rappel « clique Show
+   pour l'afficher »).
+
+N'appelle **jamais** `show`. L'opérateur révise puis affiche manuellement.
+L'agent IA in-app découvre le tool automatiquement (`AiToolBridge`, cache 60s).
+Tool non-destructif → exécution directe sans confirmation client.
+
+### Live-refresh
+
+Nouvel event sur le canal `sommaire` : `SommaireEventType.SET_MARKDOWN =
+"set-markdown"`, payload `{ markdown: string }`. Le `SommaireRenderer` (overlay)
+n'a pas de case pour ce type → il l'ignore (fallthrough vers `sendAck`). Le
+`SommairePanel` s'abonne au canal via `useWebSocketChannel("sommaire")` et, sur
+`set-markdown`, fait `setMarkdown(payload.markdown)` + toast « Sommaire mis à
+jour par l'IA ».
+
+Garde-fou accepté : le live-update écrase le contenu en cours d'édition. C'est le
+comportement voulu (l'opérateur a demandé à l'IA de remplir).
+
+### Fichiers
+
+- `lib/models/OverlayEvents.ts` — `SommaireEventType.SET_MARKDOWN`
+- `lib/models/Sommaire.ts` — `sommaireSetMarkdownPayloadSchema = z.object({ markdown: z.string().min(1) })`
+- `server/api/overlays.ts` — case `set-markdown` dans la route `/sommaire`
+- `mcp-server/src/tools/sommaire.ts` — tool `set-sommaire` (+ import `frontendFetch`)
+- `components/shell/panels/SommairePanel.tsx` — abonnement + handler `set-markdown`
+- `lib/services/ai/systemPrompt.ts` — capacité Sommaire + consigne de structuration
+- `messages/fr.json`, `messages/en.json` — clé toast `dashboard.sommaire.aiUpdated`
+- `mcp-server/__tests__/tools/sommaire.test.ts` — tests du tool
+
+## Partie B — Overlay ancré en bas
+
+Dans `components/overlays/SommaireDisplay.tsx`, remplacer le positionnement
+centré fixe par un positionnement par le bas calculé à partir de la hauteur
+mesurée du bloc :
+
+```
+bottomPx = max(MARGIN, (window.innerHeight - blockHeight) / 2)
+```
+
+- Bloc court → `(vh - h)/2 > MARGIN` → `bottom = (vh - h)/2` ⇒ visuellement
+  centré (top et bottom égaux).
+- Bloc long → `(vh - h)/2 < MARGIN` → `bottom = MARGIN` ⇒ ancré en bas, s'empile
+  vers le haut.
+
+Implémentation : `ref` sur le `motion.div`, `useLayoutEffect` qui mesure
+`offsetHeight` et recalcule `bottomPx` (dépendances : `categories`), plus un
+listener `resize`. Style : `bottom: bottomPx`, suppression de `top: "50%"` et
+`transform: translateY(-50%)`. L'animation framer-motion (`x`, slide gauche) est
+inchangée — `bottom` n'entre pas en conflit avec le `transform` animé.
+
+`MARGIN` ≈ 60px. Caveat assumé (YAGNI) : un sommaire plus haut que l'écran
+débordera en **haut** ; un scale-down auto pourra être ajouté plus tard.
+
+## Hors périmètre
+
+- Pas de scale-down/auto-fit pour les sommaires dépassant la hauteur d'écran.
+- Pas de tool IA pour Show/Hide/Highlight (l'opérateur pilote l'antenne).
+- Pas de garde anti-écrasement de l'édition en cours dans le panel.
+
+## Tests
+
+- `mcp-server/__tests__/tools/sommaire.test.ts` : succès (persist + broadcast
+  appelés avec les bons arguments), markdown sans catégorie → erreur, échec
+  persist → erreur.
+- `pnpm type-check` + `pnpm test:mcp`.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -13,6 +13,10 @@ module.exports = {
       autorestart: true,
       watch: false,
       max_memory_restart: '300M',
+      max_restarts: 3,
+      min_uptime: '5s',
+      // Exit code 100 = port already in use -> do not restart (avoid spawn loop)
+      stop_exit_codes: [100],
       windowsHide: true,
       env: {
         NODE_ENV: 'production',
@@ -36,6 +40,8 @@ module.exports = {
       max_memory_restart: '500M',
       max_restarts: 3,
       min_uptime: '5s',
+      // Exit code 100 = port already in use -> do not restart (avoid spawn loop)
+      stop_exit_codes: [100],
       windowsHide: true,
       env: {
         NODE_ENV: 'production',

--- a/lib/models/OverlayEvents.ts
+++ b/lib/models/OverlayEvents.ts
@@ -107,6 +107,8 @@ export enum SommaireEventType {
   SHOW = "show",
   HIDE = "hide",
   HIGHLIGHT = "highlight",
+  /** Pushes new markdown into the dashboard panel (live edit), not the overlay. */
+  SET_MARKDOWN = "set-markdown",
 }
 
 /**

--- a/lib/models/Sommaire.ts
+++ b/lib/models/Sommaire.ts
@@ -37,6 +37,17 @@ export const sommaireHighlightPayloadSchema = z.object({
 export type SommaireHighlightPayload = z.infer<typeof sommaireHighlightPayloadSchema>;
 
 /**
+ * Set-markdown payload schema.
+ * Pushes raw markdown into the dashboard SommairePanel for live editing
+ * (does not affect the on-air overlay).
+ */
+export const sommaireSetMarkdownPayloadSchema = z.object({
+  markdown: z.string().min(1),
+});
+
+export type SommaireSetMarkdownPayload = z.infer<typeof sommaireSetMarkdownPayloadSchema>;
+
+/**
  * Parse markdown into sommaire categories.
  * Lines starting with # become categories, ## become sub-items.
  */

--- a/lib/services/ai/systemPrompt.ts
+++ b/lib/services/ai/systemPrompt.ts
@@ -8,6 +8,7 @@ Tu peux piloter le live via des outils (tools) :
 - **Overlays** : afficher/masquer le lower third, le poster, le countdown, le chat highlight
 - **Countdown** : démarrer, arrêter un compte à rebours
 - **Chat** : mettre en avant un message chat
+- **Sommaire** : construire le sommaire (table des matières) et le charger dans le panel via \`set-sommaire\`
 - **OBS** : obtenir le statut, changer de scène
 
 ## Consignes
@@ -20,4 +21,5 @@ Tu peux piloter le live via des outils (tools) :
 - Pour les actions destructives (suppression d'invité, d'affiche, effacement d'overlays), demande TOUJOURS confirmation en langage naturel avant d'appeler le tool.
 - Si aucun tool ne correspond à la demande, réponds en mode texte.
 - **INTERDIT d'inventer des faits ou des informations factuelles.** Mais tu PEUX reformuler ou synthétiser le texte fourni par l'utilisateur pour créer des titres/sous-titres pertinents.
+- **Sommaire** : quand l'utilisateur colle une liste de sections/parties d'émission, structure-la en markdown avec \`#\` pour les titres principaux et \`##\` pour les sous-titres, puis appelle \`set-sommaire\`. Déduis la hiérarchie du sens (ex : un "ACTE" ou une partie = \`#\`, un "CHAPITRE" ou une sous-section = \`##\`). N'affiche PAS le sommaire à l'antenne toi-même : \`set-sommaire\` ne fait que remplir le panel, l'opérateur l'affiche ensuite.
 `;

--- a/mcp-server/__tests__/tools/sommaire.test.ts
+++ b/mcp-server/__tests__/tools/sommaire.test.ts
@@ -1,0 +1,119 @@
+const mockBackendFetch = jest.fn();
+const mockFrontendFetch = jest.fn();
+jest.mock('../../src/httpClient', () => ({
+  backendFetch: (...args: unknown[]) => mockBackendFetch(...args),
+  frontendFetch: (...args: unknown[]) => mockFrontendFetch(...args),
+  errorResponse: jest.requireActual('../../src/httpClient').errorResponse,
+  textResponse: jest.requireActual('../../src/httpClient').textResponse,
+}));
+
+import { registerSommaireTools } from '../../src/tools/sommaire';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+
+function createMockServer() {
+  const tools = new Map<string, ToolHandler>();
+  return {
+    registerTool: jest.fn((name: string, _config: unknown, handler: ToolHandler) =>
+      tools.set(name, handler),
+    ),
+    tools,
+  };
+}
+
+const MARKDOWN = `# ACTE 1\n## Chapitre 1\n## Chapitre 2\n# ACTE 2\n## Chapitre 3`;
+
+describe('sommaire tools', () => {
+  let server: ReturnType<typeof createMockServer>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    server = createMockServer();
+    registerSommaireTools(server as never);
+  });
+
+  describe('set-sommaire', () => {
+    it('persists markdown then broadcasts a set-markdown event', async () => {
+      mockFrontendFetch.mockResolvedValue({ success: true });
+      mockBackendFetch.mockResolvedValue({ success: true });
+
+      const handler = server.tools.get('set-sommaire')!;
+      const result = await handler({ markdown: MARKDOWN });
+
+      expect(mockFrontendFetch).toHaveBeenCalledWith('/api/settings/sommaire', {
+        method: 'POST',
+        body: JSON.stringify({ markdown: MARKDOWN }),
+      });
+      expect(mockBackendFetch).toHaveBeenCalledWith('/api/overlays/sommaire', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'set-markdown', payload: { markdown: MARKDOWN } }),
+      });
+      // 2 categories, 3 sub-items
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: "Sommaire chargé dans le panel : 2 catégorie(s), 3 sous-élément(s). L'opérateur peut le réviser puis cliquer Show.",
+          },
+        ],
+      });
+    });
+
+    it('returns an error when markdown has no categories', async () => {
+      const handler = server.tools.get('set-sommaire')!;
+      const result = await handler({ markdown: 'just some text\nno headings here' });
+
+      expect(mockFrontendFetch).not.toHaveBeenCalled();
+      expect(mockBackendFetch).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: 'Error: No categories found in markdown. Use # for titles and ## for sub-titles.',
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it('returns an error and skips broadcast when persistence fails', async () => {
+      mockFrontendFetch.mockResolvedValue({ success: false, error: 'DB write failed' });
+
+      const handler = server.tools.get('set-sommaire')!;
+      const result = await handler({ markdown: MARKDOWN });
+
+      expect(mockFrontendFetch).toHaveBeenCalled();
+      expect(mockBackendFetch).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'Error: DB write failed' }],
+        isError: true,
+      });
+    });
+  });
+
+  describe('show-sommaire', () => {
+    it('parses markdown and posts categories to the overlay', async () => {
+      mockBackendFetch.mockResolvedValue({ success: true });
+
+      const handler = server.tools.get('show-sommaire')!;
+      const result = await handler({ markdown: MARKDOWN });
+
+      expect(mockBackendFetch).toHaveBeenCalledWith('/api/overlays/sommaire', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'show',
+          payload: {
+            categories: [
+              { index: 0, title: 'ACTE 1', items: ['Chapitre 1', 'Chapitre 2'] },
+              { index: 1, title: 'ACTE 2', items: ['Chapitre 3'] },
+            ],
+            activeIndex: -1,
+          },
+        }),
+      });
+      expect(result).toEqual({
+        content: [{ type: 'text', text: 'Sommaire displayed with 2 categories.' }],
+      });
+    });
+  });
+});

--- a/mcp-server/src/tools/sommaire.ts
+++ b/mcp-server/src/tools/sommaire.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod/v4';
-import { backendFetch, errorResponse, textResponse } from '../httpClient.js';
+import { backendFetch, frontendFetch, errorResponse, textResponse } from '../httpClient.js';
 
 /**
  * Parse markdown into sommaire categories.
@@ -53,6 +53,39 @@ export function registerSommaireTools(server: McpServer) {
 
     if (!result.success) return errorResponse(result.error);
     return textResponse(`Sommaire displayed with ${categories.length} categories.`);
+  });
+
+  server.registerTool('set-sommaire', {
+    title: 'Set Sommaire (fill panel)',
+    description:
+      'Build the sommaire (table of contents) from structured markdown and load it into the dashboard Sommaire panel for the operator to review. Use # for top-level titles and ## for sub-titles, one per line. Use this to turn a raw pasted list of show sections into a structured sommaire. This does NOT display it on air — the operator reviews and clicks Show.',
+    inputSchema: z.object({
+      markdown: z.string().describe('Markdown with # for titles and ## for sub-titles, one per line'),
+    }),
+  }, async ({ markdown }) => {
+    const categories = parseSommaireMarkdown(markdown);
+    if (categories.length === 0) {
+      return errorResponse('No categories found in markdown. Use # for titles and ## for sub-titles.');
+    }
+
+    // Persist so the sommaire survives a panel reload (reuses the settings route).
+    const saved = await frontendFetch('/api/settings/sommaire', {
+      method: 'POST',
+      body: JSON.stringify({ markdown }),
+    });
+    if (!saved.success) return errorResponse(saved.error);
+
+    // Broadcast so an already-open panel refreshes live (best-effort: the data
+    // is already persisted, so the panel will also pick it up on next load).
+    await backendFetch('/api/overlays/sommaire', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'set-markdown', payload: { markdown } }),
+    });
+
+    const itemCount = categories.reduce((sum, c) => sum + c.items.length, 0);
+    return textResponse(
+      `Sommaire chargé dans le panel : ${categories.length} catégorie(s), ${itemCount} sous-élément(s). L'opérateur peut le réviser puis cliquer Show.`,
+    );
   });
 
   server.registerTool('hide-sommaire', {

--- a/messages/en.json
+++ b/messages/en.json
@@ -428,7 +428,8 @@
       "hide": "Hide",
       "none": "None",
       "noCategories": "No categories found. Use # for categories.",
-      "error": "Error controlling sommaire"
+      "error": "Error controlling sommaire",
+      "aiUpdated": "Sommaire updated by AI"
     }
   },
   "navigation": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -428,7 +428,8 @@
       "hide": "Masquer",
       "none": "Aucun",
       "noCategories": "Aucune catégorie trouvée. Utilisez # pour les catégories.",
-      "error": "Erreur lors du contrôle du sommaire"
+      "error": "Erreur lors du contrôle du sommaire",
+      "aiUpdated": "Sommaire mis à jour par l'IA"
     }
   },
   "navigation": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:all": "pnpm test && pnpm test:functional && pnpm test:functional:ui",
     "streamdeck:ids": "node scripts/list-streamdeck-ids.js",
     "backup:appdata": "node scripts/backup-appdata.js",
+    "reserve:ports": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/reserve-ports.ps1",
     "dev:mcp": "cd mcp-server && pnpm dev",
     "test:mcp": "pnpm --filter obs-live-suite-mcp test",
     "studio-return:dev": "cd studio-return && pnpm dev",

--- a/scripts/port-diagnostics.mjs
+++ b/scripts/port-diagnostics.mjs
@@ -1,0 +1,125 @@
+/**
+ * Port conflict diagnostics — shared by server.js (frontend) and server/backend.ts.
+ *
+ * When a server can't bind its port, these helpers identify WHO holds it and
+ * print a copy-pasteable remediation, so a port conflict is diagnosed in
+ * seconds instead of a guessing game.
+ *
+ * Crucially, on Windows this covers the "Bound" TCP state (a process that called
+ * bind() without listen()). That state is invisible to `netstat` and to
+ * `Get-NetTCPConnection -State Listen`, which is exactly how a stray Stream Deck
+ * socket on port 3002 once blocked the backend with no visible listener.
+ */
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+const EXEC_TIMEOUT_MS = 4000;
+
+/**
+ * @typedef {Object} PortHolder
+ * @property {number} pid
+ * @property {string} name
+ * @property {string} path
+ * @property {string} states  Comma-joined TCP states (e.g. "Bound" or "Listen,Established")
+ */
+
+/**
+ * Best-effort lookup of which processes currently hold a TCP port (any state).
+ * Returns [] on any failure — diagnostics must never throw into the caller.
+ *
+ * @param {number} port
+ * @returns {Promise<PortHolder[]>}
+ */
+export async function findPortHolders(port) {
+  try {
+    if (process.platform === "win32") {
+      // -EncodedCommand avoids all shell-quoting pitfalls.
+      const script = `
+$ErrorActionPreference = 'SilentlyContinue'
+$c = Get-NetTCPConnection -LocalPort ${port}
+if ($c) {
+  $c | Group-Object OwningProcess | Where-Object { $_.Name -ne '0' } | ForEach-Object {
+    $procId = [int]$_.Name
+    $p = Get-Process -Id $procId
+    [PSCustomObject]@{
+      pid    = $procId
+      name   = [string]$p.ProcessName
+      path   = [string]$p.Path
+      states = (($_.Group.State | Sort-Object -Unique) -join ',')
+    }
+  } | ConvertTo-Json -Compress
+}`;
+      const encoded = Buffer.from(script, "utf16le").toString("base64");
+      const { stdout } = await execAsync(
+        `powershell -NoProfile -NonInteractive -EncodedCommand ${encoded}`,
+        { timeout: EXEC_TIMEOUT_MS }
+      );
+      const text = stdout.trim();
+      if (!text) return [];
+      const parsed = JSON.parse(text);
+      return Array.isArray(parsed) ? parsed : [parsed];
+    }
+
+    // POSIX (best effort): lsof listeners.
+    const { stdout } = await execAsync(`lsof -nP -iTCP:${port} -sTCP:LISTEN`, {
+      timeout: EXEC_TIMEOUT_MS,
+    });
+    return stdout
+      .trim()
+      .split("\n")
+      .slice(1)
+      .filter(Boolean)
+      .map((line) => {
+        const cols = line.split(/\s+/);
+        return { pid: Number(cols[1]), name: cols[0], path: "", states: "LISTEN" };
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Build a human-readable port-conflict report: who holds the port and how to free it.
+ *
+ * @param {number} port
+ * @param {string} label  Short prefix for log lines, e.g. "frontend" or "backend".
+ * @returns {Promise<string>}
+ */
+export async function getPortConflictReport(port, label) {
+  const holders = await findPortHolders(port);
+  const lines = [`[${label}] Port ${port} is already in use — refusing to start.`];
+
+  if (holders.length > 0) {
+    lines.push(`[${label}] Held by:`);
+    for (const h of holders) {
+      const where = h.path ? `  (${h.path})` : "";
+      lines.push(`[${label}]   • PID ${h.pid} — ${h.name || "unknown"} [${h.states}]${where}`);
+    }
+    const pids = [...new Set(holders.map((h) => h.pid))].join(",");
+    lines.push(
+      process.platform === "win32"
+        ? `[${label}] → Free it:   Stop-Process -Id ${pids} -Force`
+        : `[${label}] → Free it:   kill -9 ${pids}`
+    );
+  } else {
+    lines.push(
+      `[${label}] Could not identify the owner — it may hold a "Bound" socket without listening.`
+    );
+    if (process.platform === "win32") {
+      lines.push(
+        `[${label}] → Inspect:   Get-NetTCPConnection -LocalPort ${port} | Select LocalAddress,State,OwningProcess`
+      );
+    }
+  }
+
+  if (process.platform === "win32") {
+    lines.push(
+      `[${label}] → Permanent fix (admin): reserve the port so no app grabs it as a dynamic port:`,
+      `[${label}]     netsh int ipv4 add excludedportrange protocol=tcp startport=${port} numberofports=1`,
+      `[${label}]     netsh int ipv6 add excludedportrange protocol=tcp startport=${port} numberofports=1`
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/scripts/reserve-ports.ps1
+++ b/scripts/reserve-ports.ps1
@@ -1,0 +1,171 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Reserve OBS Live Suite's fixed ports so Windows (or apps like Stream Deck) can't
+  grab them as dynamic ports — the root cause of EADDRINUSE on 3002/3004.
+
+.DESCRIPTION
+  On this machine the TCP dynamic port range starts at 1024, so any app can be
+  assigned a low port (3000-3004) as an ephemeral port. This script reserves the
+  suite's ports via `netsh ... add excludedportrange` (IPv4 + IPv6) so they are
+  never auto-assigned to anything else.
+
+  The script:
+    1. Self-elevates via UAC (netsh excludedportrange requires admin).
+    2. Stops PM2 to free the ports (skipped with -SkipPm2).
+    3. Reserves each port that isn't already excluded (idempotent — safe to re-run).
+    4. Restarts PM2 (skipped with -NoRestart or -SkipPm2).
+
+  A port that is still held after the PM2 stop is reported (with the owning PID
+  and process name) and skipped — close that app and re-run.
+
+.PARAMETER Ports
+  Ports to reserve. Default: 3000 (frontend), 3002 (backend HTTP), 3003 (WS hub),
+  3004 (MCP). 3000/3003 are usually already reserved and will be skipped.
+
+.PARAMETER NoRestart
+  Reserve the ports but do not restart PM2 afterwards.
+
+.PARAMETER SkipPm2
+  Don't touch PM2 at all (assumes the ports are already free).
+
+.EXAMPLE
+  pnpm reserve:ports
+
+.EXAMPLE
+  powershell -NoProfile -ExecutionPolicy Bypass -File scripts/reserve-ports.ps1 -Ports 3002,3004
+#>
+[CmdletBinding()]
+param(
+  [int[]] $Ports = @(3000, 3002, 3003, 3004),
+  [switch] $NoRestart,
+  [switch] $SkipPm2
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Self-elevate (netsh excludedportrange needs admin) ----------------------
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+  [Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+  Write-Host "Administrator rights required - relaunching via UAC..." -ForegroundColor Yellow
+  $exe = (Get-Process -Id $PID).Path
+  $argList = @('-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PSCommandPath,
+    '-Ports', ($Ports -join ','))
+  if ($NoRestart) { $argList += '-NoRestart' }
+  if ($SkipPm2)   { $argList += '-SkipPm2' }
+  try {
+    Start-Process -FilePath $exe -Verb RunAs -ArgumentList $argList
+  } catch {
+    Write-Host "Elevation cancelled. Re-run from an elevated terminal." -ForegroundColor Red
+    exit 1
+  }
+  exit 0
+}
+
+# --- Helpers -----------------------------------------------------------------
+function Get-ExcludedRanges {
+  param([string] $Family)
+  $ranges = @()
+  $out = netsh int $Family show excludedportrange protocol=tcp 2>$null
+  foreach ($line in $out) {
+    # Data rows are "<start>  <end>" (locale-independent); skip headers/dashes.
+    if ($line -match '^\s*(\d+)\s+(\d+)') {
+      $ranges += [pscustomobject]@{ Start = [int]$Matches[1]; End = [int]$Matches[2] }
+    }
+  }
+  return , $ranges
+}
+
+function Test-PortExcluded {
+  param([int] $Port, $Ranges)
+  foreach ($r in $Ranges) {
+    if ($Port -ge $r.Start -and $Port -le $r.End) { return $true }
+  }
+  return $false
+}
+
+function Get-PortHolder {
+  param([int] $Port)
+  $c = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue |
+    Where-Object { $_.OwningProcess -ne 0 }
+  if (-not $c) { return $null }
+  $g = $c | Group-Object OwningProcess | Select-Object -First 1
+  $procId = [int] $g.Name
+  $p = Get-Process -Id $procId -ErrorAction SilentlyContinue
+  return [pscustomobject]@{
+    Pid    = $procId
+    Name   = if ($p) { $p.ProcessName } else { 'unknown' }
+    States = (($g.Group.State | Sort-Object -Unique) -join ',')
+  }
+}
+
+function Invoke-Pnpm {
+  param([string] $Script)
+  Push-Location $projectRoot
+  try {
+    pnpm $Script 2>&1 | Out-Host
+    return $true
+  } catch {
+    Write-Host ("  pnpm $Script failed: {0}" -f $_.Exception.Message) -ForegroundColor DarkYellow
+    return $false
+  } finally {
+    Pop-Location
+  }
+}
+
+# --- Main --------------------------------------------------------------------
+$projectRoot = Split-Path $PSScriptRoot -Parent
+$families = @('ipv4', 'ipv6')
+
+Write-Host ""
+Write-Host "OBS Live Suite - port reservation" -ForegroundColor Cyan
+Write-Host ("Ports : {0}" -f ($Ports -join ', '))
+Write-Host ("Root  : {0}" -f $projectRoot)
+
+# 1. Free the ports by stopping PM2.
+if (-not $SkipPm2) {
+  Write-Host "`nStopping PM2 (to free the ports)..." -ForegroundColor Yellow
+  [void] (Invoke-Pnpm 'pm2:stop')
+  Start-Sleep -Milliseconds 800
+}
+
+# 2. Reserve each port (IPv4 + IPv6), idempotently, only if currently free.
+Write-Host "`nReserving ports..." -ForegroundColor Yellow
+foreach ($port in $Ports) {
+  $holder = Get-PortHolder $port
+  if ($holder) {
+    Write-Host ("  {0}: STILL IN USE by PID {1} ({2}) [{3}] - skipped. Close it and re-run." -f `
+        $port, $holder.Pid, $holder.Name, $holder.States) -ForegroundColor Red
+    continue
+  }
+  foreach ($fam in $families) {
+    if (Test-PortExcluded $port (Get-ExcludedRanges $fam)) {
+      Write-Host ("  {0} [{1}]: already reserved" -f $port, $fam) -ForegroundColor DarkGray
+      continue
+    }
+    $null = netsh int $fam add excludedportrange protocol=tcp startport=$port numberofports=1
+    if ($LASTEXITCODE -eq 0) {
+      Write-Host ("  {0} [{1}]: reserved" -f $port, $fam) -ForegroundColor Green
+    } else {
+      Write-Host ("  {0} [{1}]: netsh failed (exit {2})" -f $port, $fam, $LASTEXITCODE) -ForegroundColor Red
+    }
+  }
+}
+
+# 3. Restart PM2.
+if (-not $SkipPm2 -and -not $NoRestart) {
+  Write-Host "`nStarting PM2..." -ForegroundColor Yellow
+  [void] (Invoke-Pnpm 'pm2:start')
+}
+
+# 4. Summary.
+Write-Host "`nSummary (IPv4 exclusions):" -ForegroundColor Cyan
+$ranges4 = Get-ExcludedRanges 'ipv4'
+foreach ($port in $Ports) {
+  $ok = Test-PortExcluded $port $ranges4
+  $mark = if ($ok) { 'reserved   ' } else { 'NOT reserved' }
+  $color = if ($ok) { 'Green' } else { 'Red' }
+  Write-Host ("  {0} : {1}" -f $port, $mark) -ForegroundColor $color
+}
+Write-Host "`nDone." -ForegroundColor Cyan

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ import next from 'next';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { getPortConflictReport } from './scripts/port-diagnostics.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -30,8 +31,11 @@ const httpsOptions = {
   cert: fs.readFileSync(CERT_PATH),
 };
 
+// Exit code that tells PM2 (via `stop_exit_codes`) NOT to restart on port conflict.
+const PORT_IN_USE_EXIT_CODE = 100;
+
 app.prepare().then(() => {
-  createServer(httpsOptions, async (req, res) => {
+  const httpServer = createServer(httpsOptions, async (req, res) => {
     try {
       const parsedUrl = parse(req.url, true);
       await handle(req, res, parsedUrl);
@@ -40,7 +44,20 @@ app.prepare().then(() => {
       res.statusCode = 500;
       res.end('internal server error');
     }
-  }).listen(port, hostname, (err) => {
+  });
+
+  // If the port is taken, report WHO holds it + how to free it, then exit with
+  // PORT_IN_USE_EXIT_CODE so PM2 (via `stop_exit_codes`) does NOT restart in a loop.
+  httpServer.once('error', async (err) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(await getPortConflictReport(port, 'frontend'));
+      console.error(`[frontend] PM2 will NOT restart this process (exit ${PORT_IN_USE_EXIT_CODE}).`);
+      process.exit(PORT_IN_USE_EXIT_CODE);
+    }
+    throw err;
+  });
+
+  httpServer.listen(port, hostname, (err) => {
     if (err) throw err;
     console.log(`> Ready on https://localhost:${port}`);
     console.log(`> Network: https://192.168.1.10:${port}`);

--- a/server/api/overlays.ts
+++ b/server/api/overlays.ts
@@ -19,7 +19,7 @@ import {
   OverlayChannel
 } from "../../lib/models/OverlayEvents";
 import { lowerThirdShowPayloadSchema, chatHighlightShowPayloadSchema, titleRevealPlayPayloadSchema, sommaireShowPayloadSchema } from "../../lib/models/OverlayEvents";
-import { sommaireHighlightPayloadSchema } from "../../lib/models/Sommaire";
+import { sommaireHighlightPayloadSchema, sommaireSetMarkdownPayloadSchema } from "../../lib/models/Sommaire";
 import { enrichLowerThirdPayload, enrichCountdownPayload, enrichPosterPayload, enrichChatHighlightPayload, enrichTitleRevealPayload } from "../../lib/utils/themeEnrichment";
 import { updatePosterSourceInOBS } from "./obs-helpers";
 import { Logger } from "../../lib/utils/Logger";
@@ -381,6 +381,12 @@ router.post("/sommaire", overlayHandler(async (req, res) => {
     case "highlight":
       const highlightPayload = sommaireHighlightPayloadSchema.parse(payload);
       await channelManager.publish(OverlayChannel.SOMMAIRE, SommaireEventType.HIGHLIGHT, highlightPayload);
+      break;
+
+    case "set-markdown":
+      // Pushes markdown to the dashboard panel for live editing (not the on-air overlay).
+      const setMarkdownPayload = sommaireSetMarkdownPayloadSchema.parse(payload);
+      await channelManager.publish(OverlayChannel.SOMMAIRE, SommaireEventType.SET_MARKDOWN, setMarkdownPayload);
       break;
 
     default:

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -36,12 +36,16 @@ import mediaPlayerRouter from "./api/media-player";
 import wordHarvestRouter from "./api/word-harvest";
 import { APP_PORT, BACKEND_PORT, WS_PORT } from "../lib/config/urls";
 import { createServerWithFallback } from "../lib/utils/CertificateManager";
+import { getPortConflictReport } from "../scripts/port-diagnostics.mjs";
 import { expressError } from "../lib/utils/apiError";
 import { MediaPlayerManager } from "../lib/services/MediaPlayerManager";
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// Exit code that tells PM2 (via `stop_exit_codes`) NOT to restart on port conflict.
+const PORT_IN_USE_EXIT_CODE = 100;
 
 class BackendServer {
   private logger: Logger;
@@ -262,6 +266,17 @@ class BackendServer {
       await new Promise<void>((resolve) => {
         const { server, isHttps } = createServerWithFallback(this.app);
         this.httpServer = server;
+
+        // If the port is taken, report WHO holds it + how to free it, then exit with
+        // PORT_IN_USE_EXIT_CODE so PM2 (via `stop_exit_codes`) does NOT restart in a loop.
+        this.httpServer.once("error", async (err: NodeJS.ErrnoException) => {
+          if (err.code === "EADDRINUSE") {
+            console.error(await getPortConflictReport(this.httpPort, "backend"));
+            console.error(`[backend] PM2 will NOT restart this process (exit ${PORT_IN_USE_EXIT_CODE}).`);
+            process.exit(PORT_IN_USE_EXIT_CODE);
+          }
+          throw err;
+        });
 
         this.httpServer.listen(this.httpPort, () => {
           if (isHttps) {


### PR DESCRIPTION
## Résumé

Cette PR porte deux ensembles de changements (cf. les deux commits).

### 1. Tool IA `set-sommaire` + overlay ancré en bas (commit `feat(sommaire)`)

- **`set-sommaire`** : l'assistant IA de l'app transforme une liste brute de sections d'émission en sommaire structuré `#`/`##` et **remplit le panel Sommaire** pour que l'opérateur révise — ça ne part **jamais** à l'antenne tout seul. La structuration titre/sous-titre est faite par le LLM ; le tool ne fait que valider, **persister** (`/api/settings/sommaire`) et **diffuser** un event `SET_MARKDOWN` sur le canal `sommaire`.
- **Live-refresh** : `SommairePanel` s'abonne au canal et se remplit en direct (+ toast), même s'il était déjà ouvert.
- **Overlay anti-débordement** : centré quand il tient, ancré en bas (empilement vers le haut) quand il est long — `bottom = max(MARGIN, (innerHeight - blockHeight) / 2)`.
- L'agent in-app découvre le tool **automatiquement** (AiToolBridge) — rien à câbler côté chat.
- Spec : `docs/superpowers/specs/2026-05-31-sommaire-ai-tool-bottom-anchor-design.md`.

### 2. Durcissement des conflits de ports Windows (commit `chore(ports)`)

- Diagnostic du processus qui squatte un port (y compris l'état **"Bound"** invisible à `netstat`, ex. Stream Deck sur 3002) + remédiation copiable.
- `server.js` / `server/backend.ts` : sur `EADDRINUSE`, on imprime le rapport et on sort en **exit 100** au lieu de throw.
- `ecosystem.config.cjs` : `stop_exit_codes: [100]` → PM2 ne redémarre plus en boucle sur un conflit de port.
- `scripts/reserve-ports.ps1` + script `reserve:ports` : réserve les ports fixes via `netsh excludedportrange`.

## Tests / vérification

- ✅ `mcp-server` : `tsc --noEmit` exit 0.
- ✅ Type-check complet (forcé non-incrémental) : 0 erreur dans les fichiers de cette PR (les 31 erreurs restantes sont pré-existantes : `outline-solid`, `AiToolBridge`, `LLMProviderFactory`, `studio-return/debug`).
- ✅ Logique de parsing validée sur un exemple réel (8 catégories / 10 sous-items).
- ⚠️ `pnpm test:mcp` ne tourne pas dans l'environnement de dev utilisé (crash `jest-validate` / mauvaise version de `camelcase` résolue par pnpm, **avant** la découverte des tests — sans rapport avec ce code). À relancer en local : `pnpm test:mcp`.

## Caveat assumé (YAGNI)

Un sommaire plus haut que l'écran entier débordera encore par le **haut** ; un scale-down auto pourra être ajouté plus tard si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
