### PR TITLE
docs: guide dev live-assist + premières skills Claude Code

### DIFF
--- a/.claude/skills/dry-guardrails/SKILL.md
+++ b/.claude/skills/dry-guardrails/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: dry-guardrails
+description: >-
+  Before writing boilerplate in this repo, reuse the project's shared abstraction instead. Use this
+  WHENEVER you are about to add or edit a Next.js API route (try/catch, error responses), a settings
+  component (load/edit/save with useState+useEffect), a client-side fetch, a file upload handler, a
+  WebSocket subscription, or any hardcoded number / timing / limit. It maps "what you're about to
+  hand-roll" to "the existing utility you must call instead" with exact paths. This repo treats DRY
+  as a hard rule (see CLAUDE.md Development Rules), and these utilities encode subtle correctness
+  (ref-based effects, 400-vs-500 mapping) that re-implementations get wrong. Consult it even when
+  the user only says "add an endpoint" or "add a settings toggle" — the reuse rule still applies.
+---
+
+# Reuse the abstraction — don't reinvent it
+
+This repo has shared utilities for every common pattern. Re-implementing them by hand is the most
+common quality regression here: it duplicates code AND drops the correctness the utility bakes in.
+Before writing one of the patterns below, **read the named file and use it.** If the abstraction is
+genuinely insufficient, extend it in place rather than forking a parallel version.
+
+| About to write… | Use instead | Path |
+|---|---|---|
+| A settings form: `useState` + `useEffect` load + `handleSave` | `useSettings<TGet, TState>({ endpoint, initialState, fromResponse, toPayload? })` → `{ data, setData, loading, saving, saveResult, save }` | `lib/hooks/useSettings.ts` |
+| A Next.js API route with `try/catch` returning JSON errors | `withErrorHandler(handler, "[Ctx]")` (with route params) or `withSimpleErrorHandler` (without), plus `ApiResponses.ok/created/badRequest/notFound/conflict/…` | `lib/utils/ApiResponses.ts` |
+| A Next.js route that forwards to the Express backend | `proxyToBackend("/api/…", { method, body, errorMessage, logPrefix })` | `lib/utils/ProxyHelper.ts` |
+| A client-side `fetch(...)` + `res.json()` + error handling | `apiGet` / `apiPost` / `apiPut` (throw `ClientFetchError`) | `lib/utils/ClientFetch.ts` |
+| Saving an uploaded file (validate, unique name, mkdir) | `uploadFile(file, options)` and helpers | `lib/utils/fileUpload.ts` |
+| Subscribing a component to real-time events | `useWebSocketChannel<T>(channel, onMessage, options)` → `{ isConnected, send, sendAck }` | `hooks/useWebSocketChannel.ts` |
+| Propagating a data change across dashboards | `useDataSync` / `broadcastDataChange` | `hooks/useDataSync.ts` |
+| A magic number, timeout, limit, or default | A named constant referenced from one place | `lib/config/Constants.ts`, `lib/config/AppConfig.ts` |
+
+## Why this matters (not just style)
+
+- `useSettings` stores its callbacks in **refs** to avoid the infinite re-render loop you get when
+  passing inline `fromResponse`/`toPayload` into a plain `useEffect`. Hand-rolled versions reliably
+  reintroduce that bug.
+- `withErrorHandler` maps known validation errors to **400** and everything else to **500**, with a
+  consistent log prefix. A bare `catch` that returns 500 for everything hides client errors.
+- Centralized constants are why a timing tweak is one edit, not a hunt across 3–5 copies.
+
+The known violation inventory (with file lists) lives at
+`docs/audit-reports/03-dry-violations-audit.md` — useful context when refactoring.
+
+## How to apply
+1. Recognize the pattern from the left column before writing it.
+2. Open the named file, read its signature/JSDoc (each has usage examples), and call it.
+3. Only if it truly can't express your case: extend the shared utility, and note why in the diff —
+   don't branch a one-off copy.

--- a/.claude/skills/live-assist/SKILL.md
+++ b/.claude/skills/live-assist/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: live-assist
+description: >-
+  Orient yourself before working on the live-assist feature — the real-time studio listening system
+  (mic → French faster-whisper STT → keyword detection → −15/+15s context window → LLM intent
+  extractor → action providers → validatable suggestion cards in a Dockview panel). Use this WHENEVER
+  the task touches live-assist, the STT pipeline (`realtime-stt/`, `lib/services/liveassist/`), a
+  keyword detector / window scheduler / intent extractor, an ActionProvider, suggestion cards, the
+  `live-assist` WebSocket channel, or the `/settings/live-assist` page — even on terse asks like
+  "add a new live-assist suggestion type" or "why isn't STT producing suggestions". The feature is
+  WIP / not production-ready, so this skill points you at the current state and the known gaps before
+  you change anything.
+---
+
+# Working on live-assist
+
+**Read `docs/LIVE-ASSIST.md` first.** It is the up-to-date developer guide grounded in the shipped
+code: the end-to-end data flow, the full HTTP contract, the `live-assist` WebSocket events, the
+pipeline stage-by-stage, configuration/run, and — importantly — the **known gaps** (VAD placeholder
+in `realtime-stt/main.py`, Wikipedia-as-poster-source quality → issue #116, the OpenAI-strict
+extractor schema). Don't rediscover those; build on them. Deeper design rationale lives in
+`docs/superpowers/specs/2026-06-24-assistant-live-design.md` (+ the plan alongside it).
+
+## Most common task: add an ActionProvider
+
+A provider turns an extracted entity into a suggestion card + an apply side-effect. Adding one is
+~1 file plus a registration. Interface (`lib/services/liveassist/providers/ActionProvider.ts`):
+
+```ts
+interface ActionProvider {
+  id: string;                 // also the LLM intent id and the keyword bucket key
+  description: string;        // injected into the extractor's prompt + schema enum
+  defaultKeywords: string[];  // fallback when the Settings keyword list is empty
+  build(entity: string, window: TranscriptWindow): Promise<BuiltSuggestion | null>;
+  apply(payload: Record<string, unknown>): Promise<ApplyResult>;
+}
+```
+
+1. Implement it — model it on `PosterActionProvider` (`build` → preview + `applyPayload`) and
+   `DefinitionActionProvider` (`apply` → side-effect via an existing endpoint). **Reuse** the
+   existing services rather than new code: `WikipediaResolverService`, the poster endpoint
+   (`/api/assets/posters`), the lower-third endpoint (`/api/overlays/lower`).
+2. Register it with `registry.register(new YourProvider(...))` inside `buildOrchestrator()`
+   (`server/api/liveAssistBoot.ts`). The registry auto-feeds the extractor's intent enum + prompt
+   (`registry.ids()` / `registry.descriptions()`) — no extractor edits needed.
+3. Add default keywords under `LIVE_ASSIST.DEFAULT_KEYWORDS[<id>]` in `lib/config/Constants.ts`.
+4. Add i18n keys (`messages/fr.json`, `messages/en.json`) for any new UI label.
+
+## Map of the pieces
+- **Pipeline** (`lib/services/liveassist/`): `TranscriptBuffer` → `KeywordDetector` →
+  `WindowScheduler` → `IntentExtractor` (LLM via `createAiModel()`) → providers → `SuggestionStore`,
+  orchestrated by `LiveAssistOrchestrator`, assembled in `server/api/liveAssistBoot.ts`.
+- **Contract**: backend router `server/api/live-assist.ts` (`POST /api/stt/segment`, the
+  `/api/live-assist/suggestions*` routes); Next proxies under `app/api/live-assist/**`.
+- **UI**: `components/dashboard/panels/LiveAssistPanel.tsx`, `components/live-assist/`,
+  `lib/stores/liveAssistStore.ts`. **Models**: `lib/models/LiveAssist.ts`.
+- **STT service**: `realtime-stt/` (Python, `pnpm dev:stt`, requires CUDA).
+
+## Debugging "no suggestions appear"
+Walk the pipeline in order (the orchestrator logs each stage): is STT posting segments
+(`POST /api/stt/segment`)? did a keyword fire? did the window flush (timestamp or
+`WINDOW_MAX_WAIT_MS`)? did the extractor return `actionnable` above the confidence threshold (is an
+AI provider configured in Settings > AI)? did the provider's `build()` find anything? `docs/LIVE-ASSIST.md`
+has the full flow and the exact failure points.
+
+## Reuse / related skills
+Live-assist is wired from existing pieces — extend those, don't parallel them (`dry-guardrails`).
+Adding a dashboard panel for it? See `new-panel`. New overlay output? See `new-overlay`.

--- a/.claude/skills/new-overlay/SKILL.md
+++ b/.claude/skills/new-overlay/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: new-overlay
+description: >-
+  Scaffold a new broadcast overlay (an OBS browser source like lower-third, poster, countdown,
+  chat-highlight) end-to-end in this repo: the OverlayChannel + event schema, the backend publish
+  route, the Next.js proxy, the overlay page, and the Renderer/Display component pair wired to the
+  WebSocket hub. Use this WHENEVER the task is to add, create, or build a new overlay / browser
+  source / on-air graphic that the dashboard pushes live to OBS — even if the user just says
+  "add an X overlay" or "make a new on-screen graphic" without naming the file pattern. Not for
+  editing an existing overlay's visuals (use the overlay-animation agent) or for a dashboard panel
+  (use new-panel).
+---
+
+# Add a new overlay
+
+Overlays follow one consistent 7-file pattern across the repo. The fastest correct path is to
+**copy the smallest existing overlay (`chat-highlight`) and rename**, because it has the least
+incidental complexity (just show/hide). Read these reference files first, then mirror them:
+
+- `lib/models/OverlayEvents.ts` — channel enum, event schemas, type guards
+- `components/overlays/ChatHighlightRenderer.tsx` — the Renderer pattern
+- `app/api/overlays/chat-highlight/route.ts` — the Next.js proxy
+- `server/api/overlays.ts` — the backend publish handler
+
+## The one thing that breaks every time: the channel string
+
+Pick a kebab-case channel name (e.g. `now-playing`) and use **the exact same string** in all of:
+the `OverlayChannel` enum value, the `app/overlays/<channel>/` dir, the `app/api/overlays/<channel>/`
+dir, the `proxyToBackend("/api/overlays/<channel>")` path, and the `useWebSocketChannel("<channel>")`
+call. A mismatch fails silently — the overlay connects but never receives events. Grep the channel
+string at the end to confirm it appears in exactly those places.
+
+## File-touch checklist
+
+1. **`lib/models/OverlayEvents.ts`** — the single source of truth for the contract:
+   - Add the channel to the `OverlayChannel` enum.
+   - Add a `<Name>EventType` enum (e.g. `SHOW`, `HIDE`).
+   - Add a Zod payload schema (`<name>ShowPayloadSchema`) + inferred type.
+   - Add the event interfaces + a discriminated union (`<Name>Event`), and add it to `TypedOverlayEvent`.
+   - Add a type guard `is<Name>Event` using a `Set` of its type strings (follow `isChatHighlightEvent`).
+2. **`server/api/overlays.ts`** — add a `POST /api/overlays/<channel>` handler that validates the
+   payload with the Zod schema and calls `ChannelManager.publish(OverlayChannel.X, type, payload)`.
+3. **`app/api/overlays/<channel>/route.ts`** — thin proxy: `withSimpleErrorHandler` wrapping
+   `proxyToBackend("/api/overlays/<channel>", { method: "POST", body, ... })`. Do NOT hand-roll
+   try/catch or fetch here (see the `dry-guardrails` skill).
+4. **`app/overlays/<channel>/page.tsx`** — a transparent full-screen wrapper that renders `<XRenderer />`.
+5. **`components/overlays/<Name>Renderer.tsx`** — owns the WebSocket + state:
+   ```tsx
+   const { sendAck } = useWebSocketChannel<XEvent>("<channel>", handleEvent, { logPrefix: "X" });
+   ```
+   In `handleEvent`, switch on `data.type` (`show`/`hide`/…), update state, then **always call
+   `sendAck(data.id)`** so the dashboard knows the overlay received it (forgetting this breaks
+   acknowledgment tracking). Wrap the Display in `<OverlayMotionProvider><AnimatePresence>` for
+   enter/exit animation, keyed by a stable id.
+6. **`components/overlays/<Name>Display.tsx`** — pure presentational component (props in, Framer
+   Motion animations). No WebSocket logic here.
+7. **`components/overlays/<name>.css`** — optional styles for the Display.
+
+## Then
+- Add the browser-source URL to the **Overlays** list in `CLAUDE.md` (size 1920×1080).
+- If the overlay needs dashboard controls, add a panel — see the `new-panel` skill (separate concern).
+- For animation polish (timing, GPU-friendly transforms), hand off to the `overlay-animation` agent.
+
+## Verify
+1. `pnpm type-check` is clean for your touched files (the discriminated union + type guard catch most mistakes).
+2. Open `http://localhost:3000/overlays/<channel>` and POST to `/api/overlays/<channel>` from the
+   dashboard — confirm the event renders and that the dashboard receives the ack.
+3. Grep the channel string: it must appear in OverlayEvents enum, both route dirs, the proxy path,
+   and the `useWebSocketChannel` call — nowhere misspelled.

--- a/.claude/skills/new-overlay/SKILL.md
+++ b/.claude/skills/new-overlay/SKILL.md
@@ -40,6 +40,9 @@ string at the end to confirm it appears in exactly those places.
    - Add a type guard `is<Name>Event` using a `Set` of its type strings (follow `isChatHighlightEvent`).
 2. **`server/api/overlays.ts`** — add a `POST /api/overlays/<channel>` handler that validates the
    payload with the Zod schema and calls `ChannelManager.publish(OverlayChannel.X, type, payload)`.
+   Also add your overlay's hide/reset to the **`POST /clear-all`** panic handler in the same file — it
+   lists every overlay explicitly (it is not derived from `OverlayChannel`), so a new source stays
+   on-air when the operator hits clear-all unless you add it.
 3. **`app/api/overlays/<channel>/route.ts`** — thin proxy: `withSimpleErrorHandler` wrapping
    `proxyToBackend("/api/overlays/<channel>", { method: "POST", body, ... })`. Do NOT hand-roll
    try/catch or fetch here (see the `dry-guardrails` skill).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,9 +328,9 @@ Real-time listening assistant (PR #117, branch `feat/assistant-live` — **WIP, 
 
 - **Pipeline**: Python STT (`realtime-stt/`, faster-whisper) → `POST /api/stt/segment` → `TranscriptBuffer` → `KeywordDetector` → `WindowScheduler` → `IntentExtractor` (LLM via `createAiModel()`) → `ActionProvider[]` → `SuggestionStore` → `ChannelManager.publishLiveAssist()` → `live-assist` WS channel → `LiveAssistPanel`.
 - **Backend**: `lib/services/liveassist/` (pipeline + `providers/`); router `server/api/live-assist.ts`, assembly `server/api/liveAssistBoot.ts` (`buildOrchestrator()`).
-- **Providers (v1)**: `poster` (Wikipedia thumbnail → `create-poster`), `definition` (Wikipedia extract → lower-third / pin). Add one ≈ 1 file implementing `ActionProvider`, registered in `liveAssistBoot.ts`.
+- **Providers (v1)**: `poster` (Wikipedia thumbnail → `POST /api/assets/posters`), `definition` (Wikipedia extract → `POST /api/overlays/lower` / pin). Add one ≈ 1 file implementing `ActionProvider`, registered in `liveAssistBoot.ts`.
 - **UI / store**: `components/dashboard/panels/LiveAssistPanel.tsx`, `components/live-assist/`, `lib/stores/liveAssistStore.ts`.
-- **Settings**: `/settings/live-assist` (device, whisper model, keywords, windows, threshold); LLM from Settings > AI. Saves apply live (no backend restart).
+- **Settings**: `/settings/live-assist` (device, whisper model, keywords, windows, threshold); LLM from Settings > AI. Backend re-reads saves live (keywords/windows/threshold/enabled); changing device or whisper model needs an STT restart.
 - **Run**: `pnpm dev:stt` (bootstraps venv); PM2 app `obs-stt`. **STT requires CUDA** (`device="cuda"` in `realtime-stt/main.py`).
 - **Constants**: `LIVE_ASSIST` in `lib/config/Constants.ts` · **Models**: `lib/models/LiveAssist.ts`.
 - **Status, HTTP contract, how to extend, known gaps → `docs/LIVE-ASSIST.md`**. Deep reference: `docs/superpowers/specs/2026-06-24-assistant-live-design.md` (+ plan).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,18 @@ Each overlay connects to WebSocket hub and subscribes to its channel.
 - **MCP stateless mode**: Each tool call creates a new MCP Client + Transport (server has no session persistence between requests).
 - **TLS with mkcert**: `NODE_TLS_REJECT_UNAUTHORIZED=0` is set in `mcp-server/src/index.ts` for dev. Required when HTTPS certificates are detected.
 
+## Live Assist (Real-time Studio Listening)
+Real-time listening assistant (PR #117, branch `feat/assistant-live` — **WIP, not production-ready**). A dedicated mic is transcribed in French; keyword hits open a −15/+15s context window; an LLM extracts the cited entity; **action providers** turn it into validatable suggestion cards (Valider / Éditer / Ignorer) in a Dockview panel. Always human-in-the-loop.
+
+- **Pipeline**: Python STT (`realtime-stt/`, faster-whisper) → `POST /api/stt/segment` → `TranscriptBuffer` → `KeywordDetector` → `WindowScheduler` → `IntentExtractor` (LLM via `createAiModel()`) → `ActionProvider[]` → `SuggestionStore` → `ChannelManager.publishLiveAssist()` → `live-assist` WS channel → `LiveAssistPanel`.
+- **Backend**: `lib/services/liveassist/` (pipeline + `providers/`); router `server/api/live-assist.ts`, assembly `server/api/liveAssistBoot.ts` (`buildOrchestrator()`).
+- **Providers (v1)**: `poster` (Wikipedia thumbnail → `create-poster`), `definition` (Wikipedia extract → lower-third / pin). Add one ≈ 1 file implementing `ActionProvider`, registered in `liveAssistBoot.ts`.
+- **UI / store**: `components/dashboard/panels/LiveAssistPanel.tsx`, `components/live-assist/`, `lib/stores/liveAssistStore.ts`.
+- **Settings**: `/settings/live-assist` (device, whisper model, keywords, windows, threshold); LLM from Settings > AI. Saves apply live (no backend restart).
+- **Run**: `pnpm dev:stt` (bootstraps venv); PM2 app `obs-stt`. **STT requires CUDA** (`device="cuda"` in `realtime-stt/main.py`).
+- **Constants**: `LIVE_ASSIST` in `lib/config/Constants.ts` · **Models**: `lib/models/LiveAssist.ts`.
+- **Status, HTTP contract, how to extend, known gaps → `docs/LIVE-ASSIST.md`**. Deep reference: `docs/superpowers/specs/2026-06-24-assistant-live-design.md` (+ plan).
+
 ## Stream Deck Plugin
 - Location: `streamdeck-plugin/obslive-suite/`
 - Source: `streamdeck-plugin/obslive-suite/src/`

--- a/docs/LIVE-ASSIST.md
+++ b/docs/LIVE-ASSIST.md
@@ -48,12 +48,14 @@ and `app/api/settings/live-assist/route.ts`.
 ## WebSocket channel
 
 Channel `live-assist` (`LIVE_ASSIST.CHANNEL`), published via `ChannelManager.publishLiveAssist()`
-(no-ack — overlays don't acknowledge). Event union (`lib/models/LiveAssist.ts`):
+(no-ack — overlays don't acknowledge). Each event is `{ type, payload }` (no `id`/`timestamp`
+envelope, unlike `OverlayEvent`); the shapes below are the `payload` per `type`
+(`lib/models/LiveAssist.ts`):
 
-- `suggestion:new` — `{ suggestion }`
-- `suggestion:update` — `{ id, status }`
-- `stt:status` — `{ connected, device }`
-- `transcript` — `{ text, t0, t1 }` (live debug view of what STT hears)
+- `suggestion:new` — payload `{ suggestion }`
+- `suggestion:update` — payload `{ id, status }`
+- `stt:status` — payload `{ connected, device }`
+- `transcript` — payload `{ text, t0, t1 }` (live debug view of what STT hears)
 
 The panel subscribes through `lib/stores/liveAssistStore.ts` (zustand).
 
@@ -116,7 +118,10 @@ Current providers:
 - **Settings page** `/settings/live-assist` (`components/settings/LiveAssistSettings.tsx`): enabled toggle,
   input device dropdown (populated from `POST /api/stt/devices`), whisper model, per-provider keyword editor,
   before/after window seconds, confidence threshold. Persisted via `SettingsService.getLiveAssistSettings()` /
-  `saveLiveAssistSettings()`. Settings are re-read live — saves take effect without a backend restart.
+  `saveLiveAssistSettings()`. The **backend** re-reads settings live — keyword lists, window size, confidence
+  threshold and the enabled gate apply without a restart. **Exception:** the Python STT reads `inputDevice` and
+  `whisperModel` only once at startup (`main.py`), so changing the mic or model requires restarting the STT
+  service (`pnpm dev:stt` / PM2 `obs-stt`).
 - **LLM**: cloud by default via `createAiModel()` (Settings > AI: Ollama / OpenAI / Anthropic). No hardcoded provider.
 - **STT service** (`realtime-stt/`): `pnpm dev:stt` bootstraps the venv + installs deps + runs (`run.mjs`);
   PM2 app `obs-stt`. **Requires an NVIDIA GPU** — `main.py` loads faster-whisper with `device="cuda"`.
@@ -124,8 +129,9 @@ Current providers:
 
 ## Known gaps / TODO before production
 
-- **VAD is a placeholder.** `realtime-stt/main.py` batches a fixed `time.sleep(2.0)  # … replace with VAD
-  silence detection` (comment: "Use silero-vad or webrtcvad here"). Replace with real silence-boundary VAD so
+- **VAD is a placeholder.** `realtime-stt/main.py` batches a fixed ~2 s window (`time.sleep(2.0)`) instead of
+  detecting silence boundaries (inline comment: "replace with VAD silence detection" / "Use silero-vad or
+  webrtcvad here"). Replace with real silence-boundary VAD so
   segment timestamps align with utterance ends. *Mitigated today* by the backend wall-clock `WINDOW_MAX_WAIT_MS`
   — no suggestion is lost, only latency varies.
 - **Poster source quality → issue #116.** Wikipedia (especially FR) is a poor poster source (copyright, ambiguity).

--- a/docs/LIVE-ASSIST.md
+++ b/docs/LIVE-ASSIST.md
@@ -1,0 +1,158 @@
+# Live Assist — Real-time Studio Listening
+
+> **Status: WIP — not production-ready.** Shipped by PR #117 (branch `feat/assistant-live`).
+> This doc is the developer entry point: how it works *as coded today*, the HTTP contract,
+> how to extend it, and the known gaps to close before production. For the original design
+> rationale see the deep references at the bottom.
+
+## What it is
+
+A dedicated studio mic is transcribed in French (faster-whisper). When a configured **keyword**
+is heard, a **−15/+15 s** context window around it is sent to an **LLM extractor**, which decides
+whether a known entity (a show/film title, a topic to define…) was cited. If so, an **action
+provider** builds a **suggestion card** (title + preview + apply payload) that the operator
+validates, edits, or ignores in a Dockview panel. **Always human-in-the-loop** — nothing goes
+on-air automatically.
+
+```
+Python realtime-stt (capture + VAD + faster-whisper)  ──POST /api/stt/segment──►  Backend Express
+  (isolated behind the HTTP contract)                                              TranscriptBuffer → KeywordDetector
+                                                                                   → WindowScheduler → IntentExtractor (LLM)
+                                                                                   → ActionProvider[] → SuggestionStore
+                                                                                   → ChannelManager (channel `live-assist`)
+                                                                                           │ WebSocket
+                                                                                   ┌───────▼────────┐
+                                                                                   │ LiveAssistPanel │  (cards + transcript debug)
+                                                                                   └────────────────┘
+```
+
+## HTTP contract (backend Express, port 3002)
+
+Defined in `server/api/live-assist.ts` (`createLiveAssistRouter`). The Python STT service and the
+Next.js proxies are the only callers — the STT service is fully replaceable behind this contract.
+
+| Endpoint | Caller | Role |
+|---|---|---|
+| `POST /api/stt/segment` | Python STT | Ingest one `TranscriptSegment` (`{text,t0,t1,final,confidence?}`). Non-final segments are ignored. |
+| `POST /api/stt/devices` | Python STT | Publish the available input devices (`{devices:[{id,label}]}` → `SettingsService.saveSttDevices`). |
+| `GET /api/stt/config` | Python STT (~2 s) | Returns `{enabled,inputDevice,whisperModel}` **and doubles as the liveness heartbeat** (`orchestrator.markSttAlive`). |
+| `GET /api/stt/status` | dashboard | Current `{connected, device}`. |
+| `GET /api/live-assist/suggestions` | Next proxy | `{suggestions, sttStatus}`. |
+| `POST /api/live-assist/suggestions/:id/apply` | Next proxy | Body `{intent, payload}` → `registry.get(intent).apply(payload)`; on success marks `applied`. |
+| `POST /api/live-assist/suggestions/:id/dismiss` | Next proxy | Marks `dismissed`. |
+
+Next.js proxies (so the browser talks to port 3000, not the backend directly):
+`app/api/live-assist/suggestions/route.ts`, `.../[id]/apply/route.ts`, `.../[id]/dismiss/route.ts`,
+and `app/api/settings/live-assist/route.ts`.
+
+## WebSocket channel
+
+Channel `live-assist` (`LIVE_ASSIST.CHANNEL`), published via `ChannelManager.publishLiveAssist()`
+(no-ack — overlays don't acknowledge). Event union (`lib/models/LiveAssist.ts`):
+
+- `suggestion:new` — `{ suggestion }`
+- `suggestion:update` — `{ id, status }`
+- `stt:status` — `{ connected, device }`
+- `transcript` — `{ text, t0, t1 }` (live debug view of what STT hears)
+
+The panel subscribes through `lib/stores/liveAssistStore.ts` (zustand).
+
+## Pipeline (stage by stage)
+
+All in `lib/services/liveassist/`. The orchestrator owns the flow; each stage is a small, injectable unit.
+
+1. **`TranscriptBuffer`** — rolling buffer (`BUFFER_RETENTION_MS` = 120 s). `append()`, `latestT1()`,
+   `windowAround(tCenter, beforeMs, afterMs)` → `{text,t0,t1}`.
+2. **`KeywordDetector`** — `scan(segment)` → `KeywordHit[]`, accent-insensitive whole-word match.
+   Keyword list is rebuilt live from settings (`setKeywords`).
+3. **`WindowScheduler`** — `register(hit, now)` coalesces nearby hits; `collectReady(latestT1, now)`
+   fires a window once the `+afterSec` audio arrived **or** the wall-clock `WINDOW_MAX_WAIT_MS` (20 s)
+   elapsed (so a keyword followed by silence still fires).
+4. **`IntentExtractor`** — `extract(windowText, candidateProviderIds)` → `{actionnable,intent,entite,confiance}`
+   via `generateObject` on `createAiModel()` (Settings > AI). Guards the result to a *candidate*
+   provider for that window; failures degrade to non-actionnable.
+5. **Provider** (`registry.get(intent)`) — `build(entity, window)` → `BuiltSuggestion | null`.
+6. **`SuggestionStore`** — `add(built)` (dedup same `(intent,entity)` within `DEDUP_WINDOW_MS` = 10 min),
+   `setStatus(id, status)`, `list()`; publishes `suggestion:new` / `suggestion:update`.
+7. **`LiveAssistOrchestrator`** — `ingestSegment()` (per segment), `tick(now)` (periodic: staleness +
+   drains pending windows), `markSttAlive()` / `checkStaleness()` (heartbeat → `stt:status`).
+
+Assembled at boot by `buildOrchestrator()` in `server/api/liveAssistBoot.ts` (kept in its own module so
+the router test doesn't pull in the WebSocketHub/TLS chain). A `setInterval(STT_STALE_MS/2)` ticker
+re-syncs keywords + window size from live settings and drains pending windows.
+
+## Extending — add an ActionProvider
+
+Interface (`lib/services/liveassist/providers/ActionProvider.ts`):
+
+```ts
+interface ActionProvider {
+  id: string;                 // also the LLM intent id and the keyword bucket key
+  description: string;        // injected into the extractor prompt + schema enum
+  defaultKeywords: string[];  // fallback when Settings keyword list is empty
+  build(entity: string, window: TranscriptWindow): Promise<BuiltSuggestion | null>;
+  apply(payload: Record<string, unknown>): Promise<ApplyResult>;
+}
+```
+
+To add one (≈ 1 file + 1 registration):
+
+1. Implement the interface (see `PosterActionProvider` / `DefinitionActionProvider` for `build` →
+   preview + `applyPayload`, and `apply` → side effect). Reuse `WikipediaResolverService` and the
+   existing overlay/asset endpoints rather than new code.
+2. `registry.register(new YourProvider(...))` in `buildOrchestrator()`. The registry auto-feeds the
+   extractor's intent enum + prompt catalogue (`registry.ids()` / `registry.descriptions()`).
+3. Add default keywords under `LIVE_ASSIST.DEFAULT_KEYWORDS[<id>]` in `lib/config/Constants.ts`.
+4. Add i18n keys (`messages/fr.json`, `messages/en.json`) for any new UI label.
+
+Current providers:
+- **`poster`** — Wikipedia thumbnail → `apply` POSTs `/api/assets/posters` `{title,fileUrl,type:'image',downloadToLocal:true}`.
+  Strips Wikipedia disambiguators (`Titanic (film, 1997)` → `Titanic`); falls back to a Google-images link if no thumbnail.
+- **`definition`** — first N sentences of the Wikipedia extract; `apply` target `pin` (no-op, just keep the card) or
+  `on-air` → POSTs `/api/overlays/lower` `{action:'show',payload:{contentType:'text',body}}`.
+
+## Configuration & run
+
+- **Settings page** `/settings/live-assist` (`components/settings/LiveAssistSettings.tsx`): enabled toggle,
+  input device dropdown (populated from `POST /api/stt/devices`), whisper model, per-provider keyword editor,
+  before/after window seconds, confidence threshold. Persisted via `SettingsService.getLiveAssistSettings()` /
+  `saveLiveAssistSettings()`. Settings are re-read live — saves take effect without a backend restart.
+- **LLM**: cloud by default via `createAiModel()` (Settings > AI: Ollama / OpenAI / Anthropic). No hardcoded provider.
+- **STT service** (`realtime-stt/`): `pnpm dev:stt` bootstraps the venv + installs deps + runs (`run.mjs`);
+  PM2 app `obs-stt`. **Requires an NVIDIA GPU** — `main.py` loads faster-whisper with `device="cuda"`.
+  It auto-detects http/https against the backend `/health`.
+
+## Known gaps / TODO before production
+
+- **VAD is a placeholder.** `realtime-stt/main.py` batches a fixed `time.sleep(2.0)  # … replace with VAD
+  silence detection` (comment: "Use silero-vad or webrtcvad here"). Replace with real silence-boundary VAD so
+  segment timestamps align with utterance ends. *Mitigated today* by the backend wall-clock `WINDOW_MAX_WAIT_MS`
+  — no suggestion is lost, only latency varies.
+- **Poster source quality → issue #116.** Wikipedia (especially FR) is a poor poster source (copyright, ambiguity).
+  Disambiguation + Google-images fallback are in place, but a real source (TMDB / EN-wiki / web search) is tracked
+  in #116. Related idea: per-keyword contextualization prompts.
+- **OpenAI strict-mode extraction schema.** `IntentExtractor`'s schema uses `confiance: z.number()` with **no
+  min/max** and the intent enum `["none", ...providerIds]`, because OpenAI structured-outputs (strict mode) rejects
+  optional fields and numeric bounds. The confidence range is enforced by the orchestrator's threshold check, not Zod.
+- **Only two providers.** `poster` + `definition`. An Instagram provider was scoped as "phase 2" in the spec.
+- **Branch stacking.** PR #117 was stacked on `fix/chat-overlay-sommaire-lowerthird` (chat-highlight / régie / cue /
+  lower-third polish); confirm that base is integrated before reading the PR diff in isolation.
+
+## Tests
+
+- **Jest** — `__tests__/services/liveassist/**` (buffer, detector, scheduler, extractor, store, orchestrator,
+  providers + registry), `__tests__/api/live-assist.backend.test.ts`, `__tests__/api/live-assist.proxy.test.ts`,
+  `__tests__/models/LiveAssist.test.ts`, `__tests__/components/LiveAssistSettings.test.tsx`. Run: `pnpm test`.
+- **pytest** — `realtime-stt/tests/test_segmenter.py` (segment payload builder). Run: `cd realtime-stt && pytest`.
+
+## Reuse (DRY)
+
+This feature is wired from existing pieces — extend those rather than adding parallel code:
+`WikipediaResolverService`, the poster (`/api/assets/posters`) and lower-third (`/api/overlays/lower`) endpoints,
+`ChannelManager` / `WebSocketHub`, `PANEL_REGISTRY` / Dockview, the `useSettings` hook, and `createAiModel()`.
+
+## Deep reference
+
+- Design spec: `docs/superpowers/specs/2026-06-24-assistant-live-design.md`
+- Implementation plan (TDD task breakdown): `docs/superpowers/plans/2026-06-24-assistant-live.md`
+- STT service: `realtime-stt/README.md`


### PR DESCRIPTION
## Résumé
Documentation pour aider les prochains agents à travailler sur ce repo. **Aucun code applicatif touché** — uniquement `CLAUDE.md`, `docs/`, et `.claude/skills/`.

Deux volets complémentaires :

### 1. Guide dev live-assist (feature PR #117, désormais dans `main`)
- **`CLAUDE.md`** : nouvelle section `## Live Assist` (pair de *AI Chat Assistant*) — pipeline en une ligne, fichiers clés, providers v1, settings/run, liens.
- **`docs/LIVE-ASSIST.md`** : point d'entrée dev *calé sur le code livré* — contrat HTTP (7 endpoints), events WS `live-assist`, pipeline étage par étage, **comment ajouter un `ActionProvider`**, config/run (CUDA, `pnpm dev:stt`), et la liste des **gaps « not production ready »** (VAD placeholder, qualité affiches → #116, schéma extracteur OpenAI-strict). Le spec/plan sous `docs/superpowers/` restent la référence profonde.

### 2. Premières skills Claude Code (`.claude/skills/`)
Le repo s'appuyait sur des **agents** + **commands** + mémoire, mais sans skills *auto-déclenchées et chargées à la demande*. Ces 3 skills comblent ce manque sans dupliquer l'existant :
- **`new-overlay`** — scaffolder le pattern 7 fichiers d'un overlay (OverlayEvents → route backend → proxy Next → page → Renderer/Display), avec le piège de la string de canal.
- **`dry-guardrails`** — avant de coder du boilerplate, réutiliser l'abstraction partagée (`useSettings`, `withErrorHandler`/`ApiResponses`, `proxyToBackend`, `uploadFile`, `useWebSocketChannel`, `useDataSync`, Constants) — avec le *pourquoi*.
- **`live-assist`** — orientation sur la feature WIP → pointe vers `docs/LIVE-ASSIST.md` + recette « ajouter un ActionProvider » + gaps connus.

## Contexte
Issu d'une session de doc : la feature live-assist était volumineuse et non documentée pour les agents ; en chemin, on a comblé l'absence de skills locales. Carto des candidats faite (panels/overlays/MCP/quiz/DRY) — ce lot est le T1 (meilleur ratio valeur/risque). `new-panel` reste un command (déjà excellent) ; sa conversion en skill + `new-mcp-tool` sont des candidats T2 pour plus tard.

## Sûreté
Additif uniquement : 5 fichiers, +355 lignes, zéro fichier de code applicatif. Les skills se déclenchent côté agent (descriptions volontairement « pushy » car Claude a tendance à sous-déclencher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)