### PR TITLE
feat(live-assist): TMDB posters + LocalPosters + apply/data-sync fixes

### DIFF
--- a/__tests__/api/live-assist.apply-integration.test.ts
+++ b/__tests__/api/live-assist.apply-integration.test.ts
@@ -1,0 +1,55 @@
+import express from "express";
+import request from "supertest";
+import { createLiveAssistRouter } from "@/server/api/live-assist";
+import { SuggestionStore } from "@/lib/services/liveassist/SuggestionStore";
+import { ProviderRegistry } from "@/lib/services/liveassist/providers/ActionProvider";
+import { PosterActionProvider } from "@/lib/services/liveassist/providers/PosterActionProvider";
+
+// Higher-fidelity than the unit test: wires the REAL router + REAL store + REAL
+// registry + REAL PosterActionProvider, exercising the full backend apply chain
+// minus the HTTP hop to the frontend (createPoster is spied). Proves whether a
+// "Valider" on a fresh, stored film suggestion reaches poster creation.
+describe("live-assist apply — backend integration", () => {
+  function setup() {
+    const events: any[] = [];
+    const store = new SuggestionStore((e) => events.push(e), { now: () => 0, makeId: () => "sug-1" });
+    const registry = new ProviderRegistry();
+    const createPoster = jest.fn(async () => ({ ok: true as const }));
+    const resolver = { resolveAndFetch: jest.fn() }; // not used by apply
+    registry.register(
+      new PosterActionProvider(resolver, createPoster, {
+        id: "poster-tmdb",
+        description: "TMDB",
+        defaultKeywords: ["film"],
+      }),
+    );
+    const orchestrator = { ingestSegment: jest.fn(), getStatus: () => ({}), markSttAlive: jest.fn() } as any;
+    const app = express().use(express.json()).use(createLiveAssistRouter({ orchestrator, store, registry }));
+    return { app, store, createPoster, events };
+  }
+
+  it("creates the poster when a stored poster-tmdb suggestion is validated", async () => {
+    const { app, store, createPoster } = setup();
+    const stored = store.add({
+      intent: "poster-tmdb",
+      entity: "Titanic",
+      title: "Titanic",
+      preview: { kind: "image", imageUrl: "https://image.tmdb.org/t/p/w780/x.jpg" },
+      triggerExcerpt: "on a vu Titanic",
+      applyPayload: { title: "Titanic", fileUrl: "https://image.tmdb.org/t/p/w780/x.jpg" },
+      confidence: 0.9,
+    })!;
+
+    const res = await request(app).post(`/api/live-assist/suggestions/${stored.id}/apply`).send({ target: "pin" });
+
+    expect(res.status).toBe(200);
+    expect(createPoster).toHaveBeenCalledWith({ title: "Titanic", fileUrl: "https://image.tmdb.org/t/p/w780/x.jpg" });
+  });
+
+  it("404s for a stale id whose suggestion no longer exists (e.g. after a backend restart)", async () => {
+    const { app, createPoster } = setup();
+    const res = await request(app).post(`/api/live-assist/suggestions/ghost-id/apply`).send({ target: "pin" });
+    expect(res.status).toBe(404);
+    expect(createPoster).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/live-assist.backend.test.ts
+++ b/__tests__/api/live-assist.backend.test.ts
@@ -26,4 +26,53 @@ describe("live-assist backend router", () => {
     const res = await request(app).post("/api/stt/segment").send({ text: "x", t0: 5000, t1: 1000, final: true });
     expect(res.status).toBe(400);
   });
+
+  describe("authoritative apply", () => {
+    const buildApp = (suggestion: any, apply: jest.Mock, registryGet = jest.fn()) => {
+      const setStatus = jest.fn();
+      registryGet.mockReturnValue(suggestion ? { apply } : undefined);
+      const store = { list: () => [], get: (id: string) => (suggestion?.id === id ? suggestion : undefined), setStatus } as any;
+      const app = express()
+        .use(express.json())
+        .use(createLiveAssistRouter({ orchestrator: {} as any, store, registry: { get: registryGet } as any }));
+      return { app, setStatus, registryGet };
+    };
+
+    it("uses the STORED intent + applyPayload and ignores forged client intent/payload", async () => {
+      const apply = jest.fn(async () => ({ ok: true }));
+      const suggestion = { id: "s1", intent: "definition", applyPayload: { target: "pin", text: "hello" } };
+      const { app, setStatus, registryGet } = buildApp(suggestion, apply);
+
+      const res = await request(app)
+        .post("/api/live-assist/suggestions/s1/apply")
+        .send({ target: "on-air", intent: "FORGED", payload: { evil: true } });
+
+      expect(res.status).toBe(200);
+      expect(registryGet).toHaveBeenCalledWith("definition"); // stored intent, not "FORGED"
+      expect(apply).toHaveBeenCalledWith({ target: "on-air", text: "hello" }); // merged stored payload, only target trusted (no "evil")
+      expect(setStatus).toHaveBeenCalledWith("s1", "applied");
+    });
+
+    it("ignores an out-of-range target", async () => {
+      const apply = jest.fn(async () => ({ ok: true }));
+      const suggestion = { id: "s2", intent: "poster", applyPayload: { title: "T", fileUrl: "u" } };
+      const { app } = buildApp(suggestion, apply);
+      await request(app).post("/api/live-assist/suggestions/s2/apply").send({ target: "garbage" });
+      expect(apply).toHaveBeenCalledWith({ title: "T", fileUrl: "u" }); // no bogus target merged
+    });
+
+    it("merges a local-poster 'left'/'right' side target into the stored payload", async () => {
+      const apply = jest.fn(async () => ({ ok: true }));
+      const suggestion = { id: "lp1", intent: "local-poster", applyPayload: { posterId: "p3", fileUrl: "u", type: "image" } };
+      const { app } = buildApp(suggestion, apply);
+      await request(app).post("/api/live-assist/suggestions/lp1/apply").send({ target: "right" });
+      expect(apply).toHaveBeenCalledWith({ posterId: "p3", fileUrl: "u", type: "image", target: "right" });
+    });
+
+    it("404s when the suggestion id is unknown", async () => {
+      const { app } = buildApp(null, jest.fn());
+      const res = await request(app).post("/api/live-assist/suggestions/nope/apply").send({ target: "pin" });
+      expect(res.status).toBe(404);
+    });
+  });
 });

--- a/__tests__/api/posters.test.ts
+++ b/__tests__/api/posters.test.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Capture poster creates without touching the database
+const mockCreate = jest.fn();
+jest.mock("@/lib/repositories/PosterRepository", () => ({
+  PosterRepository: {
+    getInstance: () => ({
+      create: mockCreate,
+      getAll: jest.fn(() => []),
+    }),
+  },
+}));
+
+// Avoid backend broadcast side effects
+jest.mock("@/lib/utils/broadcastDataChange", () => ({
+  broadcastDataChange: jest.fn(),
+}));
+
+// Avoid real disk writes when a download succeeds
+jest.mock("fs/promises", () => ({
+  writeFile: jest.fn(async () => undefined),
+}));
+jest.mock("@/lib/utils/fileUpload", () => ({
+  getUploadDir: jest.fn(async (subfolder: string) => `/mock/data/uploads/${subfolder}`),
+}));
+
+import { POST } from "@/app/api/assets/posters/route";
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/assets/posters", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function imageResponse(contentType = "image/jpeg"): Response {
+  return new Response("fake-bytes", { status: 200, headers: { "content-type": contentType } });
+}
+
+const REMOTE_URL = "https://example.com/poster.jpg";
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+});
+
+describe("POST /api/assets/posters — downloadToLocal", () => {
+  it("rewrites a remote fileUrl to a local /data/uploads path when downloadToLocal is true", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(imageResponse("image/jpeg"));
+
+    const res = await POST(
+      makeRequest({ title: "Remote", fileUrl: REMOTE_URL, type: "image", downloadToLocal: true })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.poster.fileUrl).toMatch(/^\/data\/uploads\/posters\/.+\.jpg$/);
+    // Persisted poster carries the local URL, not the remote one
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate.mock.calls[0][0].fileUrl).toMatch(/^\/data\/uploads\/posters\//);
+  });
+
+  it("leaves the fileUrl untouched when downloadToLocal is absent", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+
+    const res = await POST(makeRequest({ title: "Remote", fileUrl: REMOTE_URL, type: "image" }));
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.poster.fileUrl).toBe(REMOTE_URL);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not download for a YouTube poster even when downloadToLocal is true", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+
+    const res = await POST(
+      makeRequest({
+        title: "YT",
+        fileUrl: "https://youtube.com/watch?v=abc",
+        type: "youtube",
+        downloadToLocal: true,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.poster.fileUrl).toBe("https://youtube.com/watch?v=abc");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("still creates the poster with the remote URL when the download fails", async () => {
+    jest.spyOn(global, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+
+    const res = await POST(
+      makeRequest({ title: "Remote", fileUrl: REMOTE_URL, type: "image", downloadToLocal: true })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.poster.fileUrl).toBe(REMOTE_URL);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/api/settings-integrations.test.ts
+++ b/__tests__/api/settings-integrations.test.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// In-memory settings store backing the mocked SettingsRepository
+const store = new Map<string, string>();
+const getSetting = jest.fn((key: string) => store.get(key) ?? null);
+const setSetting = jest.fn((key: string, value: string) => {
+  store.set(key, value);
+});
+
+jest.mock("@/lib/repositories/SettingsRepository", () => ({
+  SettingsRepository: {
+    getInstance: jest.fn(() => ({ getSetting, setSetting })),
+  },
+}));
+
+jest.mock("@/lib/services/OllamaSummarizerService", () => ({
+  OllamaSummarizerService: {
+    getInstance: jest.fn(() => ({ reloadConfig: jest.fn() })),
+  },
+}));
+
+import { GET, POST } from "@/app/api/settings/integrations/route";
+
+function makePost(body: Record<string, unknown>): Request {
+  return new Request("http://localhost:3000/api/settings/integrations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  store.clear();
+  jest.clearAllMocks();
+});
+
+describe("GET /api/settings/integrations", () => {
+  it("includes tmdb_api_key in the returned settings", async () => {
+    store.set("tmdb_api_key", "tmdb-secret-123");
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.settings.tmdb_api_key).toBe("tmdb-secret-123");
+  });
+
+  it("defaults tmdb_api_key to an empty string when unset", async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body.settings.tmdb_api_key).toBe("");
+  });
+});
+
+describe("POST /api/settings/integrations", () => {
+  it("persists tmdb_api_key when provided", async () => {
+    const res = await POST(makePost({ tmdb_api_key: "new-tmdb-key" }));
+    expect(res.status).toBe(200);
+
+    expect(setSetting).toHaveBeenCalledWith("tmdb_api_key", "new-tmdb-key");
+    expect(store.get("tmdb_api_key")).toBe("new-tmdb-key");
+  });
+
+  it("does not touch tmdb_api_key when omitted", async () => {
+    const res = await POST(makePost({ openai_api_key: "sk-test" }));
+    expect(res.status).toBe(200);
+
+    expect(setSetting).not.toHaveBeenCalledWith("tmdb_api_key", expect.anything());
+  });
+});

--- a/__tests__/api/tmdb-test.route.test.ts
+++ b/__tests__/api/tmdb-test.route.test.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const testConnection = jest.fn();
+
+jest.mock("@/lib/services/TmdbResolverService", () => ({
+  TmdbResolverService: { getInstance: jest.fn(() => ({ testConnection })) },
+}));
+
+import { POST } from "@/app/api/settings/integrations/tmdb-test/route";
+
+const makePost = (body: unknown): Request =>
+  new Request("http://localhost:3000/api/settings/integrations/tmdb-test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/settings/integrations/tmdb-test", () => {
+  it("forwards the typed key and returns success on a valid key", async () => {
+    testConnection.mockResolvedValue({ ok: true, message: "Connexion TMDB OK." });
+    const res = await POST(makePost({ apiKey: "TYPED" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toMatch(/OK/);
+    expect(testConnection).toHaveBeenCalledWith("TYPED");
+  });
+
+  it("returns 200 with success:false for an invalid key (not a server error)", async () => {
+    testConnection.mockResolvedValue({ ok: false, message: "Clé TMDB invalide (401)." });
+    const res = await POST(makePost({ apiKey: "BAD" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.message).toMatch(/invalide/i);
+  });
+
+  it("passes undefined when no key is sent (resolver falls back to stored)", async () => {
+    testConnection.mockResolvedValue({ ok: true, message: "Connexion TMDB OK." });
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(200);
+    expect(testConnection).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/__tests__/components/LiveAssistControls.test.tsx
+++ b/__tests__/components/LiveAssistControls.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Repo convention: mock next-intl so t("key") returns the key.
+jest.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }));
+
+const apiGet = jest.fn();
+const apiPost = jest.fn();
+jest.mock("@/lib/utils/ClientFetch", () => ({
+  apiGet: (...a: unknown[]) => apiGet(...a),
+  apiPost: (...a: unknown[]) => apiPost(...a),
+  extractErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+jest.mock("sonner", () => ({ toast: { error: jest.fn() } }));
+
+import { LiveAssistControls } from "@/components/live-assist/LiveAssistControls";
+
+// A fully-populated settings object, incl. user customizations a partial save would wipe.
+const FULL = {
+  enabled: true,
+  transcriptDebug: true,
+  inputDevice: "1",
+  whisperModel: "large-v3",
+  keywordsByProvider: { poster: ["spectacle"] },
+  contextPromptsByProvider: { poster: "règle perso" },
+  localPostersEnabled: true,
+  localPosterMinSimilarity: 0.8,
+  windowBeforeSec: 8,
+  windowAfterSec: 15,
+  confidenceThreshold: 0.6,
+};
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPost.mockReset();
+  apiGet.mockResolvedValue({ settings: FULL });
+  apiPost.mockResolvedValue({ success: true });
+});
+
+describe("LiveAssistControls", () => {
+  it("toggles `enabled` off by re-sending the FULL settings (keeps keywords/prompts)", async () => {
+    render(<LiveAssistControls />);
+    fireEvent.click(await screen.findByLabelText("listening"));
+    await waitFor(() => expect(apiPost).toHaveBeenCalledTimes(1));
+    expect(apiPost).toHaveBeenCalledWith("/api/settings/live-assist", {
+      settings: { ...FULL, enabled: false },
+    });
+  });
+
+  it("toggles `transcriptDebug` independently of `enabled`", async () => {
+    render(<LiveAssistControls />);
+    fireEvent.click(await screen.findByLabelText("transcript"));
+    await waitFor(() => expect(apiPost).toHaveBeenCalledTimes(1));
+    expect(apiPost).toHaveBeenCalledWith("/api/settings/live-assist", {
+      settings: { ...FULL, transcriptDebug: false },
+    });
+  });
+
+  it("renders nothing until settings load", () => {
+    apiGet.mockReturnValue(new Promise(() => {})); // never resolves
+    const { container } = render(<LiveAssistControls />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/components/SuggestionCard.test.tsx
+++ b/__tests__/components/SuggestionCard.test.tsx
@@ -38,4 +38,33 @@ describe("SuggestionCard", () => {
     fireEvent.click(screen.getByText("onAir")); // mocked t("onAir")
     expect(onApply).toHaveBeenCalledWith(def, "on-air");
   });
+
+  it("collapses to title only once applied, revealing detail on expand", () => {
+    const applied = { ...base, status: "applied" as const };
+    render(<SuggestionCard suggestion={applied} onApply={() => {}} onDismiss={() => {}} />);
+    expect(screen.getByText("Le Cid")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull(); // detail collapsed
+    expect(screen.queryByText("validate")).toBeNull(); // no actions once applied
+    fireEvent.click(screen.getByRole("button")); // the expand toggle
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("renders Gauche/Droite for a local-poster and applies the chosen side", () => {
+    const lp = { ...base, intent: "local-poster", applyPayload: { posterId: "p3", fileUrl: "http://x/p.jpg", type: "image" } };
+    const onApply = jest.fn();
+    render(<SuggestionCard suggestion={lp} onApply={onApply} onDismiss={() => {}} />);
+    // mocked t() returns the key
+    fireEvent.click(screen.getByText("posterRight"));
+    expect(onApply).toHaveBeenCalledWith(lp, "right");
+    expect(screen.queryByText("validate")).toBeNull(); // no generic validate button for local posters
+  });
+
+  it("keeps a re-validate button on a dismissed suggestion, even collapsed", () => {
+    const dismissed = { ...base, status: "dismissed" as const };
+    const onApply = jest.fn();
+    render(<SuggestionCard suggestion={dismissed} onApply={onApply} onDismiss={() => {}} />);
+    expect(screen.queryByRole("img")).toBeNull(); // detail collapsed
+    fireEvent.click(screen.getByText("validate")); // change-your-mind button still present
+    expect(onApply).toHaveBeenCalledWith(dismissed, "pin");
+  });
 });

--- a/__tests__/config/internal-app-url.test.ts
+++ b/__tests__/config/internal-app-url.test.ts
@@ -1,0 +1,13 @@
+import { INTERNAL_APP_URL } from "@/lib/config/urls";
+
+// Regression guard for the "fetch failed" bug: the backend's Live Assist providers
+// POST to the Next.js app, and on Node 22 + Windows `localhost` resolves to ::1
+// (IPv6) while the dev server listens on IPv4 → ECONNREFUSED. The internal
+// server-to-server base MUST use the 127.0.0.1 loopback, never `localhost`.
+describe("INTERNAL_APP_URL", () => {
+  it("targets the 127.0.0.1 loopback on the app port, never localhost", () => {
+    expect(INTERNAL_APP_URL).toContain("127.0.0.1");
+    expect(INTERNAL_APP_URL).not.toContain("localhost");
+    expect(INTERNAL_APP_URL).toMatch(/:3000$/);
+  });
+});

--- a/__tests__/models/LiveAssist.test.ts
+++ b/__tests__/models/LiveAssist.test.ts
@@ -2,6 +2,7 @@ import {
   TranscriptSegmentSchema,
   SuggestionSchema,
   LiveAssistSettingsSchema,
+  migrateLiveAssistSettings,
 } from "@/lib/models/LiveAssist";
 
 describe("LiveAssist models", () => {
@@ -30,6 +31,42 @@ describe("LiveAssist models", () => {
     expect(cfg.windowAfterSec).toBe(15);
     expect(cfg.confidenceThreshold).toBeCloseTo(0.6);
     expect(cfg.enabled).toBe(false);
+    expect(cfg.transcriptDebug).toBe(false);
     expect(cfg.keywordsByProvider.poster).toContain("spectacle");
+  });
+
+  describe("migrateLiveAssistSettings", () => {
+    it("migrates the exact pre-split legacy poster default and adds poster-tmdb", () => {
+      const stored = LiveAssistSettingsSchema.parse({
+        keywordsByProvider: {
+          poster: ["spectacle", "affiche", "pièce", "film", "concert"], // legacy default
+          definition: ["définition"],
+        },
+      });
+      const out = migrateLiveAssistSettings(stored);
+      // film/série removed from Wikipedia poster…
+      expect(out.keywordsByProvider.poster).not.toContain("film");
+      expect(out.keywordsByProvider.poster).toContain("spectacle");
+      // …and a TMDB provider seeded with its defaults
+      expect(out.keywordsByProvider["poster-tmdb"]).toContain("film");
+      expect(out.keywordsByProvider["poster-tmdb"]).toContain("série");
+    });
+
+    it("leaves a customised poster list untouched but still adds the missing poster-tmdb", () => {
+      const stored = LiveAssistSettingsSchema.parse({
+        keywordsByProvider: { poster: ["mon", "custom", "film"], definition: ["définition"] },
+      });
+      const out = migrateLiveAssistSettings(stored);
+      expect(out.keywordsByProvider.poster).toEqual(["mon", "custom", "film"]); // untouched
+      expect(out.keywordsByProvider["poster-tmdb"]).toBeDefined(); // additively surfaced
+    });
+
+    it("is a no-op when poster-tmdb is already present", () => {
+      const stored = LiveAssistSettingsSchema.parse({
+        keywordsByProvider: { poster: ["spectacle"], "poster-tmdb": ["film"], definition: ["x"] },
+      });
+      const out = migrateLiveAssistSettings(stored);
+      expect(out.keywordsByProvider).toEqual(stored.keywordsByProvider);
+    });
   });
 });

--- a/__tests__/models/dataSyncEvents.test.ts
+++ b/__tests__/models/dataSyncEvents.test.ts
@@ -1,0 +1,25 @@
+import { parseDataChangedEvent } from "@/lib/models/DataSyncEvents";
+
+describe("parseDataChangedEvent", () => {
+  const inner = { type: "data-changed", entity: "posters", action: "created", clientId: "unknown", timestamp: 1 };
+
+  it("unwraps the OverlayEvent-wrapped form produced by ChannelManager.publish()", () => {
+    // This is the shape the dashboard actually receives — the regression that broke
+    // every cross-process refresh (Live Assist poster / text-preset).
+    const wrapped = { channel: "system", type: "data-changed", payload: inner, timestamp: 2, id: "x" };
+    const event = parseDataChangedEvent(wrapped);
+    expect(event?.entity).toBe("posters");
+    expect(event?.clientId).toBe("unknown");
+  });
+
+  it("accepts a flat data-changed event defensively", () => {
+    expect(parseDataChangedEvent(inner)?.entity).toBe("posters");
+  });
+
+  it("returns null for non-data-changed messages", () => {
+    expect(parseDataChangedEvent({ channel: "system", type: "something-else", payload: {} })).toBeNull();
+    expect(parseDataChangedEvent({ type: "data-changed", payload: { type: "data-changed" } })).toBeNull(); // missing entity/clientId
+    expect(parseDataChangedEvent(null)).toBeNull();
+    expect(parseDataChangedEvent("nope")).toBeNull();
+  });
+});

--- a/__tests__/services/TmdbResolverService.test.ts
+++ b/__tests__/services/TmdbResolverService.test.ts
@@ -1,0 +1,130 @@
+import { TmdbResolverService } from "@/lib/services/TmdbResolverService";
+import { SettingsRepository } from "@/lib/repositories/SettingsRepository";
+
+jest.mock("@/lib/repositories/SettingsRepository", () => ({
+  SettingsRepository: { getInstance: jest.fn() },
+}));
+
+const mockGetSetting = (value: string | null) => {
+  (SettingsRepository.getInstance as jest.Mock).mockReturnValue({ getSetting: () => value });
+};
+
+const okJson = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+describe("TmdbResolverService", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns the most popular movie/tv hit with a w780 poster URL", async () => {
+    mockGetSetting("KEY");
+    const fetchImpl = jest.fn(async () =>
+      okJson({
+        results: [
+          { media_type: "person", name: "James Cameron", popularity: 99 },
+          { media_type: "movie", title: "Titanic", overview: "Jack et Rose.", poster_path: "/abc.jpg", popularity: 80 },
+          { media_type: "movie", title: "Titanic II", overview: "", poster_path: "/z.jpg", popularity: 5 },
+        ],
+      }),
+    ) as unknown as typeof fetch;
+
+    const svc = TmdbResolverService.createForTest({ fetchImpl });
+    const r = await svc.resolveAndFetch("Titanic");
+
+    expect(r.title).toBe("Titanic");
+    expect(r.extract).toBe("Jack et Rose.");
+    expect(r.thumbnail).toBe("https://image.tmdb.org/t/p/w780/abc.jpg");
+    expect(r.source).toBe("tmdb");
+    // request carried the key + fr-FR
+    const calledUrl = (fetchImpl as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("api_key=KEY");
+    expect(calledUrl).toContain("language=fr-FR");
+  });
+
+  it("uses the tv `name` field and omits thumbnail when no poster_path", async () => {
+    mockGetSetting("KEY");
+    const fetchImpl = jest.fn(async () =>
+      okJson({ results: [{ media_type: "tv", name: "Le Bureau des légendes", overview: "Espions.", poster_path: null, popularity: 50 }] }),
+    ) as unknown as typeof fetch;
+
+    const svc = TmdbResolverService.createForTest({ fetchImpl });
+    const r = await svc.resolveAndFetch("le bureau des légendes");
+    expect(r.title).toBe("Le Bureau des légendes");
+    expect(r.thumbnail).toBeUndefined();
+  });
+
+  it("throws when no API key is configured", async () => {
+    mockGetSetting(null);
+    const svc = TmdbResolverService.createForTest({ fetchImpl: jest.fn() as unknown as typeof fetch });
+    await expect(svc.resolveAndFetch("Titanic")).rejects.toThrow(/api key/i);
+  });
+
+  it("throws when there is no movie/tv match (person-only results)", async () => {
+    mockGetSetting("KEY");
+    const fetchImpl = jest.fn(async () => okJson({ results: [{ media_type: "person", name: "X", popularity: 9 }] })) as unknown as typeof fetch;
+    const svc = TmdbResolverService.createForTest({ fetchImpl });
+    await expect(svc.resolveAndFetch("X")).rejects.toThrow(/no TMDB/i);
+  });
+
+  describe("testConnection", () => {
+    it("returns ok when /configuration responds 200, using the passed-in (unsaved) key", async () => {
+      mockGetSetting(null); // nothing stored — proves the override key is used
+      const fetchImpl = jest.fn(async () => ({ ok: true, status: 200 }) as unknown as Response) as unknown as typeof fetch;
+      const svc = TmdbResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection("TYPED_KEY");
+      expect(r.ok).toBe(true);
+      expect((fetchImpl as jest.Mock).mock.calls[0][0]).toContain("api_key=TYPED_KEY");
+      expect((fetchImpl as jest.Mock).mock.calls[0][0]).toContain("/configuration");
+    });
+
+    it("reports an invalid key on 401", async () => {
+      mockGetSetting("STORED");
+      const fetchImpl = jest.fn(async () => ({ ok: false, status: 401 }) as unknown as Response) as unknown as typeof fetch;
+      const svc = TmdbResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection("BAD");
+      expect(r.ok).toBe(false);
+      expect(r.message).toMatch(/invalide|401/i);
+    });
+
+    it("falls back to the stored key when no override is given", async () => {
+      mockGetSetting("STORED_KEY");
+      const fetchImpl = jest.fn(async () => ({ ok: true, status: 200 }) as unknown as Response) as unknown as typeof fetch;
+      const svc = TmdbResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection();
+      expect(r.ok).toBe(true);
+      expect((fetchImpl as jest.Mock).mock.calls[0][0]).toContain("api_key=STORED_KEY");
+    });
+
+    it("returns a friendly failure (no throw) when no key is available", async () => {
+      mockGetSetting(null);
+      const fetchImpl = jest.fn() as unknown as typeof fetch;
+      const svc = TmdbResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection("");
+      expect(r.ok).toBe(false);
+      expect(fetchImpl as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it("returns a friendly failure (no throw) on a network error", async () => {
+      mockGetSetting("STORED");
+      const fetchImpl = jest.fn(async () => {
+        throw new Error("boom");
+      }) as unknown as typeof fetch;
+      const svc = TmdbResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection("K");
+      expect(r).toEqual({ ok: false, message: "boom" });
+    });
+  });
+
+  it("serves a cached result within TTL without re-fetching", async () => {
+    mockGetSetting("KEY");
+    const fetchImpl = jest.fn(async () =>
+      okJson({ results: [{ media_type: "movie", title: "Dune", overview: "Sable.", poster_path: "/d.jpg", popularity: 70 }] }),
+    ) as unknown as typeof fetch;
+    let t = 1000;
+    const svc = TmdbResolverService.createForTest({ fetchImpl, now: () => t });
+
+    await svc.resolveAndFetch("Dune");
+    t += 1000; // still within TTL
+    await svc.resolveAndFetch("DUNE"); // case-insensitive cache key
+    expect((fetchImpl as jest.Mock).mock.calls).toHaveLength(1);
+  });
+});

--- a/__tests__/services/liveassist/IntentExtractor.test.ts
+++ b/__tests__/services/liveassist/IntentExtractor.test.ts
@@ -4,10 +4,18 @@ describe("IntentExtractor", () => {
   const descriptions = { poster: "Trouver l'affiche d'un spectacle/film", definition: "Définir un sujet" };
 
   it("returns the model's structured object", async () => {
-    const fake = async () => ({ object: { actionnable: true, intent: "poster", entite: "Le Cid", confiance: 0.9 } });
+    const fake = async () => ({ object: { actionnable: true, intent: "poster", entite: "Le Cid", confiance: 0.9, infere: false } });
     const x = new IntentExtractor(["poster", "definition"], descriptions, fake);
     const out = await x.extract("…le spectacle Le Cid…", ["poster"]);
-    expect(out).toEqual({ actionnable: true, intent: "poster", entite: "Le Cid", confiance: 0.9 });
+    expect(out).toEqual({ actionnable: true, intent: "poster", entite: "Le Cid", confiance: 0.9, infere: false });
+  });
+
+  it("passes through infere=true when the model deduced the entity", async () => {
+    const fake = async () => ({ object: { actionnable: true, intent: "poster-tmdb", entite: "Basic Instinct", confiance: 0.85, infere: true } });
+    const x = new IntentExtractor(["poster-tmdb"], { "poster-tmdb": "TMDB" }, fake);
+    const out = await x.extract("…ce film avec Sharon Stone…", ["poster-tmdb"]);
+    expect(out.infere).toBe(true);
+    expect(out.entite).toBe("Basic Instinct");
   });
 
   it("includes candidate providers and window text in the prompt", async () => {
@@ -22,6 +30,32 @@ describe("IntentExtractor", () => {
     expect(seenPrompt).toContain("definition");
   });
 
+  it("injects each candidate's context prompt as its Règle", async () => {
+    let seenPrompt = "";
+    const fake = async ({ prompt }: { prompt: string }) => {
+      seenPrompt = prompt;
+      return { object: { actionnable: false, intent: "none", entite: "", confiance: 0 } };
+    };
+    const x = new IntentExtractor(["poster", "poster-tmdb"], { ...descriptions, "poster-tmdb": "Affiche TMDB" }, fake, {
+      "poster-tmdb": "entité = titre exact du film",
+    });
+    await x.extract("…Titanic…", ["poster-tmdb"]);
+    expect(seenPrompt).toContain("Règle : entité = titre exact du film");
+  });
+
+  it("setContextPrompts swaps the injected rules live", async () => {
+    let seenPrompt = "";
+    const fake = async ({ prompt }: { prompt: string }) => {
+      seenPrompt = prompt;
+      return { object: { actionnable: false, intent: "none", entite: "", confiance: 0 } };
+    };
+    const x = new IntentExtractor(["definition"], descriptions, fake, { definition: "ANCIEN" });
+    x.setContextPrompts({ definition: "NOUVEAU contexte" });
+    await x.extract("…", ["definition"]);
+    expect(seenPrompt).toContain("Règle : NOUVEAU contexte");
+    expect(seenPrompt).not.toContain("ANCIEN");
+  });
+
   it("coerces an invalid model object to non-actionnable", async () => {
     const fake = async () => ({ object: { garbage: true } });
     const x = new IntentExtractor(["poster"], descriptions, fake);
@@ -31,7 +65,7 @@ describe("IntentExtractor", () => {
   });
 
   it("falls back when the model picks an intent outside the candidates", async () => {
-    const fake = async () => ({ object: { actionnable: true, intent: "definition", entite: "X", confiance: 0.9 } });
+    const fake = async () => ({ object: { actionnable: true, intent: "definition", entite: "X", confiance: 0.9, infere: false } });
     const x = new IntentExtractor(["poster", "definition"], descriptions, fake);
     const out = await x.extract("…", ["poster"]); // definition not a candidate this call
     expect(out.actionnable).toBe(false);
@@ -42,12 +76,12 @@ describe("IntentExtractor", () => {
     const fake = async () => { throw new Error("network"); };
     const x = new IntentExtractor(["poster"], descriptions, fake);
     const out = await x.extract("…", ["poster"]);
-    expect(out).toEqual({ actionnable: false, intent: "none", entite: "", confiance: 0 });
+    expect(out).toEqual({ actionnable: false, intent: "none", entite: "", confiance: 0, infere: false });
   });
 
   it("clamps an out-of-range confiance into [0,1]", async () => {
     // A model that ignores the [0,1] instruction and answers on a 0–100 scale.
-    const fake = async () => ({ object: { actionnable: true, intent: "poster", entite: "Le Cid", confiance: 85 } });
+    const fake = async () => ({ object: { actionnable: true, intent: "poster", entite: "Le Cid", confiance: 85, infere: false } });
     const x = new IntentExtractor(["poster"], descriptions, fake);
     const out = await x.extract("…", ["poster"]);
     expect(out.confiance).toBe(1);

--- a/__tests__/services/liveassist/LiveAssistOrchestrator.test.ts
+++ b/__tests__/services/liveassist/LiveAssistOrchestrator.test.ts
@@ -41,6 +41,21 @@ describe("LiveAssistOrchestrator", () => {
     expect(events.some((e) => e.type === "suggestion:new")).toBe(true);
   });
 
+  it("fires a local-poster suggestion via the fast-path on ingest (no window/LLM)", async () => {
+    const built = {
+      intent: "local-poster", entity: "p3", title: "Eclypsia",
+      preview: { kind: "image", imageUrl: "u" }, triggerExcerpt: "x",
+      applyPayload: { posterId: "p3" }, confidence: 0.9,
+    };
+    const { orch, events } = makeOrchestrator(
+      { actionnable: false, intent: "none", entite: "", confiance: 0 }, // extractor would say no
+      { matchLocalPosters: (text: string) => (text.includes("eclypsia") ? [built] : []) },
+    );
+    // No registered keyword in this text → only the fast-path can produce a suggestion.
+    await orch.ingestSegment(seg("on recoit eclypsia", 0, 1000));
+    expect(events.some((e) => e.type === "suggestion:new")).toBe(true);
+  });
+
   it("drains a pending window on tick when no further segment arrives (silence)", async () => {
     let fakeNow = 0;
     const { orch, events } = makeOrchestrator(
@@ -75,6 +90,21 @@ describe("LiveAssistOrchestrator", () => {
     expect(events.some((e) => e.type === "suggestion:new")).toBe(false);
   });
 
+  it("gates a DEDUCED (infere) suggestion behind the stricter inferred bar (0.7)", async () => {
+    // 0.65 clears the normal 0.6 seuil but not the inferred 0.7 bar → dropped.
+    // ("spectacle" is the fixture's registered keyword that fires the window.)
+    const dropped = makeOrchestrator({ actionnable: true, intent: "poster", entite: "Basic Instinct", confiance: 0.65, infere: true });
+    await dropped.orch.ingestSegment(seg("le spectacle avec Sharon Stone", 10000, 11000));
+    await dropped.orch.ingestSegment(seg("contexte", 26000, 27000));
+    expect(dropped.events.some((e) => e.type === "suggestion:new")).toBe(false);
+
+    // 0.75 clears the inferred bar → created.
+    const kept = makeOrchestrator({ actionnable: true, intent: "poster", entite: "Basic Instinct", confiance: 0.75, infere: true });
+    await kept.orch.ingestSegment(seg("le spectacle avec Sharon Stone", 10000, 11000));
+    await kept.orch.ingestSegment(seg("contexte", 26000, 27000));
+    expect(kept.events.some((e) => e.type === "suggestion:new")).toBe(true);
+  });
+
   it("creates nothing when confidence is below threshold", async () => {
     const { orch, events } = makeOrchestrator({ actionnable: true, intent: "poster", entite: "Le Cid", confiance: 0.3 });
     await orch.ingestSegment(seg("le spectacle Le Cid", 10000, 11000));
@@ -99,6 +129,29 @@ describe("LiveAssistOrchestrator", () => {
     expect(events.some((e) => e.type === "suggestion:new")).toBe(false);
   });
 
+  it("publishes the live transcript for the debug view by default", async () => {
+    const transcripts: string[] = [];
+    const { orch } = makeOrchestrator(
+      { actionnable: false, intent: "none", entite: "", confiance: 0 },
+      { publishTranscript: (text: string) => transcripts.push(text) },
+    );
+    await orch.ingestSegment(seg("bonjour le monde", 0, 1000));
+    expect(transcripts).toEqual(["bonjour le monde"]);
+  });
+
+  it("does not publish the transcript when debug is disabled (no websocket fan-out)", async () => {
+    const transcripts: string[] = [];
+    const { orch } = makeOrchestrator(
+      { actionnable: false, intent: "none", entite: "", confiance: 0 },
+      {
+        publishTranscript: (text: string) => transcripts.push(text),
+        isTranscriptDebugEnabled: () => false,
+      },
+    );
+    await orch.ingestSegment(seg("bonjour le monde", 0, 1000));
+    expect(transcripts).toEqual([]);
+  });
+
   it("publishes stt:status connected on first segment", async () => {
     const statusCalls: Array<[boolean, string | null]> = [];
     const publishStatus = (connected: boolean, device: string | null) => {
@@ -111,6 +164,20 @@ describe("LiveAssistOrchestrator", () => {
     await orch.ingestSegment(seg("bonjour", 0, 1000));
     expect(statusCalls.length).toBeGreaterThanOrEqual(1);
     expect(statusCalls[0][0]).toBe(true);
+  });
+
+  it("resolves a device id to its label in status (setSttStatus + markSttAlive)", async () => {
+    const { orch } = makeOrchestrator(
+      { actionnable: false, intent: "none", entite: "", confiance: 0 },
+      { resolveDeviceLabel: (id: string) => (id === "1" ? "USB Mic" : id) },
+    );
+    orch.setSttStatus(false, "1");
+    expect(orch.getStatus().device).toBe("USB Mic");
+    orch.markSttAlive("1");
+    expect(orch.getStatus().device).toBe("USB Mic");
+    // null device stays null (no lookup)
+    orch.setSttStatus(false, null);
+    expect(orch.getStatus().device).toBeNull();
   });
 
   it("publishes stt:status disconnected when stale", async () => {

--- a/__tests__/services/liveassist/LocalPosterMatcher.test.ts
+++ b/__tests__/services/liveassist/LocalPosterMatcher.test.ts
@@ -1,0 +1,50 @@
+import { LocalPosterMatcher } from "@/lib/services/liveassist/LocalPosterMatcher";
+
+const posters = [
+  { id: "p1", title: "Pilote", fileUrl: "u1", type: "image" },
+  { id: "p2", title: "Casseroles", fileUrl: "u2", type: "image" },
+  { id: "p3", title: "Rowanne - Eclypsia", fileUrl: "u3", type: "image", thumbnailUrl: null },
+];
+
+describe("LocalPosterMatcher", () => {
+  it("matches a distinctive token of a multi-word title", () => {
+    const m = new LocalPosterMatcher();
+    m.setPosters(posters);
+    const r = m.match("on reçoit Eclypsia ce soir");
+    expect(r.map((x) => x.poster.id)).toContain("p3");
+  });
+
+  it("tolerates an STT typo + accent (« Éclipsia » → Eclypsia)", () => {
+    const m = new LocalPosterMatcher();
+    m.setPosters(posters);
+    const r = m.match("voici Éclipsia");
+    expect(r[0]?.poster.id).toBe("p3");
+    expect(r[0]?.score).toBeGreaterThan(0.8);
+  });
+
+  it("does not match unrelated speech", () => {
+    const m = new LocalPosterMatcher();
+    m.setPosters(posters);
+    expect(m.match("bonjour tout le monde")).toHaveLength(0);
+  });
+
+  it("returns one entry per poster even on repeated mentions", () => {
+    const m = new LocalPosterMatcher();
+    m.setPosters(posters);
+    const r = m.match("Pilote pilote pilote");
+    expect(r.filter((x) => x.poster.id === "p1")).toHaveLength(1);
+  });
+
+  it("ignores titles whose only tokens are short or stop-words", () => {
+    const m = new LocalPosterMatcher();
+    m.setPosters([{ id: "x", title: "Le Roi", fileUrl: "u", type: "image" }]);
+    expect(m.match("le roi est mort")).toHaveLength(0); // "roi"<4 chars, "le" is a stop-word
+  });
+
+  it("respects a stricter minSimilarity (rejects the typo, keeps the exact word)", () => {
+    const m = new LocalPosterMatcher();
+    m.setPosters(posters, 0.99);
+    expect(m.match("Eclipsia")).toHaveLength(0); // 0.875 < 0.99
+    expect(m.match("Eclypsia").map((x) => x.poster.id)).toContain("p3");
+  });
+});

--- a/__tests__/services/liveassist/providers/DefinitionActionProvider.test.ts
+++ b/__tests__/services/liveassist/providers/DefinitionActionProvider.test.ts
@@ -10,25 +10,51 @@ describe("DefinitionActionProvider", () => {
     }),
   };
 
-  it("builds a text suggestion truncated to N sentences", async () => {
-    const p = new DefinitionActionProvider(resolver, async () => ({ ok: true }), 3);
+  const noop = async () => ({ ok: true });
+
+  it("builds a text suggestion truncated to N sentences, carrying the subject name", async () => {
+    const p = new DefinitionActionProvider(resolver, noop, noop, 3);
     const s = await p.build("Commedia dell'arte", window);
     expect(s?.preview.kind).toBe("text");
     expect(s?.preview.text).toBe("Phrase un. Phrase deux. Phrase trois.");
-    expect(s?.applyPayload).toEqual({ target: "pin", text: "Phrase un. Phrase deux. Phrase trois." });
+    expect(s?.applyPayload).toEqual({
+      target: "pin",
+      text: "Phrase un. Phrase deux. Phrase trois.",
+      name: "Commedia dell'arte",
+    });
   });
 
-  it("pin apply is a no-op success", async () => {
-    const p = new DefinitionActionProvider(resolver, async () => ({ ok: false, message: "should not call" }), 3);
-    const r = await p.apply({ target: "pin", text: "x" });
+  it("validate (pin) creates a text preset named after the subject", async () => {
+    let created: { name: string; body: string } | null = null;
+    const p = new DefinitionActionProvider(
+      resolver,
+      async () => ({ ok: false, message: "on-air should not be called" }),
+      async (input) => { created = input; return { ok: true }; },
+      3,
+    );
+    const r = await p.apply({ target: "pin", text: "Une définition.", name: "Commedia dell'arte" });
     expect(r.ok).toBe(true);
+    expect(created).toEqual({ name: "Commedia dell'arte", body: "Une définition." });
   });
 
-  it("on-air apply pushes the text to the lower third", async () => {
+  it("on-air apply pushes the text to the lower third (not the preset)", async () => {
     let aired = "";
-    const p = new DefinitionActionProvider(resolver, async (t) => { aired = t; return { ok: true }; }, 3);
-    const r = await p.apply({ target: "on-air", text: "Définition courte" });
+    const p = new DefinitionActionProvider(
+      resolver,
+      async (t) => { aired = t; return { ok: true }; },
+      async () => ({ ok: false, message: "preset should not be called" }),
+      3,
+    );
+    const r = await p.apply({ target: "on-air", text: "Définition courte", name: "Sujet" });
     expect(r.ok).toBe(true);
     expect(aired).toBe("Définition courte");
+  });
+
+  it("falls back to a truncated body as the preset name when none is provided", async () => {
+    let created: { name: string; body: string } | null = null;
+    const p = new DefinitionActionProvider(resolver, noop, async (input) => { created = input; return { ok: true }; }, 3);
+    const r = await p.apply({ target: "pin", text: "Texte sans nom." });
+    expect(r.ok).toBe(true);
+    expect(created?.name).toBe("Texte sans nom.");
   });
 });

--- a/__tests__/services/liveassist/providers/LocalPosterProvider.test.ts
+++ b/__tests__/services/liveassist/providers/LocalPosterProvider.test.ts
@@ -27,6 +27,32 @@ describe("LocalPosterProvider", () => {
       const noThumb = LocalPosterProvider.toSuggestion({ id: "v", title: "Casseroles", fileUrl: "v.mp4", type: "video" }, "t", 0.9);
       expect(noThumb.preview.kind).toBe("text");
     });
+
+    it("carries a video clip's range/chapters into the apply payload (not just the raw file)", () => {
+      const s = LocalPosterProvider.toSuggestion(
+        {
+          id: "clip", title: "Best of", fileUrl: "full.mp4", type: "video", thumbnailUrl: "t.jpg",
+          startTime: 12, endTime: 34, endBehavior: "loop",
+          metadata: { chapters: [{ timestamp: 5, title: "intro" }] },
+        },
+        "le best of",
+        0.9,
+      );
+      expect(s.applyPayload).toEqual({
+        posterId: "clip", fileUrl: "full.mp4", type: "video",
+        startTime: 12, endTime: 34, endBehavior: "loop",
+        chapters: [{ timestamp: 5, title: "intro" }],
+      });
+    });
+
+    it("omits clip fields for an image poster", () => {
+      const s = LocalPosterProvider.toSuggestion(
+        { id: "p", title: "Affiche", fileUrl: "a.jpg", type: "image", startTime: 9, endTime: 99 },
+        "x",
+        0.9,
+      );
+      expect(s.applyPayload).toEqual({ posterId: "p", fileUrl: "a.jpg", type: "image" });
+    });
   });
 
   describe("apply", () => {
@@ -63,6 +89,22 @@ describe("LocalPosterProvider", () => {
     it("fails cleanly when the fileUrl is missing", async () => {
       const p = new LocalPosterProvider(async () => ({ ok: true }), okEnabler);
       expect((await p.apply({ posterId: "p" })).ok).toBe(false);
+    });
+
+    it("forwards a stored clip's range/chapters to the show payload", async () => {
+      const shown: Array<Record<string, unknown>> = [];
+      const p = new LocalPosterProvider(async (payload) => {
+        shown.push(payload as Record<string, unknown>);
+        return { ok: true };
+      }, okEnabler);
+      await p.apply({
+        posterId: "clip", fileUrl: "full.mp4", type: "video", target: "left",
+        startTime: 12, endTime: 34, endBehavior: "loop", chapters: [{ timestamp: 5, title: "intro" }],
+      });
+      expect(shown[0]).toEqual({
+        posterId: "clip", fileUrl: "full.mp4", type: "video", side: "left", transition: "fade",
+        startTime: 12, endTime: 34, endBehavior: "loop", chapters: [{ timestamp: 5, title: "intro" }],
+      });
     });
   });
 });

--- a/__tests__/services/liveassist/providers/LocalPosterProvider.test.ts
+++ b/__tests__/services/liveassist/providers/LocalPosterProvider.test.ts
@@ -1,0 +1,68 @@
+import { LocalPosterProvider } from "@/lib/services/liveassist/providers/LocalPosterProvider";
+
+describe("LocalPosterProvider", () => {
+  describe("toSuggestion", () => {
+    it("builds an image suggestion keyed on the poster id", () => {
+      const s = LocalPosterProvider.toSuggestion(
+        { id: "p3", title: "Rowanne - Eclypsia", fileUrl: "u3", type: "image" },
+        "voici Eclypsia",
+        0.92,
+      );
+      expect(s.intent).toBe("local-poster");
+      expect(s.entity).toBe("p3");
+      expect(s.title).toBe("Rowanne - Eclypsia");
+      expect(s.preview).toEqual({ kind: "image", imageUrl: "u3" });
+      expect(s.applyPayload).toEqual({ posterId: "p3", fileUrl: "u3", type: "image" });
+      expect(s.confidence).toBeCloseTo(0.92);
+    });
+
+    it("prefers the thumbnail and falls back to text for a thumbnail-less video", () => {
+      const withThumb = LocalPosterProvider.toSuggestion(
+        { id: "v", title: "Clip", fileUrl: "v.mp4", type: "video", thumbnailUrl: "thumb.jpg" },
+        "t",
+        0.9,
+      );
+      expect(withThumb.preview).toEqual({ kind: "image", imageUrl: "thumb.jpg" });
+
+      const noThumb = LocalPosterProvider.toSuggestion({ id: "v", title: "Casseroles", fileUrl: "v.mp4", type: "video" }, "t", 0.9);
+      expect(noThumb.preview.kind).toBe("text");
+    });
+  });
+
+  describe("apply", () => {
+    const okEnabler = jest.fn(async () => ({ ok: true as const }));
+    beforeEach(() => okEnabler.mockClear());
+
+    it("shows the poster overlay with side = right when target is 'right'", async () => {
+      const shown: unknown[] = [];
+      const p = new LocalPosterProvider(async (payload) => {
+        shown.push(payload);
+        return { ok: true };
+      }, okEnabler);
+      const r = await p.apply({ posterId: "p3", fileUrl: "u3", type: "image", target: "right" });
+      expect(r.ok).toBe(true);
+      expect(shown[0]).toEqual({ posterId: "p3", fileUrl: "u3", type: "image", side: "right", transition: "fade" });
+    });
+
+    it("enables the poster (adds it to the Affiches panel) before showing — either side", async () => {
+      const p = new LocalPosterProvider(async () => ({ ok: true }), okEnabler);
+      await p.apply({ posterId: "p3", fileUrl: "u3", type: "image", target: "left" });
+      expect(okEnabler).toHaveBeenCalledWith("p3");
+    });
+
+    it("defaults to the left side for any non-'right' target", async () => {
+      let side = "";
+      const p = new LocalPosterProvider(async (payload) => {
+        side = payload.side;
+        return { ok: true };
+      }, okEnabler);
+      await p.apply({ posterId: "p", fileUrl: "u", type: "image", target: "left" });
+      expect(side).toBe("left");
+    });
+
+    it("fails cleanly when the fileUrl is missing", async () => {
+      const p = new LocalPosterProvider(async () => ({ ok: true }), okEnabler);
+      expect((await p.apply({ posterId: "p" })).ok).toBe(false);
+    });
+  });
+});

--- a/__tests__/utils/downloadToLocal.test.ts
+++ b/__tests__/utils/downloadToLocal.test.ts
@@ -1,0 +1,165 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Mock disk + upload-dir so nothing is written for real
+jest.mock("fs/promises", () => ({
+  writeFile: jest.fn(async () => undefined),
+}));
+jest.mock("@/lib/utils/fileUpload", () => ({
+  getUploadDir: jest.fn(async (subfolder: string) => `/mock/data/uploads/${subfolder}`),
+}));
+
+import { writeFile } from "fs/promises";
+import {
+  downloadRemoteToUpload,
+  DownloadError,
+  resolvePosterFileUrl,
+} from "@/lib/utils/downloadToLocal";
+
+const writeFileMock = writeFile as jest.MockedFunction<typeof writeFile>;
+
+function imageResponse(contentType = "image/jpeg", body = "fake-bytes"): Response {
+  return new Response(body, { status: 200, headers: { "content-type": contentType } });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+});
+
+describe("downloadRemoteToUpload", () => {
+  it("downloads and persists an image, returning a /data/uploads URL", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(imageResponse("image/jpeg"));
+
+    const result = await downloadRemoteToUpload("https://example.com/x.jpg");
+
+    expect(result.type).toBe("image");
+    expect(result.url).toMatch(/^\/data\/uploads\/posters\/[0-9a-f-]+\.jpg$/);
+    expect(result.filename).toMatch(/\.jpg$/);
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives extension from Content-Type when the URL has none", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(imageResponse("image/png"));
+
+    const result = await downloadRemoteToUpload("https://example.com/image-no-ext");
+
+    expect(result.url).toMatch(/\.png$/);
+  });
+
+  it("classifies videos by Content-Type", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(imageResponse("video/mp4"));
+
+    const result = await downloadRemoteToUpload("https://example.com/clip.mp4");
+
+    expect(result.type).toBe("video");
+    expect(result.url).toMatch(/\.mp4$/);
+  });
+
+  it("throws DownloadError(400) on a non-OK response", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response("nope", { status: 404, statusText: "Not Found" })
+    );
+
+    await expect(downloadRemoteToUpload("https://example.com/x.jpg")).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it("throws DownloadError(400) for an unsupported content type", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response("<html>", { status: 200, headers: { "content-type": "text/html" } })
+    );
+
+    await expect(downloadRemoteToUpload("https://example.com/x")).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("throws DownloadError(400) when content-length exceeds 50MB", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response("x", {
+        status: 200,
+        headers: {
+          "content-type": "image/jpeg",
+          "content-length": String(60 * 1024 * 1024),
+        },
+      })
+    );
+
+    await expect(downloadRemoteToUpload("https://example.com/x.jpg")).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("throws DownloadError(408) on a timeout/abort", async () => {
+    const timeoutErr = Object.assign(new Error("The operation timed out"), {
+      name: "TimeoutError",
+    });
+    jest.spyOn(global, "fetch").mockRejectedValue(timeoutErr);
+
+    await expect(downloadRemoteToUpload("https://example.com/x.jpg")).rejects.toMatchObject({
+      status: 408,
+    });
+  });
+
+  it("throws DownloadError(400) on a network (TypeError) failure", async () => {
+    jest.spyOn(global, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(downloadRemoteToUpload("https://example.com/x.jpg")).rejects.toBeInstanceOf(
+      DownloadError
+    );
+    await expect(downloadRemoteToUpload("https://example.com/x.jpg")).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});
+
+describe("resolvePosterFileUrl", () => {
+  it("rewrites a remote URL to a local path when downloadToLocal is true", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(imageResponse("image/jpeg"));
+
+    const out = await resolvePosterFileUrl("https://example.com/x.jpg", "image", true);
+
+    expect(out).toMatch(/^\/data\/uploads\/posters\//);
+  });
+
+  it("leaves the URL untouched when downloadToLocal is falsy", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+
+    const out = await resolvePosterFileUrl("https://example.com/x.jpg", "image", undefined);
+
+    expect(out).toBe("https://example.com/x.jpg");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("never downloads a YouTube poster even when downloadToLocal is true", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+
+    const out = await resolvePosterFileUrl(
+      "https://youtube.com/watch?v=abc",
+      "youtube",
+      true
+    );
+
+    expect(out).toBe("https://youtube.com/watch?v=abc");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("leaves an already-local /data path untouched", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+
+    const out = await resolvePosterFileUrl("/data/uploads/posters/x.jpg", "image", true);
+
+    expect(out).toBe("/data/uploads/posters/x.jpg");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the remote URL when the download fails", async () => {
+    jest.spyOn(global, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+
+    const out = await resolvePosterFileUrl("https://example.com/x.jpg", "image", true);
+
+    expect(out).toBe("https://example.com/x.jpg");
+  });
+});

--- a/__tests__/utils/fuzzyMatch.test.ts
+++ b/__tests__/utils/fuzzyMatch.test.ts
@@ -1,0 +1,32 @@
+import { levenshtein, similarity } from "@/lib/utils/fuzzyMatch";
+
+describe("levenshtein", () => {
+  it("is 0 for identical strings", () => {
+    expect(levenshtein("eclypsia", "eclypsia")).toBe(0);
+  });
+  it("counts single edits", () => {
+    expect(levenshtein("eclypsia", "eclipsia")).toBe(1); // y→i
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+  it("handles empty strings", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+    expect(levenshtein("", "")).toBe(0);
+  });
+});
+
+describe("similarity", () => {
+  it("is 1 for identical strings", () => {
+    expect(similarity("eclypsia", "eclypsia")).toBe(1);
+  });
+  it("is high for a one-character typo", () => {
+    expect(similarity("eclypsia", "eclipsia")).toBeCloseTo(1 - 1 / 8); // 0.875
+    expect(similarity("eclypsia", "eclipsia")).toBeGreaterThan(0.8);
+  });
+  it("is low for unrelated words", () => {
+    expect(similarity("eclypsia", "casseroles")).toBeLessThan(0.5);
+  });
+  it("treats two empty strings as identical", () => {
+    expect(similarity("", "")).toBe(1);
+  });
+});

--- a/app/api/assets/download-upload/route.ts
+++ b/app/api/assets/download-upload/route.ts
@@ -1,10 +1,5 @@
 import { NextResponse } from "next/server";
-import { writeFile } from "fs/promises";
-import { join } from "path";
-import { randomUUID } from "crypto";
-import { IMAGE_TYPES, VIDEO_TYPES } from "@/lib/filetypes";
-import { getMediaTypeFromUrl, getFilenameFromUrl } from "@/lib/utils/urlDetection";
-import { getUploadDir } from "@/lib/utils/fileUpload";
+import { downloadRemoteToUpload, DownloadError } from "@/lib/utils/downloadToLocal";
 
 /**
  * POST /api/assets/download-upload
@@ -15,124 +10,19 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { url } = body;
 
-    if (!url || typeof url !== 'string') {
-      return NextResponse.json(
-        { error: "No URL provided" },
-        { status: 400 }
-      );
+    if (!url || typeof url !== "string") {
+      return NextResponse.json({ error: "No URL provided" }, { status: 400 });
     }
 
-    // Fetch the file from the external URL
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'User-Agent': 'OBS-Live-Suite/1.0',
-      },
-      // Timeout after 30 seconds
-      signal: AbortSignal.timeout(30000),
-    });
-
-    if (!response.ok) {
-      return NextResponse.json(
-        { error: `Failed to download file: ${response.statusText}` },
-        { status: 400 }
-      );
-    }
-
-    // Get Content-Type and validate
-    const contentType = response.headers.get('content-type') || '';
-    const allowedTypes = [...IMAGE_TYPES, ...VIDEO_TYPES];
-
-    if (!allowedTypes.some(type => contentType.includes(type.replace('*', '')))) {
-      return NextResponse.json(
-        { error: `Unsupported file type: ${contentType}. Use images or videos.` },
-        { status: 400 }
-      );
-    }
-
-    // Get Content-Length and validate size (max 50MB)
-    const contentLength = response.headers.get('content-length');
-    const maxSizeBytes = 50 * 1024 * 1024; // 50MB
-
-    if (contentLength && parseInt(contentLength) > maxSizeBytes) {
-      return NextResponse.json(
-        { error: "File too large. Maximum size: 50MB" },
-        { status: 400 }
-      );
-    }
-
-    // Download the file
-    const arrayBuffer = await response.arrayBuffer();
-
-    // Double-check size after download
-    if (arrayBuffer.byteLength > maxSizeBytes) {
-      return NextResponse.json(
-        { error: "File too large. Maximum size: 50MB" },
-        { status: 400 }
-      );
-    }
-
-    // Determine file type
-    const mediaType = getMediaTypeFromUrl(url);
-    const type = contentType.startsWith('image/') ? 'image' : 'video';
-
-    // Get extension from URL or Content-Type
-    let ext = '';
-    const urlExt = url.split('.').pop()?.split('?')[0]?.toLowerCase();
-    if (urlExt && ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'mp4', 'webm', 'mov'].includes(urlExt)) {
-      ext = urlExt;
-    } else {
-      // Fallback to Content-Type
-      const typeMap: Record<string, string> = {
-        'image/jpeg': 'jpg',
-        'image/png': 'png',
-        'image/gif': 'gif',
-        'image/webp': 'webp',
-        'image/avif': 'avif',
-        'video/mp4': 'mp4',
-        'video/webm': 'webm',
-        'video/quicktime': 'mov',
-      };
-      ext = typeMap[contentType] || 'jpg';
-    }
-
-    // Get (or create) upload directory
-    const uploadDir = await getUploadDir("posters");
-
-    // Generate unique filename
-    const filename = `${randomUUID()}.${ext}`;
-    const filepath = join(uploadDir, filename);
-
-    // Write file to disk
-    const buffer = Buffer.from(arrayBuffer);
-    await writeFile(filepath, buffer);
-
-    // Return URL relative to data directory
-    const relativeUrl = `/data/uploads/posters/${filename}`;
-
-    return NextResponse.json({
-      url: relativeUrl,
-      filename,
-      type,
-    });
-
+    const result = await downloadRemoteToUpload(url);
+    return NextResponse.json(result);
   } catch (error) {
     console.error("Download-upload error:", error);
 
-    // Handle timeout errors
-    if (error instanceof Error && error.name === 'AbortError') {
-      return NextResponse.json(
-        { error: "Download timeout. The file took too long to download (max 30s)." },
-        { status: 408 }
-      );
-    }
-
-    // Handle fetch errors (network, DNS, etc.)
-    if (error instanceof TypeError) {
-      return NextResponse.json(
-        { error: "Failed to download media from URL. Check that the URL is valid and accessible." },
-        { status: 400 }
-      );
+    // DownloadError carries the exact HTTP status to return
+    // (400 for bad url/type/size, 408 for timeout)
+    if (error instanceof DownloadError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
     }
 
     return NextResponse.json(

--- a/app/api/assets/posters/[id]/route.ts
+++ b/app/api/assets/posters/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   RouteContext,
 } from "@/lib/utils/ApiResponses";
 import { broadcastDataChange } from "@/lib/utils/broadcastDataChange";
+import { resolvePosterFileUrl } from "@/lib/utils/downloadToLocal";
 
 const LOG_CONTEXT = "[PostersAPI]";
 
@@ -37,8 +38,15 @@ export const PATCH = withErrorHandler<{ id: string }>(
     const { id } = await context.params;
     const body = await request.json();
 
+    // downloadToLocal is not part of updatePosterSchema — pull it out and, when
+    // a remote fileUrl is provided, persist the file to local storage.
+    const { downloadToLocal, ...rest } = body;
+    if (rest.fileUrl) {
+      rest.fileUrl = await resolvePosterFileUrl(rest.fileUrl, rest.type, downloadToLocal);
+    }
+
     const parseResult = updatePosterSchema.safeParse({
-      ...body,
+      ...rest,
       id,
     });
 

--- a/app/api/assets/posters/route.ts
+++ b/app/api/assets/posters/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/utils/ApiResponses";
 import { parseBooleanQueryParam } from "@/lib/utils/queryParams";
 import { broadcastDataChange } from "@/lib/utils/broadcastDataChange";
+import { resolvePosterFileUrl } from "@/lib/utils/downloadToLocal";
 
 const LOG_CONTEXT = "[PostersAPI]";
 
@@ -33,9 +34,14 @@ export const GET = withSimpleErrorHandler(async (request: Request) => {
 export const POST = withSimpleErrorHandler(async (request: Request) => {
   const body = await request.json();
 
+  // downloadToLocal is not part of posterSchema — pull it out and, when
+  // requested for a remote media URL, persist the file to local storage.
+  const { downloadToLocal, ...rest } = body;
+  rest.fileUrl = await resolvePosterFileUrl(rest.fileUrl, rest.type, downloadToLocal);
+
   const parseResult = posterSchema.safeParse({
     id: randomUUID(),
-    ...body,
+    ...rest,
     createdAt: new Date(),
     updatedAt: new Date(),
   });

--- a/app/api/settings/integrations/route.ts
+++ b/app/api/settings/integrations/route.ts
@@ -26,6 +26,9 @@ export const GET = withSimpleErrorHandler(async () => {
     // Anthropic
     anthropic_api_key: db.getSetting("anthropic_api_key") || "",
     anthropic_model: db.getSetting("anthropic_model") || "claude-3-5-sonnet-20241022",
+
+    // TMDB (movie/TV posters)
+    tmdb_api_key: db.getSetting("tmdb_api_key") || "",
   };
 
   return ApiResponses.ok({ settings });
@@ -68,6 +71,11 @@ export const POST = withSimpleErrorHandler(async (request: Request) => {
   }
   if (body.anthropic_model !== undefined) {
     settingsToSave.anthropic_model = body.anthropic_model;
+  }
+
+  // TMDB (movie/TV posters)
+  if (body.tmdb_api_key !== undefined) {
+    settingsToSave.tmdb_api_key = body.tmdb_api_key;
   }
 
   // Save all settings

--- a/app/api/settings/integrations/tmdb-test/route.ts
+++ b/app/api/settings/integrations/tmdb-test/route.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { TmdbResolverService } from "@/lib/services/TmdbResolverService";
+import { ApiResponses, withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+
+const LOG_CONTEXT = "[TmdbTestAPI]";
+
+const schema = z.object({ apiKey: z.string().optional() });
+
+/**
+ * POST /api/settings/integrations/tmdb-test
+ * Validate a TMDB API key. Tests the key in the request body (the value typed in
+ * Settings, possibly unsaved); falls back to the stored key when none is sent.
+ * Returns 200 with { success, message } for both valid and invalid keys — an
+ * invalid key is a validation result, not a server error.
+ */
+export const POST = withSimpleErrorHandler(async (request: Request) => {
+  const body = await request.json().catch(() => ({}));
+  const { apiKey } = schema.parse(body ?? {});
+  const result = await TmdbResolverService.getInstance().testConnection(apiKey);
+  return ApiResponses.ok({ success: result.ok, message: result.message });
+}, LOG_CONTEXT);

--- a/components/dashboard/cards/PosterCard.tsx
+++ b/components/dashboard/cards/PosterCard.tsx
@@ -35,6 +35,7 @@ import { PosterQuickAdd } from "@/components/assets/PosterQuickAdd";
 import { apiGet, apiPost } from "@/lib/utils/ClientFetch";
 import { useSyncWithOverlayState } from "@/hooks/useSyncWithOverlayState";
 import { useArmedVideoPoster, type DisplayMode } from "@/hooks/useArmedVideoPoster";
+import { useDataChangeRefetch } from "@/hooks/useDataChangeRefetch";
 import { CLIENT_ID } from "@/lib/utils/clientId";
 import { posterEndpoint } from "@/lib/utils/posterHelpers";
 import { toast } from "sonner";
@@ -216,6 +217,11 @@ export function PosterContent({ className }: PosterContentProps) {
       setLoading(false);
     }
   };
+
+  // Refresh when a poster is created/changed elsewhere — notably the Live Assist
+  // backend adding an affiche server-side (this panel holds local state, so the
+  // React-Query-based useDataSync doesn't cover it).
+  useDataChangeRefetch("posters", fetchPosters);
 
   const fetchDefaultDisplayMode = async () => {
     try {

--- a/components/dashboard/panels/LiveAssistPanel.tsx
+++ b/components/dashboard/panels/LiveAssistPanel.tsx
@@ -8,6 +8,7 @@ import { apiGet, apiPost, extractErrorMessage } from "@/lib/utils/ClientFetch";
 import { useLiveAssistStore } from "@/lib/stores/liveAssistStore";
 import { SuggestionCard } from "@/components/live-assist/SuggestionCard";
 import { SttStatusBar } from "@/components/live-assist/SttStatusBar";
+import { LiveAssistControls } from "@/components/live-assist/LiveAssistControls";
 import type { LiveAssistEvent, Suggestion } from "@/lib/models/LiveAssist";
 
 const config: PanelConfig = { id: "liveAssist", context: "dashboard" };
@@ -55,7 +56,11 @@ export function LiveAssistPanel(_props: IDockviewPanelProps) {
   return (
     <BasePanelWrapper config={config}>
       <div className="flex flex-col h-full">
-        <SttStatusBar />
+        {/* Header: STT status (left) + quick listening/transcript kill switches (right). */}
+        <div className="flex items-center justify-between gap-2 px-3 py-2 border-b">
+          <SttStatusBar />
+          <LiveAssistControls />
+        </div>
         <div className="flex flex-col gap-2 p-3 overflow-auto flex-1">
           {suggestions.map((s) => (
             <SuggestionCard key={s.id} suggestion={s} onApply={onApply} onDismiss={onDismiss} />

--- a/components/dashboard/panels/LiveAssistPanel.tsx
+++ b/components/dashboard/panels/LiveAssistPanel.tsx
@@ -39,9 +39,10 @@ export function LiveAssistPanel(_props: IDockviewPanelProps) {
   );
   useWebSocketChannel<LiveAssistEvent>("live-assist", handleEvent, { logPrefix: "LiveAssistPanel" });
 
-  const onApply = useCallback((s: Suggestion, target: "pin" | "on-air") => {
-    const payload = s.intent === "definition" ? { ...s.applyPayload, target } : s.applyPayload;
-    apiPost(`/api/live-assist/suggestions/${s.id}/apply`, { intent: s.intent, payload }).catch((e) =>
+  const onApply = useCallback((s: Suggestion, target: "pin" | "on-air" | "left" | "right") => {
+    // The server is authoritative: it reloads the stored suggestion by id and uses
+    // its own applyPayload. We only send the runtime pin/on-air choice.
+    apiPost(`/api/live-assist/suggestions/${s.id}/apply`, { target }).catch((e) =>
       toast.error(extractErrorMessage(e, "Échec de l'application de la suggestion")),
     );
   }, []);
@@ -69,8 +70,8 @@ export function LiveAssistPanel(_props: IDockviewPanelProps) {
             </div>
             <div className="px-3 pb-2 max-h-40 overflow-auto text-xs font-mono leading-relaxed space-y-0.5">
               {transcripts.map((line, i) => (
-                <div key={i} className={i === 0 ? "text-foreground" : "text-muted-foreground"}>
-                  {line}
+                <div key={line.id} className={i === 0 ? "text-foreground" : "text-muted-foreground"}>
+                  {line.text}
                 </div>
               ))}
             </div>

--- a/components/live-assist/LiveAssistControls.tsx
+++ b/components/live-assist/LiveAssistControls.tsx
@@ -1,0 +1,80 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import { apiGet, apiPost, extractErrorMessage } from "@/lib/utils/ClientFetch";
+import type { LiveAssistSettings } from "@/lib/models/LiveAssist";
+
+/**
+ * Quick in-panel kill switches for Live Assist, so the operator can stop the
+ * assistant fast during a live show without digging into Settings:
+ *  - "Écoute" (`enabled`): the master switch — gates STT ingest AND the Python
+ *    transcription loop, so flipping it off silences everything.
+ *  - "Transcript" (`transcriptDebug`): just the live transcript re-broadcast.
+ *
+ * Settings are persisted as one whole object (the POST schema-parses the full
+ * shape), so we keep the full settings in local state and flip a single flag —
+ * sending a partial would reset every other field (keywords, prompts, …) to its
+ * default. The backend re-reads settings live, so the toggle takes effect with
+ * no restart.
+ */
+export function LiveAssistControls() {
+  const t = useTranslations("dashboard.liveAssist");
+  const [settings, setSettings] = useState<LiveAssistSettings | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    apiGet<{ settings: LiveAssistSettings }>("/api/settings/live-assist")
+      .then((d) => setSettings(d.settings))
+      .catch(() => {});
+  }, []);
+
+  const toggle = useCallback(
+    async (key: "enabled" | "transcriptDebug", value: boolean) => {
+      setSettings((current) => {
+        if (!current) return current;
+        const next = { ...current, [key]: value };
+        setBusy(true);
+        apiPost("/api/settings/live-assist", { settings: next })
+          .catch((e) => {
+            setSettings(current); // revert on failure
+            toast.error(extractErrorMessage(e, t("toggleFailed")));
+          })
+          .finally(() => setBusy(false));
+        return next; // optimistic
+      });
+    },
+    [t],
+  );
+
+  if (!settings) return null;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex items-center gap-1.5">
+        <Switch
+          id="la-listening"
+          checked={settings.enabled}
+          disabled={busy}
+          onCheckedChange={(v) => toggle("enabled", v)}
+        />
+        <Label htmlFor="la-listening" className="text-xs cursor-pointer">
+          {t("listening")}
+        </Label>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <Switch
+          id="la-transcript"
+          checked={settings.transcriptDebug}
+          disabled={busy}
+          onCheckedChange={(v) => toggle("transcriptDebug", v)}
+        />
+        <Label htmlFor="la-transcript" className="text-xs cursor-pointer">
+          {t("transcript")}
+        </Label>
+      </div>
+    </div>
+  );
+}

--- a/components/live-assist/SttStatusBar.tsx
+++ b/components/live-assist/SttStatusBar.tsx
@@ -6,7 +6,9 @@ export function SttStatusBar() {
   const t = useTranslations("dashboard.liveAssist");
   const status = useLiveAssistStore((s) => s.status);
   return (
-    <div className="flex items-center gap-2 text-xs px-3 py-2 border-b">
+    // Layout (padding/border) is owned by the panel header row so the status can
+    // sit alongside the quick-toggle controls.
+    <div className="flex items-center gap-2 text-xs">
       <span>{status.connected ? "🟢" : "🔴"}</span>
       <span>{status.connected ? (status.device ?? t("connected")) : t("disconnected")}</span>
     </div>

--- a/components/live-assist/SuggestionCard.tsx
+++ b/components/live-assist/SuggestionCard.tsx
@@ -1,42 +1,89 @@
 "use client";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
+import { ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { Suggestion } from "@/lib/models/LiveAssist";
 
 interface Props {
   suggestion: Suggestion;
-  onApply: (s: Suggestion, target: "pin" | "on-air") => void;
+  onApply: (s: Suggestion, target: "pin" | "on-air" | "left" | "right") => void;
   onDismiss: (s: Suggestion) => void;
 }
 
 export function SuggestionCard({ suggestion: s, onApply, onDismiss }: Props) {
   const t = useTranslations("dashboard.liveAssist");
-  const dimmed = s.status !== "pending";
+  const isPending = s.status === "pending";
+  const isDismissed = s.status === "dismissed";
+  const isDefinition = s.intent === "definition";
+  const isLocalPoster = s.intent === "local-poster";
+  const [expanded, setExpanded] = useState(false);
+  // Once acted on, collapse to just icon + title to save space; an explicit
+  // expand reveals the detail again. Pending cards always show their detail.
+  const showDetail = isPending || expanded;
+  const icon = isDefinition ? "📖" : isLocalPoster ? "🖼️" : s.intent === "poster-tmdb" ? "🎬" : "🎭";
+
   return (
-    <div className={`rounded border p-3 flex flex-col gap-2 ${dimmed ? "opacity-40" : ""}`}>
-      <div className="flex items-center gap-2">
-        <span>{s.intent === "poster" ? "🎭" : "📖"}</span>
-        <span className="font-medium">{s.title}</span>
-      </div>
-      {s.preview.kind === "image" && s.preview.imageUrl ? (
-        <img src={s.preview.imageUrl} alt={s.title} className="max-h-40 rounded object-contain" />
+    <div className={`rounded border p-3 flex flex-col gap-2 ${isPending ? "" : "opacity-70"}`}>
+      {/* Header: icon + title. Once acted on it becomes a collapse/expand toggle. */}
+      {isPending ? (
+        <div className="flex items-center gap-2">
+          <span>{icon}</span>
+          <span className="font-medium">{s.title}</span>
+        </div>
       ) : (
-        <p className="text-sm text-muted-foreground">{s.preview.text}</p>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="flex items-center gap-2 text-left w-full"
+        >
+          <span>{icon}</span>
+          <span className="font-medium flex-1 truncate">{s.title}</span>
+          <ChevronDown
+            className={`w-4 h-4 shrink-0 text-muted-foreground transition-transform ${expanded ? "rotate-180" : ""}`}
+          />
+        </button>
       )}
-      <p className="text-xs italic opacity-60">{s.triggerExcerpt}</p>
-      {!dimmed && (
-        <div className="flex gap-2">
-          <Button size="sm" onClick={() => onApply(s, "pin")}>
-            {s.intent === "definition" ? t("pin") : t("validate")}
-          </Button>
-          {s.intent === "definition" && (
-            <Button size="sm" variant="outline" onClick={() => onApply(s, "on-air")}>
-              {t("onAir")}
+
+      {showDetail && (
+        <>
+          {s.preview.kind === "image" && s.preview.imageUrl ? (
+            <img src={s.preview.imageUrl} alt={s.title} className="max-h-40 rounded object-contain" />
+          ) : (
+            <p className="text-sm text-muted-foreground">{s.preview.text}</p>
+          )}
+          <p className="text-xs italic opacity-60">{s.triggerExcerpt}</p>
+        </>
+      )}
+
+      {/* Actions. Pending → full set. Dismissed → keep a way to change your mind
+          (re-validate), shown even while collapsed. Applied → none (it's done). */}
+      {(isPending || isDismissed) && (
+        <div className="flex gap-2 flex-wrap">
+          {isLocalPoster ? (
+            // A local poster is shown on the program overlay on the chosen side.
+            <>
+              <Button size="sm" onClick={() => onApply(s, "left")}>{t("posterLeft")}</Button>
+              <Button size="sm" variant="outline" onClick={() => onApply(s, "right")}>{t("posterRight")}</Button>
+            </>
+          ) : (
+            <>
+              <Button size="sm" onClick={() => onApply(s, "pin")}>
+                {isDefinition ? t("quickText") : t("validate")}
+              </Button>
+              {isDefinition && (
+                <Button size="sm" variant="outline" onClick={() => onApply(s, "on-air")}>
+                  {t("onAir")}
+                </Button>
+              )}
+            </>
+          )}
+          {isPending && (
+            <Button size="sm" variant="ghost" onClick={() => onDismiss(s)}>
+              {t("dismiss")}
             </Button>
           )}
-          <Button size="sm" variant="ghost" onClick={() => onDismiss(s)}>
-            {t("dismiss")}
-          </Button>
         </div>
       )}
     </div>

--- a/components/settings/LiveAssistSettings.tsx
+++ b/components/settings/LiveAssistSettings.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { Slider } from "@/components/ui/slider";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -58,6 +59,54 @@ export function LiveAssistSettings() {
         />
       </div>
 
+      {/* Transcription debug — re-broadcasts each STT segment to the panel's live
+          debug view. Off by default to avoid loading the websocket for nothing. */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-1">
+          <Label htmlFor="liveAssistTranscriptDebug" className="text-base font-medium">
+            {t("transcriptDebug")}
+          </Label>
+          <p className="text-sm text-muted-foreground">{t("transcriptDebugHelp")}</p>
+        </div>
+        <Switch
+          id="liveAssistTranscriptDebug"
+          checked={data.transcriptDebug}
+          onCheckedChange={(checked) => setData({ ...data, transcriptDebug: checked })}
+        />
+      </div>
+
+      {/* Local posters — fuzzy-match spoken words against existing poster titles (no LLM). */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-1">
+          <Label htmlFor="liveAssistLocalPosters" className="text-base font-medium">
+            {t("localPosters")}
+          </Label>
+          <p className="text-sm text-muted-foreground">{t("localPostersHelp")}</p>
+        </div>
+        <Switch
+          id="liveAssistLocalPosters"
+          checked={data.localPostersEnabled}
+          onCheckedChange={(checked) => setData({ ...data, localPostersEnabled: checked })}
+        />
+      </div>
+
+      {data.localPostersEnabled && (
+        <div className="space-y-3">
+          <Label className="text-base font-medium">{t("localPosterSensitivity")}</Label>
+          <div className="flex items-center gap-4">
+            <Slider
+              value={[data.localPosterMinSimilarity]}
+              onValueChange={([v]) => setData({ ...data, localPosterMinSimilarity: v })}
+              min={0.5}
+              max={1}
+              step={0.05}
+              className="flex-1"
+            />
+            <span className="text-sm font-mono w-12 text-right">{data.localPosterMinSimilarity.toFixed(2)}</span>
+          </div>
+        </div>
+      )}
+
       {/* Input device */}
       <div className="space-y-3">
         <div className="flex items-center gap-2">
@@ -96,27 +145,47 @@ export function LiveAssistSettings() {
         />
       </div>
 
-      {/* Keyword editors (one per provider) */}
+      {/* Per-provider editors: keywords + the extraction context prompt (the "Règle"
+          injected into the LLM). Leaving the prompt empty falls back to the
+          provider's built-in default. */}
       {Object.entries(data.keywordsByProvider).map(([provider, words]) => (
-        <div key={provider} className="space-y-2">
-          <Label className="text-base font-medium">
-            {t("keywords")} — {provider}
-          </Label>
-          <Input
-            value={words.join(", ")}
-            onChange={(e) =>
-              setData({
-                ...data,
-                keywordsByProvider: {
-                  ...data.keywordsByProvider,
-                  [provider]: e.target.value
-                    .split(",")
-                    .map((w) => w.trim())
-                    .filter(Boolean),
-                },
-              })
-            }
-          />
+        <div key={provider} className="space-y-2 rounded-md border p-3">
+          <Label className="text-base font-medium">{provider}</Label>
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">{t("keywords")}</Label>
+            <Input
+              value={words.join(", ")}
+              onChange={(e) =>
+                setData({
+                  ...data,
+                  keywordsByProvider: {
+                    ...data.keywordsByProvider,
+                    [provider]: e.target.value
+                      .split(",")
+                      .map((w) => w.trim())
+                      .filter(Boolean),
+                  },
+                })
+              }
+            />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">{t("contextPrompt")}</Label>
+            <Textarea
+              rows={2}
+              placeholder={t("contextPromptPlaceholder")}
+              value={data.contextPromptsByProvider?.[provider] ?? ""}
+              onChange={(e) =>
+                setData({
+                  ...data,
+                  contextPromptsByProvider: {
+                    ...data.contextPromptsByProvider,
+                    [provider]: e.target.value,
+                  },
+                })
+              }
+            />
+          </div>
         </div>
       ))}
 

--- a/components/settings/OllamaSettings.tsx
+++ b/components/settings/OllamaSettings.tsx
@@ -17,7 +17,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { toast } from "sonner";
 import { Loader2, CheckCircle, XCircle, RefreshCw, Trash2 } from "lucide-react";
 import { useSettings } from "@/lib/hooks/useSettings";
-import { apiGet, apiPost, apiDelete, isClientFetchError } from "@/lib/utils/ClientFetch";
+import { apiGet, apiPost, apiDelete, isClientFetchError, extractErrorMessage } from "@/lib/utils/ClientFetch";
 
 type LLMProvider = "ollama" | "openai" | "anthropic";
 
@@ -98,11 +98,7 @@ export function OllamaSettings() {
       if (data.success) toast.success(message);
       else toast.error(message);
     } catch (error) {
-      const message = isClientFetchError(error)
-        ? error.errorMessage
-        : error instanceof Error
-          ? error.message
-          : "Échec de la connexion TMDB.";
+      const message = extractErrorMessage(error, "Échec de la connexion TMDB.");
       setTmdbTestResult({ success: false, message });
       toast.error(message);
     } finally {

--- a/components/settings/OllamaSettings.tsx
+++ b/components/settings/OllamaSettings.tsx
@@ -35,6 +35,9 @@ interface LLMSettings {
   // Anthropic
   anthropic_api_key?: string;
   anthropic_model?: string;
+
+  // TMDB (affiches films/séries)
+  tmdb_api_key?: string;
 }
 
 interface LLMSettingsResponse {
@@ -79,6 +82,33 @@ export function OllamaSettings() {
     message: string;
   } | null>(null);
   const [isClearingCache, setIsClearingCache] = useState(false);
+  const [isTestingTmdb, setIsTestingTmdb] = useState(false);
+  const [tmdbTestResult, setTmdbTestResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  const handleTestTmdb = async () => {
+    setIsTestingTmdb(true);
+    setTmdbTestResult(null);
+    try {
+      const data = await apiPost<{ success: boolean; message?: string }>(
+        "/api/settings/integrations/tmdb-test",
+        { apiKey: settings.tmdb_api_key ?? "" },
+      );
+      const message = data.message || (data.success ? "Connexion TMDB OK." : "Échec de la connexion TMDB.");
+      setTmdbTestResult({ success: data.success, message });
+      if (data.success) toast.success(message);
+      else toast.error(message);
+    } catch (error) {
+      const message = isClientFetchError(error)
+        ? error.errorMessage
+        : error instanceof Error
+          ? error.message
+          : "Échec de la connexion TMDB.";
+      setTmdbTestResult({ success: false, message });
+      toast.error(message);
+    } finally {
+      setIsTestingTmdb(false);
+    }
+  };
 
   // Load available models when provider changes
   useEffect(() => {
@@ -410,6 +440,73 @@ export function OllamaSettings() {
           </Card>
         </TabsContent>
       </Tabs>
+
+      {/* TMDB (movie/TV posters) */}
+      <Card>
+        <CardHeader>
+          <CardTitle>TMDB (affiches films/séries)</CardTitle>
+          <CardDescription>
+            The Movie Database API settings
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="tmdb_api_key">API Key</Label>
+            <Input
+              id="tmdb_api_key"
+              type="password"
+              value={settings.tmdb_api_key || ""}
+              onChange={(e) =>
+                setSettings({ ...settings, tmdb_api_key: e.target.value })
+              }
+              placeholder="TMDB API key"
+            />
+            <p className="text-sm text-muted-foreground">
+              Get your API key from{" "}
+              <a
+                href="https://www.themoviedb.org/settings/api"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                themoviedb.org
+              </a>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              This product uses the TMDB API but is not endorsed or certified by TMDB.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleTestTmdb}
+              disabled={isTestingTmdb || !settings.tmdb_api_key}
+            >
+              {isTestingTmdb ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Test en cours…
+                </>
+              ) : (
+                "Tester la connexion"
+              )}
+            </Button>
+
+            {tmdbTestResult && (
+              <div className="flex items-center gap-2 px-3 py-2 rounded border">
+                {tmdbTestResult.success ? (
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-red-500" />
+                )}
+                <span className="text-sm">{tmdbTestResult.message}</span>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Test & Save */}
       <div className="flex justify-between items-center">

--- a/hooks/useDataChangeRefetch.ts
+++ b/hooks/useDataChangeRefetch.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback } from "react";
+import { useWebSocketChannel } from "./useWebSocketChannel";
+import { CLIENT_ID } from "@/lib/utils/clientId";
+import { parseDataChangedEvent, type SyncEntity } from "@/lib/models/DataSyncEvents";
+
+/**
+ * Re-run `refetch` when another client OR a server-side process (e.g. the Live
+ * Assist backend creating a poster / text preset) changes `entity`.
+ *
+ * This is the local-state counterpart to {@link useDataSync}: useDataSync
+ * invalidates React Query caches, but components that hold their own fetched
+ * state (useState + apiGet) get nothing from a query invalidation. They use this
+ * instead. Changes originating from THIS tab are skipped (same clientId) — the
+ * tab's own mutation already refreshed its state.
+ */
+export function useDataChangeRefetch(entity: SyncEntity, refetch: () => void): void {
+  const onMessage = useCallback(
+    (data: unknown) => {
+      const event = parseDataChangedEvent(data);
+      if (!event) return;
+      if (event.entity !== entity) return;
+      if (event.clientId === CLIENT_ID) return;
+      refetch();
+    },
+    [entity, refetch],
+  );
+
+  useWebSocketChannel("system", onMessage);
+}

--- a/hooks/useDataSync.ts
+++ b/hooks/useDataSync.ts
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useWebSocketChannel } from "./useWebSocketChannel";
 import { queryKeys } from "@/lib/queries/queryKeys";
 import { CLIENT_ID } from "@/lib/utils/clientId";
-import type { DataChangedEvent, SyncEntity } from "@/lib/models/DataSyncEvents";
+import { parseDataChangedEvent, type SyncEntity } from "@/lib/models/DataSyncEvents";
 
 const ENTITY_QUERY_KEYS: Record<SyncEntity, readonly string[]> = {
   guests: queryKeys.guests.all,
@@ -27,8 +27,10 @@ export function useDataSync(): void {
 
   const onMessage = useCallback(
     (data: unknown) => {
-      const event = data as DataChangedEvent;
-      if (event.type !== "data-changed") return;
+      // The event arrives wrapped in an OverlayEvent ({ type, payload, ... }) — the
+      // real DataChangedEvent is nested under `.payload`. parseDataChangedEvent unwraps.
+      const event = parseDataChangedEvent(data);
+      if (!event) return;
       if (event.clientId === CLIENT_ID) return;
 
       const queryKey = ENTITY_QUERY_KEYS[event.entity];

--- a/lib/config/Constants.ts
+++ b/lib/config/Constants.ts
@@ -704,11 +704,59 @@ export const LIVE_ASSIST = {
   WINDOW_MAX_WAIT_MS: 20_000,
   /** Default faster-whisper model. */
   DEFAULT_WHISPER_MODEL: "large-v3",
-  /** Default keyword list per provider id. */
+  /** Default keyword list per provider id.
+   *  `poster` (Wikipedia) handles théâtre/concerts; `poster-tmdb` (TMDB) handles
+   *  films/séries. `affiche` is intentionally listed under BOTH so both become
+   *  candidates and the LLM disambiguates film-vs-théâtre via the context prompts. */
   DEFAULT_KEYWORDS: {
-    poster: ["spectacle", "affiche", "pièce", "film", "concert"],
+    poster: ["spectacle", "pièce", "affiche", "concert"],
+    "poster-tmdb": ["film", "série", "affiche"],
     definition: ["définition", "c'est quoi", "qu'est-ce que", "ça veut dire"],
   } as Record<string, string[]>,
+  /** The pre-split `poster` default, used only to detect & migrate untouched configs. */
+  LEGACY_POSTER_KEYWORDS: ["spectacle", "affiche", "pièce", "film", "concert"],
+  /** Default per-provider extraction guidance injected into the IntentExtractor prompt.
+   *  Each provider's prompt shapes how the entity is formed for ITS source. */
+  DEFAULT_CONTEXT_PROMPTS: {
+    poster:
+      "entité = titre exact du spectacle / pièce / concert (sans article) ; ajoute le type entre parenthèses pour viser le bon article Wikipédia : « Roméo et Juliette (pièce de théâtre) », « Les Vieilles Canailles (concert) ».",
+    "poster-tmdb":
+      "entité = titre du film / série. S'il est nommé, reprends-le tel quel (sans année ni article). S'il n'est PAS nommé mais identifiable d'après les indices (acteur, intrigue, réplique, époque), PROPOSE le titre le plus emblématique qui correspond — p. ex. « le film avec Sharon Stone » → « Basic Instinct », « le film de requins de Spielberg » → « Les Dents de la mer », « la série des Stranger » → « Stranger Things » — avec infere=true et une confiance reflétant ta certitude. Ne reste non actionnable QUE si vraiment aucun titre plausible ne ressort. Base TMDB (cinéma/séries), sans parenthèses.",
+    definition: "entité = le concept / sujet exact à définir, sans article.",
+  } as Record<string, string>,
+  /** Stricter confidence bar for a DEDUCED (inferred) entity, to limit false guesses
+   *  while still admitting a confident iconic match (a human validates anyway). */
+  INFERRED_CONFIDENCE_THRESHOLD: 0.7,
+  /** LocalPosters fast-path: match spoken words against existing poster titles (no LLM). */
+  LOCAL_POSTER_MIN_SIMILARITY: 0.8,
+  /** Only title tokens at least this long can trigger (drops noise words). */
+  LOCAL_POSTER_MIN_TOKEN_LEN: 4,
+  /** Small French stop-word set excluded from title triggers. */
+  LOCAL_POSTER_STOPWORDS_FR: [
+    "le", "la", "les", "un", "une", "des", "de", "du", "et", "ou", "au", "aux",
+    "ce", "ces", "cette", "son", "sa", "ses", "leur", "leurs", "dans", "pour",
+    "par", "sur", "avec", "sans", "que", "qui", "quoi",
+  ] as string[],
+} as const;
+
+// ============================================================================
+// TMDB (The Movie Database) — poster source for films / séries
+// ============================================================================
+
+/** TMDB v3 API config. The API key is read at runtime from the `tmdb_api_key` setting. */
+export const TMDB = {
+  /** REST API base (v3). */
+  API_BASE: "https://api.themoviedb.org/3",
+  /** Image CDN base; combine with a size + poster_path. */
+  IMAGE_BASE: "https://image.tmdb.org/t/p",
+  /** Poster size segment (w780 ≈ good balance of quality vs weight for a local asset). */
+  POSTER_SIZE: "w780",
+  /** Preferred result language (falls back to original metadata when missing). */
+  LANGUAGE: "fr-FR",
+  /** In-memory resolver cache TTL (ms). */
+  CACHE_TTL_MS: 6 * 60 * 60 * 1000,
+  /** Setting key holding the API key (mirrors `openai_api_key`). */
+  API_KEY_SETTING: "tmdb_api_key",
 } as const;
 
 // ============================================================================

--- a/lib/config/Constants.ts
+++ b/lib/config/Constants.ts
@@ -755,6 +755,8 @@ export const TMDB = {
   LANGUAGE: "fr-FR",
   /** In-memory resolver cache TTL (ms). */
   CACHE_TTL_MS: 6 * 60 * 60 * 1000,
+  /** Abort a TMDB request after this many ms (search + connection test). */
+  REQUEST_TIMEOUT_MS: 8000,
   /** Setting key holding the API key (mirrors `openai_api_key`). */
   API_KEY_SETTING: "tmdb_api_key",
 } as const;

--- a/lib/config/urls.ts
+++ b/lib/config/urls.ts
@@ -84,6 +84,21 @@ export const BACKEND_URL = process.env.BACKEND_URL || `${HTTP_PROTOCOL}://localh
 export const APP_URL = process.env.NEXT_PUBLIC_APP_URL || `${HTTP_PROTOCOL}://localhost:${APP_PORT}`;
 
 /**
+ * Internal loopback URL for server-to-server calls FROM the backend TO the
+ * Next.js app (e.g. the Live Assist providers creating a poster / text preset).
+ *
+ * Deliberately NOT `APP_URL`:
+ *  - Uses `127.0.0.1` (never `localhost`) to dodge Node 22's `localhost`→`::1`
+ *    resolution, which yields ECONNREFUSED / "fetch failed" when the dev server
+ *    listens on IPv4 only (mirrors the MCP server's config).
+ *  - Ignores `NEXT_PUBLIC_APP_URL` (which may point at a public host like
+ *    `https://edison:3000` that isn't a reliable loopback target).
+ * TLS cert mismatch on the loopback is tolerated by `NODE_TLS_REJECT_UNAUTHORIZED=0`
+ * in dev (set in `.env` / by `pnpm setup:https`).
+ */
+export const INTERNAL_APP_URL = process.env.INTERNAL_APP_URL || `${HTTP_PROTOCOL}://127.0.0.1:${APP_PORT}`;
+
+/**
  * WebSocket hub URL (ws:// or wss:// protocol)
  * Used by clients to connect to the WebSocket server
  */

--- a/lib/models/DataSyncEvents.ts
+++ b/lib/models/DataSyncEvents.ts
@@ -17,3 +17,25 @@ export interface DataChangedEvent {
   clientId: string;
   timestamp: number;
 }
+
+/**
+ * Extract a {@link DataChangedEvent} from a `system`-channel websocket message.
+ *
+ * The generic `ChannelManager.publish()` wraps the payload into an OverlayEvent
+ * (`{ channel, type, payload, timestamp, id }`), so the real DataChangedEvent
+ * lands under `.payload` — NOT at the top level. (Contrast `publishLiveAssist`,
+ * which spreads its event flat, which is why live-assist worked but data-sync
+ * silently didn't.) A flat event is also accepted defensively. Returns `null`
+ * when the message isn't a data-changed event.
+ */
+export function parseDataChangedEvent(data: unknown): DataChangedEvent | null {
+  if (!data || typeof data !== "object") return null;
+  const msg = data as Record<string, unknown>;
+  const inner =
+    msg.type === "data-changed" && msg.payload && typeof msg.payload === "object"
+      ? (msg.payload as Record<string, unknown>)
+      : msg;
+  if (inner.type !== "data-changed") return null;
+  if (typeof inner.entity !== "string" || typeof inner.clientId !== "string") return null;
+  return inner as unknown as DataChangedEvent;
+}

--- a/lib/models/LiveAssist.ts
+++ b/lib/models/LiveAssist.ts
@@ -40,16 +40,51 @@ export type SttDevice = z.infer<typeof SttDeviceSchema>;
 
 export const LiveAssistSettingsSchema = z.object({
   enabled: z.boolean().default(false),
+  /**
+   * Re-broadcast each finalized STT segment over the `live-assist` websocket so
+   * the panel can show a live "Transcription (debug)" view. Off by default: it's
+   * a debug aid, and broadcasting every segment to all subscribers is wasted
+   * fan-out when nobody is watching it.
+   */
+  transcriptDebug: z.boolean().default(false),
   inputDevice: z.string().nullable().default(null),
   whisperModel: z.string().default(LIVE_ASSIST.DEFAULT_WHISPER_MODEL),
   keywordsByProvider: z
     .record(z.string(), z.array(z.string()))
     .default(LIVE_ASSIST.DEFAULT_KEYWORDS),
+  /** Per-provider extraction guidance overriding the provider's default context prompt. */
+  contextPromptsByProvider: z.record(z.string(), z.string()).default({}),
+  /** LocalPosters: fuzzy-match spoken words against existing poster titles (no LLM). */
+  localPostersEnabled: z.boolean().default(true),
+  /** Similarity bar (0–1) for a local poster title match; higher = stricter. */
+  localPosterMinSimilarity: z.number().min(0).max(1).default(LIVE_ASSIST.LOCAL_POSTER_MIN_SIMILARITY),
   windowBeforeSec: z.number().int().nonnegative().default(LIVE_ASSIST.WINDOW_BEFORE_SEC),
   windowAfterSec: z.number().int().nonnegative().default(LIVE_ASSIST.WINDOW_AFTER_SEC),
   confidenceThreshold: z.number().min(0).max(1).default(LIVE_ASSIST.CONFIDENCE_THRESHOLD),
 });
 export type LiveAssistSettings = z.infer<typeof LiveAssistSettingsSchema>;
+
+/**
+ * Bring stored Live Assist settings forward to the current provider set without
+ * surprising the user:
+ *  (a) additively surface any default provider key missing from the stored map
+ *      (e.g. the `poster-tmdb` provider added after a config was first saved), and
+ *  (b) ONLY if the stored `poster` keywords are still the exact pre-split legacy
+ *      default, migrate them to the new split (film/série moved to `poster-tmdb`).
+ * A customised config is left untouched.
+ */
+export function migrateLiveAssistSettings(s: LiveAssistSettings): LiveAssistSettings {
+  const kw: Record<string, string[]> = { ...s.keywordsByProvider };
+  const eq = (a: string[] | undefined, b: readonly string[]) =>
+    !!a && a.length === b.length && a.every((v, i) => v === b[i]);
+  if (eq(kw.poster, LIVE_ASSIST.LEGACY_POSTER_KEYWORDS)) {
+    kw.poster = [...LIVE_ASSIST.DEFAULT_KEYWORDS.poster];
+  }
+  for (const [pid, words] of Object.entries(LIVE_ASSIST.DEFAULT_KEYWORDS)) {
+    if (!kw[pid]) kw[pid] = [...words];
+  }
+  return { ...s, keywordsByProvider: kw };
+}
 
 /** WebSocket event payloads on the `live-assist` channel. */
 export type LiveAssistEvent =

--- a/lib/services/SettingsService.ts
+++ b/lib/services/SettingsService.ts
@@ -25,7 +25,7 @@ import type { PresenterChannelSettings } from "../models/PresenterChannel";
 import type { ChatPredefinedMessage } from "../models/ChatMessages";
 import { StudioReturnSettingsSchema } from "../models/StudioReturn";
 import type { StudioReturnSettings, MonitorInfo } from "../models/StudioReturn";
-import { LiveAssistSettingsSchema } from "../models/LiveAssist";
+import { LiveAssistSettingsSchema, migrateLiveAssistSettings } from "../models/LiveAssist";
 import type { SttDevice, LiveAssistSettings } from "../models/LiveAssist";
 
 // ============================================================================
@@ -904,15 +904,28 @@ export class SettingsService {
   /**
    * Get Live Assist feature settings.
    * Falls back to schema defaults if nothing is stored yet.
+   *
+   * This is on the hot path (read live on every STT segment / tick so Settings
+   * saves apply without a restart). We still read the raw row from SQLite every
+   * call — cheap, and the source of truth across the backend/Next.js processes —
+   * but skip the JSON.parse + Zod parse + migration when the raw string is
+   * unchanged. Re-parsing is what's expensive, not the read.
    */
+  private liveAssistCache?: { raw: string; value: LiveAssistSettings };
+
   getLiveAssistSettings(): LiveAssistSettings {
+    const json = this.db.getSetting("liveAssist");
+    if (json && this.liveAssistCache?.raw === json) return this.liveAssistCache.value;
+    let value: LiveAssistSettings;
     try {
-      const json = this.db.getSetting("liveAssist");
-      if (json) return LiveAssistSettingsSchema.parse(JSON.parse(json));
+      value = json ? LiveAssistSettingsSchema.parse(JSON.parse(json)) : LiveAssistSettingsSchema.parse({});
     } catch {
       this.logger.warn("Failed to read/parse liveAssist settings, returning defaults");
+      return LiveAssistSettingsSchema.parse({});
     }
-    return LiveAssistSettingsSchema.parse({});
+    value = migrateLiveAssistSettings(value);
+    if (json) this.liveAssistCache = { raw: json, value };
+    return value;
   }
 
   /**
@@ -920,6 +933,7 @@ export class SettingsService {
    */
   saveLiveAssistSettings(settings: LiveAssistSettings): void {
     this.db.setSetting("liveAssist", JSON.stringify(settings));
+    this.liveAssistCache = undefined; // force a fresh parse on next read
     this.logger.info("Live Assist settings saved to database");
   }
 }

--- a/lib/services/TmdbResolverService.ts
+++ b/lib/services/TmdbResolverService.ts
@@ -86,7 +86,7 @@ export class TmdbResolverService {
     try {
       const res = await this.fetchImpl(
         `${TMDB.API_BASE}/configuration?api_key=${encodeURIComponent(apiKey)}`,
-        { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(8000) },
+        { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(TMDB.REQUEST_TIMEOUT_MS) },
       );
       if (res.ok) return { ok: true, message: "Connexion TMDB OK." };
       if (res.status === 401) return { ok: false, message: "Clé TMDB invalide (401)." };
@@ -119,7 +119,7 @@ export class TmdbResolverService {
 
     const res = await this.fetchImpl(url, {
       headers: { Accept: "application/json" },
-      signal: AbortSignal.timeout(8000),
+      signal: AbortSignal.timeout(TMDB.REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) throw new Error(`TMDB search failed (${res.status})`);
 

--- a/lib/services/TmdbResolverService.ts
+++ b/lib/services/TmdbResolverService.ts
@@ -1,0 +1,147 @@
+import { TMDB } from "@/lib/config/Constants";
+import { SettingsRepository } from "@/lib/repositories/SettingsRepository";
+
+/**
+ * Result shape compatible with the `Resolver` contract consumed by
+ * PosterActionProvider (`{ title, extract, thumbnail? }`). `source` is carried
+ * for parity with WikipediaResult but is not required by the contract.
+ */
+export interface TmdbResult {
+  title: string;
+  extract: string;
+  thumbnail?: string;
+  source: "tmdb";
+}
+
+/** Minimal subset of a TMDB /search/multi result we rely on. */
+interface TmdbMultiItem {
+  media_type?: string;
+  title?: string; // movies
+  name?: string; // tv
+  overview?: string;
+  poster_path?: string | null;
+  popularity?: number;
+}
+
+type CacheEntry = { value: TmdbResult; exp: number };
+
+/**
+ * Resolves a film / série title to its official TMDB poster + overview.
+ *
+ * TMDB is a cinema/TV-dedicated database, so it sidesteps the ambiguity that
+ * plagues Wikipedia ("Titanic" → the ship). Used by the `poster-tmdb` provider;
+ * théâtre / concerts / concepts keep using Wikipedia.
+ *
+ * The API key is read live from the `tmdb_api_key` setting (mirrors the
+ * openai/anthropic key pattern). When absent, resolveAndFetch throws so the
+ * provider's `resolveOrNull` simply yields no suggestion (graceful degradation).
+ */
+export class TmdbResolverService {
+  private static instance: TmdbResolverService;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly now: () => number;
+  private readonly fetchImpl: typeof fetch;
+
+  private constructor(opts: { now?: () => number; fetchImpl?: typeof fetch } = {}) {
+    this.now = opts.now ?? Date.now;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  static getInstance(): TmdbResolverService {
+    if (!TmdbResolverService.instance) {
+      TmdbResolverService.instance = new TmdbResolverService();
+    }
+    return TmdbResolverService.instance;
+  }
+
+  /** Test seam: build an isolated instance with injected clock / fetch. */
+  static createForTest(opts: { now?: () => number; fetchImpl?: typeof fetch }): TmdbResolverService {
+    return new TmdbResolverService(opts);
+  }
+
+  private getApiKey(): string {
+    const key = SettingsRepository.getInstance().getSetting(TMDB.API_KEY_SETTING);
+    if (!key) throw new Error("TMDB API key not configured");
+    return key;
+  }
+
+  /** Read the stored key without throwing (empty string when unset). */
+  private peekApiKey(): string {
+    try {
+      return this.getApiKey();
+    } catch {
+      return "";
+    }
+  }
+
+  /**
+   * Validate a TMDB API key against the lightweight `/configuration` endpoint.
+   * Uses the provided key (the value typed in Settings, possibly unsaved) or, if
+   * none is given, the stored key. Returns a friendly result instead of throwing
+   * so the Settings "Test connection" button can show success/failure inline.
+   */
+  async testConnection(apiKeyOverride?: string): Promise<{ ok: boolean; message: string }> {
+    const apiKey = (apiKeyOverride ?? "").trim() || this.peekApiKey();
+    if (!apiKey) return { ok: false, message: "Aucune clé TMDB renseignée." };
+    try {
+      const res = await this.fetchImpl(
+        `${TMDB.API_BASE}/configuration?api_key=${encodeURIComponent(apiKey)}`,
+        { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(8000) },
+      );
+      if (res.ok) return { ok: true, message: "Connexion TMDB OK." };
+      if (res.status === 401) return { ok: false, message: "Clé TMDB invalide (401)." };
+      return { ok: false, message: `TMDB a répondu ${res.status}.` };
+    } catch (error) {
+      return { ok: false, message: error instanceof Error ? error.message : "Échec réseau TMDB." };
+    }
+  }
+
+  /**
+   * Search TMDB for a film/série and return its title, overview and poster URL.
+   * Throws when no key is configured or no movie/tv match is found.
+   */
+  async resolveAndFetch(query: string): Promise<TmdbResult> {
+    const q = query.trim();
+    if (!q) throw new Error("empty query");
+
+    const cached = this.cache.get(q.toLowerCase());
+    if (cached && cached.exp > this.now()) return cached.value;
+
+    const apiKey = this.getApiKey();
+    const url =
+      `${TMDB.API_BASE}/search/multi?` +
+      new URLSearchParams({
+        api_key: apiKey,
+        query: q,
+        language: TMDB.LANGUAGE,
+        include_adult: "false",
+      }).toString();
+
+    const res = await this.fetchImpl(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) throw new Error(`TMDB search failed (${res.status})`);
+
+    const data = (await res.json()) as { results?: TmdbMultiItem[] };
+    const candidates = (data.results ?? [])
+      .filter((r) => r.media_type === "movie" || r.media_type === "tv")
+      .sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0));
+
+    const best = candidates[0];
+    if (!best) throw new Error(`no TMDB film/série result for "${q}"`);
+
+    const title = (best.title || best.name || q).trim();
+    const result: TmdbResult = {
+      title,
+      extract: (best.overview || "").trim(),
+      thumbnail: best.poster_path
+        ? `${TMDB.IMAGE_BASE}/${TMDB.POSTER_SIZE}${best.poster_path}`
+        : undefined,
+      source: "tmdb",
+    };
+
+    this.cache.set(q.toLowerCase(), { value: result, exp: this.now() + TMDB.CACHE_TTL_MS });
+    return result;
+  }
+}

--- a/lib/services/liveassist/IntentExtractor.ts
+++ b/lib/services/liveassist/IntentExtractor.ts
@@ -10,6 +10,8 @@ export type IntentExtraction = {
   intent: string;
   entite: string;
   confiance: number;
+  /** True when the entity was DEDUCED from clues (not explicitly named); gated stricter. */
+  infere: boolean;
 };
 
 export type GenerateObjectFn = (args: {
@@ -17,7 +19,7 @@ export type GenerateObjectFn = (args: {
   prompt: string;
 }) => Promise<{ object: unknown }>;
 
-const NOT_ACTIONNABLE: IntentExtraction = { actionnable: false, intent: "none", entite: "", confiance: 0 };
+const NOT_ACTIONNABLE: IntentExtraction = { actionnable: false, intent: "none", entite: "", confiance: 0, infere: false };
 
 const defaultGenerate: GenerateObjectFn = ({ schema, prompt }) =>
   generateObject({ model: createAiModel(), schema, prompt });
@@ -25,11 +27,15 @@ const defaultGenerate: GenerateObjectFn = ({ schema, prompt }) =>
 export class IntentExtractor {
   private readonly schema: z.ZodTypeAny;
 
+  private contextPrompts: Record<string, string>;
+
   constructor(
     providerIds: string[],
     private readonly descriptions: Record<string, string>,
     private readonly generate: GenerateObjectFn = defaultGenerate,
+    contextPrompts: Record<string, string> = {},
   ) {
+    this.contextPrompts = contextPrompts;
     this.schema = z.object({
       actionnable: z.boolean(),
       // "none" first so TS infers [string, ...string[]] (a leading spread infers [...string[], string], which won't cast).
@@ -39,12 +45,26 @@ export class IntentExtractor {
       // mode) requires every property in `required` and rejects unsupported keywords.
       // The confidence range is enforced by the orchestrator's threshold check instead.
       confiance: z.number(),
+      // True when entite was DEDUCED from clues rather than explicitly named.
+      infere: z.boolean(),
     });
   }
 
+  /** Replace the per-provider context prompts (called when Settings change, live). */
+  setContextPrompts(contextPrompts: Record<string, string>): void {
+    this.contextPrompts = contextPrompts;
+  }
+
   async extract(windowText: string, candidateProviderIds: string[]): Promise<IntentExtraction> {
+    // Each candidate contributes its description plus, when present, an adapted
+    // "Règle" telling the model how to form the entity for THAT source (Wikipedia
+    // théâtre vs TMDB cinéma vs definition). This replaces the old hard-coded
+    // poster rule so a new provider is fully described by its own config.
     const catalogue = candidateProviderIds
-      .map((id) => `- ${id} : ${this.descriptions[id] ?? id}`)
+      .map((id) => {
+        const rule = this.contextPrompts[id];
+        return `- ${id} : ${this.descriptions[id] ?? id}${rule ? `\n    Règle : ${rule}` : ""}`;
+      })
       .join("\n");
 
     const prompt = [
@@ -54,10 +74,11 @@ export class IntentExtractor {
       `INTENTS CANDIDATS :\n${catalogue}`,
       "",
       "Règles :",
-      "- Si une entité claire correspondant à un intent candidat est citée (p. ex. un titre de film / spectacle / pièce / concert pour « poster » ; un sujet à définir pour « definition ») → actionnable=true, intent = l'id exact de l'intent candidat, entite = le titre/sujet exact sans article. Pour « poster », ajoute le type entre parenthèses pour viser le bon article Wikipédia : « Titanic (film) », « Roméo et Juliette (pièce de théâtre) », « Les Bronzés font du ski (film) ».",
+      "- Si une entité correspondant à un intent candidat est citée — OU, lorsque sa « Règle » l'autorise, déductible des indices — → actionnable=true, intent = l'id exact de l'intent candidat, entite = l'entité formée selon la « Règle » de cet intent.",
       '- Sinon (rien de clair, trop vague, ou hors-sujet) → actionnable=false, intent="none", entite="".',
       '- N\'utilise JAMAIS intent="none" lorsque actionnable=true.',
       "- confiance ∈ [0,1] = ta certitude.",
+      "- infere = true UNIQUEMENT si tu as DÉDUIT l'entité (non nommée explicitement, devinée d'après les indices) ; false si elle était citée telle quelle.",
       "",
       `Transcription :\n"""${windowText}"""`,
     ].join("\n");

--- a/lib/services/liveassist/IntentExtractor.ts
+++ b/lib/services/liveassist/IntentExtractor.ts
@@ -85,7 +85,13 @@ export class IntentExtractor {
 
     try {
       const { object } = await this.generate({ schema: this.schema, prompt });
-      const parsed = this.schema.safeParse(object);
+      // Default `infere` to false when the model omitted it: non-strict providers
+      // (e.g. a local Ollama model) may not honor the required field, and its
+      // absence alone shouldn't collapse an otherwise-valid extraction back to
+      // NOT_ACTIONNABLE (the pre-`infere` behavior). Other required fields stay enforced.
+      const candidate =
+        object && typeof object === "object" ? { infere: false, ...(object as object) } : object;
+      const parsed = this.schema.safeParse(candidate);
       if (!parsed.success) return NOT_ACTIONNABLE;
       const result = parsed.data as IntentExtraction;
       // Only act on an intent that was a candidate for THIS window.

--- a/lib/services/liveassist/KeywordDetector.ts
+++ b/lib/services/liveassist/KeywordDetector.ts
@@ -2,7 +2,9 @@ import type { TranscriptSegment } from "@/lib/models/LiveAssist";
 
 export type KeywordHit = { providerId: string; keyword: string; tHit: number };
 
-const norm = (s: string) =>
+/** Normalize transcript/keyword text: lowercase, strip accents, fold apostrophes.
+ *  Shared with the LocalPosterMatcher so both match on the same normalized form. */
+export const norm = (s: string) =>
   s
     .toLowerCase()
     .normalize("NFD")

--- a/lib/services/liveassist/LiveAssistOrchestrator.ts
+++ b/lib/services/liveassist/LiveAssistOrchestrator.ts
@@ -7,6 +7,7 @@ import { KeywordDetector } from "./KeywordDetector";
 import { WindowScheduler } from "./WindowScheduler";
 import { SuggestionStore } from "./SuggestionStore";
 import { ProviderRegistry } from "./providers/ActionProvider";
+import type { BuiltSuggestion } from "./providers/ActionProvider";
 import type { IntentExtractor } from "./IntentExtractor";
 
 const logger = new Logger("LiveAssistOrchestrator");
@@ -25,8 +26,23 @@ interface Deps {
   getSettings: () => { windowBeforeSec: number; windowAfterSec: number; confidenceThreshold: number };
   now?: () => number;
   isEnabled?: () => boolean;
+  /**
+   * Gate the live transcript re-broadcast (the panel's "Transcription (debug)"
+   * view). Read live so Settings saves take effect without a backend restart.
+   * When off, no `transcript` event is published — the websocket isn't loaded
+   * for a view nobody is watching.
+   */
+  isTranscriptDebugEnabled?: () => boolean;
   publishStatus?: (connected: boolean, device: string | null) => void;
   publishTranscript?: (text: string, t0: number, t1: number) => void;
+  /** Map a device id (e.g. "1") to its human label (e.g. "USB Mic") for status display. */
+  resolveDeviceLabel?: (id: string) => string;
+  /**
+   * Non-LLM fast-path: fuzzy-match a finalized segment against existing poster
+   * titles and return ready-to-store suggestions. Runs per segment (no window,
+   * no extractor). Returns [] when disabled.
+   */
+  matchLocalPosters?: (text: string) => BuiltSuggestion[];
   staleMs?: number;
 }
 
@@ -34,21 +50,30 @@ export class LiveAssistOrchestrator {
   private status = { connected: false, device: null as string | null };
   private readonly now: () => number;
   private readonly isEnabled: () => boolean;
+  private readonly isTranscriptDebugEnabled: () => boolean;
   private readonly publishStatus: (connected: boolean, device: string | null) => void;
   private readonly publishTranscript: (text: string, t0: number, t1: number) => void;
+  private readonly resolveDeviceLabel: (id: string) => string;
   private readonly staleMs: number;
   private lastSeenAt = 0;
 
   constructor(private readonly deps: Deps) {
     this.now = deps.now ?? Date.now;
     this.isEnabled = deps.isEnabled ?? (() => true);
+    this.isTranscriptDebugEnabled = deps.isTranscriptDebugEnabled ?? (() => true);
     this.publishStatus = deps.publishStatus ?? (() => undefined);
     this.publishTranscript = deps.publishTranscript ?? (() => undefined);
+    this.resolveDeviceLabel = deps.resolveDeviceLabel ?? ((id) => id);
     this.staleMs = deps.staleMs ?? LIVE_ASSIST.STT_STALE_MS;
   }
 
+  /** Resolve a device id to its label; null/empty stays null. */
+  private labelFor(device: string | null): string | null {
+    return device ? this.resolveDeviceLabel(device) : null;
+  }
+
   setSttStatus(connected: boolean, device: string | null): void {
-    this.status = { connected, device };
+    this.status = { connected, device: this.labelFor(device) };
   }
   getStatus() {
     return { ...this.status };
@@ -62,7 +87,7 @@ export class LiveAssistOrchestrator {
    */
   markSttAlive(device?: string | null): void {
     this.lastSeenAt = this.now();
-    if (device != null) this.status.device = device;
+    if (device != null) this.status.device = this.labelFor(device);
     if (!this.status.connected) {
       this.status.connected = true;
       this.publishStatus(true, this.status.device);
@@ -91,8 +116,12 @@ export class LiveAssistOrchestrator {
     if (!segment.final) return;
     if (!this.isEnabled()) return;
     this.markSttAlive();
-    this.publishTranscript(segment.text, segment.t0, segment.t1);
+    if (this.isTranscriptDebugEnabled()) this.publishTranscript(segment.text, segment.t0, segment.t1);
     this.deps.buffer.append(segment);
+    // Non-LLM fast-path: a directly-named local poster fires immediately, no window.
+    for (const built of this.deps.matchLocalPosters?.(segment.text) ?? []) {
+      this.deps.store.add(built);
+    }
     for (const hit of this.deps.detector.scan(segment)) {
       this.deps.scheduler.register(hit, this.now());
     }
@@ -125,8 +154,21 @@ export class LiveAssistOrchestrator {
       `extraction: actionnable=${extraction.actionnable} intent=${extraction.intent} entite="${extraction.entite}" confiance=${extraction.confiance}`,
     );
 
-    if (!extraction.actionnable || extraction.confiance < confidenceThreshold) {
-      logger.info(`→ dropped (actionnable=${extraction.actionnable}, confiance ${extraction.confiance} < threshold ${confidenceThreshold})`);
+    // Report the ACTUAL drop reason — these are two distinct gates, and lumping
+    // them together printed a nonsense "confiance 0.9 < threshold 0.6".
+    if (!extraction.actionnable) {
+      logger.info(`→ dropped (non actionnable; confiance ${extraction.confiance})`);
+      return;
+    }
+    // A DEDUCED entity (the title wasn't named, the LLM guessed it) is gated behind a
+    // stricter bar to limit wrong guesses; an explicitly-cited entity uses the normal seuil.
+    const minConfiance = extraction.infere
+      ? Math.max(confidenceThreshold, LIVE_ASSIST.INFERRED_CONFIDENCE_THRESHOLD)
+      : confidenceThreshold;
+    if (extraction.confiance < minConfiance) {
+      logger.info(
+        `→ dropped (confiance ${extraction.confiance} < seuil ${minConfiance}${extraction.infere ? " [déduit]" : ""})`,
+      );
       return;
     }
 

--- a/lib/services/liveassist/LocalPosterMatcher.ts
+++ b/lib/services/liveassist/LocalPosterMatcher.ts
@@ -9,6 +9,13 @@ export interface MatchablePoster {
   fileUrl: string;
   type: string;
   thumbnailUrl?: string | null;
+  // Sub-video clip fields, forwarded into the show payload so a matched video clip
+  // honors its saved range/chapters instead of playing the raw file from the start
+  // (parity with the dashboard PosterCard show path). A raw Poster row satisfies these.
+  startTime?: number | null;
+  endTime?: number | null;
+  endBehavior?: "stop" | "loop" | null;
+  metadata?: Record<string, unknown> | null;
 }
 
 export interface PosterMatch {
@@ -60,10 +67,17 @@ export class LocalPosterMatcher {
     const matches: PosterMatch[] = [];
     for (const { poster, tokens } of this.index) {
       let best = 0;
-      for (const token of tokens) {
+      outer: for (const token of tokens) {
         for (const word of words) {
+          // Cheap upper bound: similarity ≤ 1 − |Δlen|/maxLen (since Levenshtein ≥ |Δlen|).
+          // Skip the O(len²) edit-distance DP whenever the lengths alone can't clear the bar.
+          const maxLen = Math.max(token.length, word.length);
+          if (1 - Math.abs(token.length - word.length) / maxLen < this.minSimilarity) continue;
           const s = similarity(token, word);
-          if (s > best) best = s;
+          if (s > best) {
+            best = s;
+            if (best >= 1) break outer; // exact match — no pair can beat it
+          }
         }
       }
       if (best >= this.minSimilarity) matches.push({ poster, score: best });

--- a/lib/services/liveassist/LocalPosterMatcher.ts
+++ b/lib/services/liveassist/LocalPosterMatcher.ts
@@ -1,0 +1,73 @@
+import { norm } from "./KeywordDetector";
+import { similarity } from "@/lib/utils/fuzzyMatch";
+import { LIVE_ASSIST } from "@/lib/config/Constants";
+
+/** Minimal poster shape the matcher needs (decoupled from the DB row). */
+export interface MatchablePoster {
+  id: string;
+  title: string;
+  fileUrl: string;
+  type: string;
+  thumbnailUrl?: string | null;
+}
+
+export interface PosterMatch {
+  poster: MatchablePoster;
+  score: number;
+}
+
+const STOPWORDS = new Set(LIVE_ASSIST.LOCAL_POSTER_STOPWORDS_FR);
+
+/** Split already-normalized text into alphanumeric tokens. */
+function tokenize(normalized: string): string[] {
+  return normalized.split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+/** Distinctive title tokens eligible to trigger a match (long enough, not a stop-word). */
+function triggerTokens(title: string): string[] {
+  return tokenize(norm(title)).filter(
+    (t) => t.length >= LIVE_ASSIST.LOCAL_POSTER_MIN_TOKEN_LEN && !STOPWORDS.has(t),
+  );
+}
+
+/**
+ * Fuzzy-matches transcript text against the titles of existing posters, so the
+ * Live Assist fast-path can suggest a poster the host just named — without the LLM.
+ *
+ * Matching is token-level: each distinctive word of a poster title is compared
+ * (Levenshtein similarity) against each spoken word. A poster matches on its best
+ * token/word pair clearing `minSimilarity`. Titles whose only tokens are short or
+ * stop-words (e.g. "Le Roi") cannot trigger.
+ */
+export class LocalPosterMatcher {
+  private index: { poster: MatchablePoster; tokens: string[] }[] = [];
+  private minSimilarity: number = LIVE_ASSIST.LOCAL_POSTER_MIN_SIMILARITY;
+  private readonly maxMatches = 3;
+
+  /** Rebuild the index from the current posters (live refresh). */
+  setPosters(posters: MatchablePoster[], minSimilarity: number = LIVE_ASSIST.LOCAL_POSTER_MIN_SIMILARITY): void {
+    this.minSimilarity = minSimilarity;
+    this.index = posters
+      .map((poster) => ({ poster, tokens: triggerTokens(poster.title) }))
+      .filter((e) => e.tokens.length > 0);
+  }
+
+  /** Best fuzzy poster matches for a transcript segment — one entry per poster, best score first. */
+  match(text: string): PosterMatch[] {
+    const words = tokenize(norm(text));
+    if (words.length === 0) return [];
+
+    const matches: PosterMatch[] = [];
+    for (const { poster, tokens } of this.index) {
+      let best = 0;
+      for (const token of tokens) {
+        for (const word of words) {
+          const s = similarity(token, word);
+          if (s > best) best = s;
+        }
+      }
+      if (best >= this.minSimilarity) matches.push({ poster, score: best });
+    }
+    return matches.sort((a, b) => b.score - a.score).slice(0, this.maxMatches);
+  }
+}

--- a/lib/services/liveassist/SuggestionStore.ts
+++ b/lib/services/liveassist/SuggestionStore.ts
@@ -42,6 +42,11 @@ export class SuggestionStore {
     return [...this.items];
   }
 
+  /** Fetch a single stored suggestion by id (used by the authoritative apply route). */
+  get(id: string): Suggestion | undefined {
+    return this.items.find((s) => s.id === id);
+  }
+
   setStatus(id: string, status: Suggestion["status"]): Suggestion | undefined {
     const s = this.items.find((x) => x.id === id);
     if (!s) return undefined;

--- a/lib/services/liveassist/providers/ActionProvider.ts
+++ b/lib/services/liveassist/providers/ActionProvider.ts
@@ -8,6 +8,8 @@ export interface ActionProvider {
   id: string;
   description: string;
   defaultKeywords: string[];
+  /** Per-provider extraction guidance injected into the IntentExtractor prompt (the "Règle"). */
+  defaultContextPrompt?: string;
   build(entity: string, window: TranscriptWindow): Promise<BuiltSuggestion | null>;
   apply(payload: Record<string, unknown>): Promise<ApplyResult>;
 }
@@ -29,5 +31,13 @@ export class ProviderRegistry {
   }
   descriptions(): Record<string, string> {
     return Object.fromEntries(this.all().map((p) => [p.id, p.description]));
+  }
+  /** Per-provider default context prompts (only providers that declare one). */
+  contextPrompts(): Record<string, string> {
+    return Object.fromEntries(
+      this.all()
+        .filter((p) => p.defaultContextPrompt)
+        .map((p) => [p.id, p.defaultContextPrompt as string]),
+    );
   }
 }

--- a/lib/services/liveassist/providers/DefinitionActionProvider.ts
+++ b/lib/services/liveassist/providers/DefinitionActionProvider.ts
@@ -5,6 +5,7 @@ import { resolveOrNull, type Resolver } from "./PosterActionProvider";
 
 const logger = new Logger("DefinitionActionProvider");
 export type OnAir = (text: string) => Promise<ApplyResult>;
+export type TextPresetCreator = (input: { name: string; body: string }) => Promise<ApplyResult>;
 
 /** Keep the first `n` sentences of an extract (cheap, no extra LLM call). */
 function firstSentences(text: string, n: number): string {
@@ -16,10 +17,12 @@ export class DefinitionActionProvider implements ActionProvider {
   readonly id = "definition";
   readonly description = "Donner une définition / du contexte sur un sujet évoqué";
   readonly defaultKeywords = LIVE_ASSIST.DEFAULT_KEYWORDS.definition;
+  readonly defaultContextPrompt = LIVE_ASSIST.DEFAULT_CONTEXT_PROMPTS.definition;
 
   constructor(
     private readonly resolver: Resolver,
     private readonly onAir: OnAir,
+    private readonly createTextPreset: TextPresetCreator,
     private readonly maxSentences = 3,
   ) {}
 
@@ -33,7 +36,8 @@ export class DefinitionActionProvider implements ActionProvider {
       title: result.title,
       preview: { kind: "text", text },
       triggerExcerpt: window.text,
-      applyPayload: { target: "pin", text },
+      // `name` lets apply() title the text preset after the subject.
+      applyPayload: { target: "pin", text, name: result.title },
       confidence: 0,
     };
   }
@@ -41,8 +45,11 @@ export class DefinitionActionProvider implements ActionProvider {
   async apply(payload: Record<string, unknown>): Promise<ApplyResult> {
     const target = payload.target === "on-air" ? "on-air" : "pin";
     const text = typeof payload.text === "string" ? payload.text : "";
-    if (target === "pin") return { ok: true };
     if (!text) return { ok: false, message: "Texte vide." };
-    return this.onAir(text);
+    // "Diffuser" → show on the lower-third now; "Valider" (pin) → save a reusable
+    // « texte rapide » (text preset) titled after the subject.
+    if (target === "on-air") return this.onAir(text);
+    const name = typeof payload.name === "string" && payload.name.trim() ? payload.name.trim() : text.slice(0, 80);
+    return this.createTextPreset({ name, body: text });
   }
 }

--- a/lib/services/liveassist/providers/LocalPosterProvider.ts
+++ b/lib/services/liveassist/providers/LocalPosterProvider.ts
@@ -1,0 +1,64 @@
+import type { ActionProvider, ApplyResult, BuiltSuggestion } from "./ActionProvider";
+import type { MatchablePoster } from "../LocalPosterMatcher";
+
+/** Shows an existing poster on the program overlay on the given side. */
+export type PosterShower = (payload: {
+  posterId: string;
+  fileUrl: string;
+  type: string;
+  side: "left" | "right";
+  transition: "fade";
+}) => Promise<ApplyResult>;
+
+/** Ensures a poster is enabled (so it appears in the Affiches panel). */
+export type PosterEnabler = (posterId: string) => Promise<ApplyResult>;
+
+/**
+ * Surfaces a poster ALREADY in the library when the host names it, and shows it
+ * on the poster overlay on validate. Unlike the Wikipedia/TMDB providers it does
+ * NOT create a poster — and its suggestions come from the fuzzy fast-path
+ * (LocalPosterMatcher in the orchestrator's ingestSegment), not the LLM, so
+ * `build()` is unused.
+ */
+export class LocalPosterProvider implements ActionProvider {
+  readonly id = "local-poster";
+  readonly description = "Afficher une affiche déjà présente dans la bibliothèque, citée en direct";
+  readonly defaultKeywords: string[] = [];
+
+  constructor(
+    private readonly showPoster: PosterShower,
+    private readonly enablePoster: PosterEnabler,
+  ) {}
+
+  /** Unused: LocalPoster suggestions are produced by the fast-path matcher, not the LLM. */
+  async build(): Promise<BuiltSuggestion | null> {
+    return null;
+  }
+
+  /** Build a suggestion directly from a fuzzy-matched poster. */
+  static toSuggestion(poster: MatchablePoster, triggerText: string, score: number): BuiltSuggestion {
+    const imageUrl = poster.thumbnailUrl ?? (poster.type === "image" ? poster.fileUrl : undefined);
+    return {
+      intent: "local-poster",
+      entity: poster.id, // stable dedup key
+      title: poster.title,
+      preview: imageUrl ? { kind: "image", imageUrl } : { kind: "text", text: `🖼️ ${poster.title}` },
+      triggerExcerpt: triggerText,
+      applyPayload: { posterId: poster.id, fileUrl: poster.fileUrl, type: poster.type },
+      confidence: Math.max(0, Math.min(1, score)),
+    };
+  }
+
+  async apply(payload: Record<string, unknown>): Promise<ApplyResult> {
+    const posterId = typeof payload.posterId === "string" ? payload.posterId : "";
+    const fileUrl = typeof payload.fileUrl === "string" ? payload.fileUrl : "";
+    const type = typeof payload.type === "string" ? payload.type : "image";
+    if (!fileUrl) return { ok: false, message: "Affiche introuvable." };
+    // `target` carries the chosen side (the only client-trusted field).
+    const side = payload.target === "right" ? "right" : "left";
+    // Add it to the Affiches panel: ensure the poster is enabled (idempotent) before
+    // showing it — a matched poster may be disabled in the library.
+    if (posterId) await this.enablePoster(posterId);
+    return this.showPoster({ posterId, fileUrl, type, side, transition: "fade" });
+  }
+}

--- a/lib/services/liveassist/providers/LocalPosterProvider.ts
+++ b/lib/services/liveassist/providers/LocalPosterProvider.ts
@@ -8,6 +8,12 @@ export type PosterShower = (payload: {
   type: string;
   side: "left" | "right";
   transition: "fade";
+  // Sub-video clip fields (only set for a matched video clip) — accepted by
+  // posterShowPayloadSchema and honored by the overlay.
+  startTime?: number;
+  endTime?: number;
+  endBehavior?: "stop" | "loop";
+  chapters?: unknown[];
 }) => Promise<ApplyResult>;
 
 /** Ensures a poster is enabled (so it appears in the Affiches panel). */
@@ -38,13 +44,27 @@ export class LocalPosterProvider implements ActionProvider {
   /** Build a suggestion directly from a fuzzy-matched poster. */
   static toSuggestion(poster: MatchablePoster, triggerText: string, score: number): BuiltSuggestion {
     const imageUrl = poster.thumbnailUrl ?? (poster.type === "image" ? poster.fileUrl : undefined);
+    const applyPayload: Record<string, unknown> = {
+      posterId: poster.id,
+      fileUrl: poster.fileUrl,
+      type: poster.type,
+    };
+    // Carry the saved sub-video clip range/chapters so applying a matched clip honors
+    // its bounds instead of playing the raw file from the start (parity with PosterCard).
+    if (poster.type === "video") {
+      if (poster.startTime != null) applyPayload.startTime = poster.startTime;
+      if (poster.endTime != null) applyPayload.endTime = poster.endTime;
+      if (poster.endBehavior) applyPayload.endBehavior = poster.endBehavior;
+      const chapters = (poster.metadata as { chapters?: unknown } | null | undefined)?.chapters;
+      if (Array.isArray(chapters) && chapters.length) applyPayload.chapters = chapters;
+    }
     return {
       intent: "local-poster",
       entity: poster.id, // stable dedup key
       title: poster.title,
       preview: imageUrl ? { kind: "image", imageUrl } : { kind: "text", text: `🖼️ ${poster.title}` },
       triggerExcerpt: triggerText,
-      applyPayload: { posterId: poster.id, fileUrl: poster.fileUrl, type: poster.type },
+      applyPayload,
       confidence: Math.max(0, Math.min(1, score)),
     };
   }
@@ -59,6 +79,12 @@ export class LocalPosterProvider implements ActionProvider {
     // Add it to the Affiches panel: ensure the poster is enabled (idempotent) before
     // showing it — a matched poster may be disabled in the library.
     if (posterId) await this.enablePoster(posterId);
-    return this.showPoster({ posterId, fileUrl, type, side, transition: "fade" });
+    // Forward the sub-video clip fields the suggestion carried (absent for images).
+    const clip: { startTime?: number; endTime?: number; endBehavior?: "stop" | "loop"; chapters?: unknown[] } = {};
+    if (typeof payload.startTime === "number") clip.startTime = payload.startTime;
+    if (typeof payload.endTime === "number") clip.endTime = payload.endTime;
+    if (payload.endBehavior === "stop" || payload.endBehavior === "loop") clip.endBehavior = payload.endBehavior;
+    if (Array.isArray(payload.chapters)) clip.chapters = payload.chapters;
+    return this.showPoster({ posterId, fileUrl, type, side, transition: "fade", ...clip });
   }
 }

--- a/lib/services/liveassist/providers/PosterActionProvider.ts
+++ b/lib/services/liveassist/providers/PosterActionProvider.ts
@@ -23,12 +23,31 @@ export async function resolveOrNull(
   }
 }
 
-export class PosterActionProvider implements ActionProvider {
-  readonly id = "poster";
-  readonly description = "Trouver l'affiche d'un spectacle/film/concert cité et l'ajouter aux posters";
-  readonly defaultKeywords = LIVE_ASSIST.DEFAULT_KEYWORDS.poster;
+/** Per-instance configuration so one class serves multiple sources (Wikipedia, TMDB, …). */
+export type PosterProviderOptions = {
+  id?: string;
+  description?: string;
+  defaultKeywords?: string[];
+  defaultContextPrompt?: string;
+};
 
-  constructor(private readonly resolver: Resolver, private readonly createPoster: PosterCreator) {}
+export class PosterActionProvider implements ActionProvider {
+  readonly id: string;
+  readonly description: string;
+  readonly defaultKeywords: string[];
+  readonly defaultContextPrompt?: string;
+
+  constructor(
+    private readonly resolver: Resolver,
+    private readonly createPoster: PosterCreator,
+    opts: PosterProviderOptions = {},
+  ) {
+    this.id = opts.id ?? "poster";
+    this.description =
+      opts.description ?? "Trouver l'affiche d'un spectacle/pièce/concert cité et l'ajouter aux posters";
+    this.defaultKeywords = opts.defaultKeywords ?? LIVE_ASSIST.DEFAULT_KEYWORDS.poster;
+    this.defaultContextPrompt = opts.defaultContextPrompt ?? LIVE_ASSIST.DEFAULT_CONTEXT_PROMPTS.poster;
+  }
 
   async build(entity: string, window: TranscriptWindow): Promise<BuiltSuggestion | null> {
     const result = await resolveOrNull(this.resolver, entity, logger);

--- a/lib/stores/liveAssistStore.ts
+++ b/lib/stores/liveAssistStore.ts
@@ -2,11 +2,20 @@ import { create } from "zustand";
 import { LIVE_ASSIST } from "@/lib/config/Constants";
 import type { Suggestion } from "@/lib/models/LiveAssist";
 
+/** A live transcript line with a stable id (the list is prepended, so the array
+ *  index is NOT a stable React key). */
+export interface TranscriptLine {
+  id: number;
+  text: string;
+}
+
 interface LiveAssistState {
   suggestions: Suggestion[];
   status: { connected: boolean; device: string | null };
   /** Rolling live transcript (newest first), for debugging what the STT hears. */
-  transcripts: string[];
+  transcripts: TranscriptLine[];
+  /** Monotonic counter backing the transcript line ids. */
+  transcriptSeq: number;
   setAll: (s: Suggestion[]) => void;
   upsert: (s: Suggestion) => void;
   updateStatus: (id: string, status: Suggestion["status"]) => void;
@@ -18,6 +27,7 @@ export const useLiveAssistStore = create<LiveAssistState>((set) => ({
   suggestions: [],
   status: { connected: false, device: null },
   transcripts: [],
+  transcriptSeq: 0,
   setAll: (suggestions) => set({ suggestions }),
   upsert: (s) =>
     set((st) => ({
@@ -26,5 +36,9 @@ export const useLiveAssistStore = create<LiveAssistState>((set) => ({
   updateStatus: (id, status) =>
     set((st) => ({ suggestions: st.suggestions.map((x) => (x.id === id ? { ...x, status } : x)) })),
   setStatusBar: (connected, device) => set({ status: { connected, device } }),
-  addTranscript: (text) => set((st) => ({ transcripts: [text, ...st.transcripts].slice(0, 50) })),
+  addTranscript: (text) =>
+    set((st) => {
+      const id = st.transcriptSeq + 1;
+      return { transcripts: [{ id, text }, ...st.transcripts].slice(0, 50), transcriptSeq: id };
+    }),
 }));

--- a/lib/utils/downloadToLocal.ts
+++ b/lib/utils/downloadToLocal.ts
@@ -62,11 +62,9 @@ export interface DownloadResult {
  * Determine whether a fileUrl is a remote http(s) URL (not a local asset path).
  */
 function isRemoteHttpUrl(url: string): boolean {
-  return (
-    url.startsWith("http") &&
-    !url.startsWith("/data/") &&
-    !url.startsWith("/uploads/")
-  );
+  // A real http(s) URL can never start with a local "/data/" or "/uploads/" path,
+  // so the explicit scheme check alone is sufficient (and rejects e.g. "httpfoo").
+  return url.startsWith("http://") || url.startsWith("https://");
 }
 
 /**

--- a/lib/utils/downloadToLocal.ts
+++ b/lib/utils/downloadToLocal.ts
@@ -1,0 +1,204 @@
+import { writeFile } from "fs/promises";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { IMAGE_TYPES, VIDEO_TYPES } from "@/lib/filetypes";
+import { getUploadDir } from "@/lib/utils/fileUpload";
+import { Logger } from "@/lib/utils/Logger";
+
+const logger = new Logger("DownloadToLocal");
+
+/** Maximum download size (50MB), identical to the download-upload route. */
+const MAX_SIZE_BYTES = 50 * 1024 * 1024;
+
+/** Abort the download after 30s, identical to the download-upload route. */
+const DOWNLOAD_TIMEOUT_MS = 30000;
+
+/** Known file extensions accepted directly from the URL. */
+const KNOWN_EXTENSIONS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "avif",
+  "mp4",
+  "webm",
+  "mov",
+];
+
+/** Fallback extension derived from the response Content-Type. */
+const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/avif": "avif",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+};
+
+/**
+ * Error carrying the HTTP status the download-upload route should return.
+ * Lets the route map failures to the exact same status codes it used before.
+ */
+export class DownloadError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "DownloadError";
+    this.status = status;
+  }
+}
+
+export interface DownloadResult {
+  url: string;
+  filename: string;
+  type: "image" | "video";
+}
+
+/**
+ * Determine whether a fileUrl is a remote http(s) URL (not a local asset path).
+ */
+function isRemoteHttpUrl(url: string): boolean {
+  return (
+    url.startsWith("http") &&
+    !url.startsWith("/data/") &&
+    !url.startsWith("/uploads/")
+  );
+}
+
+/**
+ * Fetch a remote URL, validate it (content-type / size), and persist it to the
+ * given upload subfolder. Returns the local `/data/uploads/...` URL.
+ *
+ * Throws {@link DownloadError} (with the appropriate HTTP status) on a bad
+ * status, unsupported type, oversized file, or timeout.
+ */
+export async function downloadRemoteToUpload(
+  url: string,
+  subfolder: "posters" = "posters"
+): Promise<DownloadResult> {
+  let contentType = "";
+  let arrayBuffer: ArrayBuffer;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "User-Agent": "OBS-Live-Suite/1.0",
+      },
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      throw new DownloadError(
+        `Failed to download file: ${response.statusText}`,
+        400
+      );
+    }
+
+    // Validate Content-Type against allowed image/video types
+    contentType = response.headers.get("content-type") || "";
+    const allowedTypes = [...IMAGE_TYPES, ...VIDEO_TYPES];
+    if (!allowedTypes.some((type) => contentType.includes(type.replace("*", "")))) {
+      throw new DownloadError(
+        `Unsupported file type: ${contentType}. Use images or videos.`,
+        400
+      );
+    }
+
+    // Validate declared size (max 50MB)
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && parseInt(contentLength) > MAX_SIZE_BYTES) {
+      throw new DownloadError("File too large. Maximum size: 50MB", 400);
+    }
+
+    arrayBuffer = await response.arrayBuffer();
+  } catch (error) {
+    // Preserve validation/status errors as-is
+    if (error instanceof DownloadError) {
+      throw error;
+    }
+
+    // Timeout (AbortSignal.timeout surfaces as AbortError / TimeoutError)
+    if (
+      error instanceof Error &&
+      (error.name === "AbortError" || error.name === "TimeoutError")
+    ) {
+      throw new DownloadError(
+        "Download timeout. The file took too long to download (max 30s).",
+        408
+      );
+    }
+
+    // Network/DNS errors from fetch surface as TypeError
+    if (error instanceof TypeError) {
+      throw new DownloadError(
+        "Failed to download media from URL. Check that the URL is valid and accessible.",
+        400
+      );
+    }
+
+    throw error;
+  }
+
+  // Double-check actual size after download
+  if (arrayBuffer.byteLength > MAX_SIZE_BYTES) {
+    throw new DownloadError("File too large. Maximum size: 50MB", 400);
+  }
+
+  const type: "image" | "video" = contentType.startsWith("image/")
+    ? "image"
+    : "video";
+
+  // Derive extension from the URL, falling back to the Content-Type
+  let ext = "";
+  const urlExt = url.split(".").pop()?.split("?")[0]?.toLowerCase();
+  if (urlExt && KNOWN_EXTENSIONS.includes(urlExt)) {
+    ext = urlExt;
+  } else {
+    ext = EXTENSION_BY_CONTENT_TYPE[contentType] || "jpg";
+  }
+
+  const uploadDir = await getUploadDir(subfolder);
+  const filename = `${randomUUID()}.${ext}`;
+  const filepath = join(uploadDir, filename);
+  await writeFile(filepath, Buffer.from(arrayBuffer));
+
+  return {
+    url: `/data/uploads/${subfolder}/${filename}`,
+    filename,
+    type,
+  };
+}
+
+/**
+ * Resolve a poster `fileUrl` for create/update: when `downloadToLocal` is
+ * requested and the URL is a remote http(s) media URL (and not a YouTube
+ * poster), download it to local storage and return the local `/data/uploads`
+ * path. On any failure, logs a warning and returns the original remote URL so
+ * poster creation/update never fails just because the download failed.
+ */
+export async function resolvePosterFileUrl(
+  fileUrl: string | undefined,
+  type: string | undefined,
+  downloadToLocal: unknown
+): Promise<string | undefined> {
+  if (downloadToLocal !== true) return fileUrl;
+  if (!fileUrl || typeof fileUrl !== "string") return fileUrl;
+  if (type === "youtube") return fileUrl;
+  if (!isRemoteHttpUrl(fileUrl)) return fileUrl;
+
+  try {
+    const local = await downloadRemoteToUpload(fileUrl);
+    return local.url;
+  } catch (error) {
+    logger.warn(
+      `Failed to download poster media to local storage; keeping remote URL: ${fileUrl}`,
+      error
+    );
+    return fileUrl;
+  }
+}

--- a/lib/utils/fuzzyMatch.ts
+++ b/lib/utils/fuzzyMatch.ts
@@ -1,0 +1,38 @@
+/**
+ * Tiny dependency-free fuzzy-matching helpers.
+ *
+ * Used by the Live Assist LocalPosterMatcher to tolerate STT typos (e.g.
+ * "éclipsia" vs "eclypsia") when matching spoken words against poster titles.
+ */
+
+/**
+ * Levenshtein edit distance (iterative, two-row — O(min(n,m)) memory).
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let curr = new Array<number>(b.length + 1);
+
+  for (let i = 0; i < a.length; i++) {
+    curr[0] = i + 1;
+    for (let j = 0; j < b.length; j++) {
+      const cost = a[i] === b[j] ? 0 : 1;
+      curr[j + 1] = Math.min(curr[j] + 1, prev[j + 1] + 1, prev[j] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length];
+}
+
+/**
+ * Normalized similarity in [0, 1]: `1 - distance / max(len)`. 1 = identical,
+ * 0 = completely different. Two empty strings are considered identical (1).
+ */
+export function similarity(a: string, b: string): number {
+  const max = Math.max(a.length, b.length);
+  if (max === 0) return 1;
+  return 1 - levenshtein(a, b) / max;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -417,7 +417,10 @@
     "liveAssist": {
       "validate": "Validate",
       "pin": "Pin",
+      "quickText": "Quick text",
       "onAir": "On Air",
+      "posterLeft": "Left",
+      "posterRight": "Right",
       "dismiss": "Dismiss",
       "connected": "Connected",
       "disconnected": "STT disconnected"
@@ -838,9 +841,16 @@
     "liveAssist": {
       "title": "Live Assist",
       "enabled": "Enabled",
+      "transcriptDebug": "Transcription (debug)",
+      "transcriptDebugHelp": "Stream the live transcription to the panel. Off keeps the websocket clear when you're not debugging.",
+      "localPosters": "Local posters",
+      "localPostersHelp": "Suggest a poster already in the library when its title is mentioned (no AI).",
+      "localPosterSensitivity": "Sensitivity (local posters)",
       "device": "Input device",
       "model": "Whisper model",
       "keywords": "Keywords",
+      "contextPrompt": "Context prompt (extraction)",
+      "contextPromptPlaceholder": "Leave empty to use the provider's default prompt.",
       "windowBefore": "Before (s)",
       "windowAfter": "After (s)",
       "threshold": "Confidence threshold",

--- a/messages/en.json
+++ b/messages/en.json
@@ -423,7 +423,10 @@
       "posterRight": "Right",
       "dismiss": "Dismiss",
       "connected": "Connected",
-      "disconnected": "STT disconnected"
+      "disconnected": "STT disconnected",
+      "listening": "Listening",
+      "transcript": "Transcript",
+      "toggleFailed": "Failed to update Live Assist"
     }
   },
   "navigation": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -417,7 +417,10 @@
     "liveAssist": {
       "validate": "Valider",
       "pin": "Épingler",
+      "quickText": "Texte rapide",
       "onAir": "À l'antenne",
+      "posterLeft": "Gauche",
+      "posterRight": "Droite",
       "dismiss": "Ignorer",
       "connected": "Connecté",
       "disconnected": "STT déconnecté"
@@ -838,9 +841,16 @@
     "liveAssist": {
       "title": "Assistant Live",
       "enabled": "Activé",
+      "transcriptDebug": "Transcription (debug)",
+      "transcriptDebugHelp": "Diffuse la transcription en direct dans le panneau.",
+      "localPosters": "Affiches locales",
+      "localPostersHelp": "Suggère une affiche déjà en bibliothèque quand son titre est cité (sans IA).",
+      "localPosterSensitivity": "Sensibilité (affiches locales)",
       "device": "Micro d'entrée",
       "model": "Modèle Whisper",
       "keywords": "Mots-clés",
+      "contextPrompt": "Prompt de contexte (extraction)",
+      "contextPromptPlaceholder": "Laisser vide pour utiliser le prompt par défaut du provider.",
       "windowBefore": "Avant (s)",
       "windowAfter": "Après (s)",
       "threshold": "Seuil de confiance",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -423,7 +423,10 @@
       "posterRight": "Droite",
       "dismiss": "Ignorer",
       "connected": "Connecté",
-      "disconnected": "STT déconnecté"
+      "disconnected": "STT déconnecté",
+      "listening": "Écoute",
+      "transcript": "Transcript",
+      "toggleFailed": "Échec de la mise à jour de l'Assistant Live"
     }
   },
   "navigation": {

--- a/realtime-stt/main.py
+++ b/realtime-stt/main.py
@@ -111,9 +111,14 @@ def run():
 
     # VAD-gated chunking: accumulate speech, transcribe on a silence boundary.
     # (Use silero-vad or webrtcvad here; pseudocode loop kept minimal.)
+    # The callback runs on PortAudio's audio thread while the main loop drains the
+    # buffer, so all buffer access is guarded by a lock to avoid losing a frame
+    # that arrives between concatenate() and clear().
     buffer = []
+    buffer_lock = threading.Lock()
     def callback(indata, frames, t, status):
-        buffer.append(indata.copy())
+        with buffer_lock:
+            buffer.append(indata.copy())
 
     with sd.InputStream(samplerate=sample_rate, channels=1, dtype="float32",
                         device=device_index, callback=callback):
@@ -127,12 +132,17 @@ def run():
             cfg_now = fetch_config(backend) or last_cfg
             last_cfg = cfg_now
             if not cfg_now.get("enabled", False):
+                with buffer_lock:
+                    buffer.clear()
+                continue
+            # Atomically swap out the captured chunks so a frame arriving mid-drain
+            # is preserved for the next iteration instead of being cleared away.
+            with buffer_lock:
+                if not buffer:
+                    continue
+                chunks = buffer[:]
                 buffer.clear()
-                continue
-            if not buffer:
-                continue
-            audio = np.concatenate(buffer).flatten()
-            buffer.clear()
+            audio = np.concatenate(chunks).flatten()
             t1_ms = int((time.monotonic() - capture_start) * 1000)
             t0_ms = t1_ms - int(len(audio) / sample_rate * 1000)
             segments, _ = model.transcribe(audio, language="fr", vad_filter=True)

--- a/server/api/live-assist.ts
+++ b/server/api/live-assist.ts
@@ -15,7 +15,11 @@ import type { LiveAssistOrchestrator } from "@/lib/services/liveassist/LiveAssis
 
 interface RouterDeps {
   orchestrator: Pick<LiveAssistOrchestrator, "ingestSegment" | "getStatus" | "markSttAlive">;
-  store: { list: () => unknown[]; setStatus: (id: string, status: "applied" | "dismissed") => unknown };
+  store: {
+    list: () => unknown[];
+    get: (id: string) => { intent: string; applyPayload: Record<string, unknown> } | undefined;
+    setStatus: (id: string, status: "applied" | "dismissed") => unknown;
+  };
   registry: { get: (id: string) => { apply: (p: Record<string, unknown>) => Promise<ApplyResult> } | undefined };
 }
 
@@ -54,12 +58,26 @@ export function createLiveAssistRouter(deps: RouterDeps): Router {
   });
 
   router.post("/api/live-assist/suggestions/:id/apply", async (req, res) => {
-    const intent = String(req.body?.intent ?? "");
-    const provider = deps.registry.get(intent);
+    // Server-authoritative: load the STORED suggestion by id and act on its own
+    // intent + applyPayload. The client is trusted only for `target` (the runtime
+    // pin-vs-on-air choice for definitions) — a forged intent/payload is ignored.
+    const suggestion = deps.store.get(req.params.id);
+    if (!suggestion) return res.status(404).json({ error: "unknown suggestion" });
+    const provider = deps.registry.get(suggestion.intent);
     if (!provider) return res.status(404).json({ error: "unknown provider" });
+
+    // `target` is the only client-trusted field: the runtime pin/on-air choice for
+    // definitions, or the left/right side for a local poster. Anything else is ignored.
+    const rawTarget = req.body?.target;
+    const target = ["pin", "on-air", "left", "right"].includes(rawTarget) ? rawTarget : undefined;
+    const payload: Record<string, unknown> = {
+      ...suggestion.applyPayload,
+      ...(target ? { target } : {}),
+    };
+
     let result;
     try {
-      result = await provider.apply(req.body?.payload ?? {});
+      result = await provider.apply(payload);
     } catch (error) {
       // apply() does network I/O (poster create / lower-third show); a rejection
       // must surface as a clean error, not an unhandled 500 that leaves the

--- a/server/api/liveAssistBoot.ts
+++ b/server/api/liveAssistBoot.ts
@@ -1,6 +1,7 @@
 import { SettingsService } from "@/lib/services/SettingsService";
 import { ChannelManager } from "@/lib/services/ChannelManager";
 import { WikipediaResolverService } from "@/lib/services/WikipediaResolverService";
+import { TmdbResolverService } from "@/lib/services/TmdbResolverService";
 import { Logger } from "@/lib/utils/Logger";
 import { LiveAssistOrchestrator } from "@/lib/services/liveassist/LiveAssistOrchestrator";
 import { TranscriptBuffer } from "@/lib/services/liveassist/TranscriptBuffer";
@@ -11,8 +12,11 @@ import { SuggestionStore } from "@/lib/services/liveassist/SuggestionStore";
 import { ProviderRegistry, type ApplyResult } from "@/lib/services/liveassist/providers/ActionProvider";
 import { PosterActionProvider } from "@/lib/services/liveassist/providers/PosterActionProvider";
 import { DefinitionActionProvider } from "@/lib/services/liveassist/providers/DefinitionActionProvider";
+import { LocalPosterProvider } from "@/lib/services/liveassist/providers/LocalPosterProvider";
+import { LocalPosterMatcher } from "@/lib/services/liveassist/LocalPosterMatcher";
+import { PosterRepository } from "@/lib/repositories/PosterRepository";
 import { LIVE_ASSIST } from "@/lib/config/Constants";
-import { APP_URL } from "@/lib/config/urls";
+import { INTERNAL_APP_URL } from "@/lib/config/urls";
 import type { LiveAssistEvent } from "@/lib/models/LiveAssist";
 
 // ---------------------------------------------------------------------------
@@ -37,6 +41,15 @@ export function buildOrchestrator(): {
   store: SuggestionStore;
   registry: ProviderRegistry;
 } {
+  // Dev-only: tolerate the self-signed / Tailscale cert on the internal HTTPS call
+  // to the frontend (poster / text-preset / lower-third). Mirrors the MCP server and
+  // the NODE_TLS_REJECT_UNAUTHORIZED=0 that `pnpm setup:https` writes to .env — set
+  // here too because the backend evaluates urls.ts BEFORE dotenv, so the .env value
+  // may not have taken effect in time.
+  if (process.env.NODE_ENV !== "production") {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  }
+
   const settingsService = SettingsService.getInstance();
   const getSettings = () => settingsService.getLiveAssistSettings();
   const liveAssistSettings = getSettings();
@@ -45,34 +58,85 @@ export function buildOrchestrator(): {
 
   const registry = new ProviderRegistry();
 
+  // Where the provider apply callbacks POST (poster / text-preset / lower-third).
+  //
+  // Resolved at RUNTIME, not from urls.ts: the backend evaluates its imports (incl.
+  // urls.ts) BEFORE dotenvConfig() runs, so urls.ts captured a stale `localhost`
+  // fallback and missed NEXT_PUBLIC_APP_URL. By the time buildOrchestrator() runs,
+  // .env IS loaded — so we read the app's REAL, browser-reachable, cert-valid origin
+  // (NEXT_PUBLIC_APP_URL, e.g. https://edison:3000) here, falling back to the 127.0.0.1
+  // loopback. localhost/127.0.0.1 both failed in the Tailscale-HTTPS setup because the
+  // served cert is for the public host, not loopback.
+  const appBaseUrl = process.env.NEXT_PUBLIC_APP_URL || INTERNAL_APP_URL;
+  logger.info(`Live Assist provider calls target ${appBaseUrl}`);
+
   // Shared POST→ApplyResult helper for provider apply callbacks (one fetch shape).
-  const postJson = async (path: string, body: unknown, failLabel: string): Promise<ApplyResult> => {
-    const r = await fetch(`${APP_URL}${path}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    return r.ok ? { ok: true } : { ok: false, message: `${failLabel} (${r.status})` };
+  // A thrown fetch (network/TLS) is reported as a clean failure (with the URL) instead
+  // of escaping as an unhandled rejection.
+  const postJson = async (path: string, body: unknown, failLabel: string, method = "POST"): Promise<ApplyResult> => {
+    try {
+      const r = await fetch(`${appBaseUrl}${path}`, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return r.ok ? { ok: true } : { ok: false, message: `${failLabel} (${r.status})` };
+    } catch (error) {
+      // undici wraps the real reason (ECONNREFUSED / ENOTFOUND / cert) in `.cause`.
+      const cause = (error as { cause?: { code?: string; message?: string } } | null)?.cause;
+      const reason = cause?.code ?? cause?.message ?? (error instanceof Error ? error.message : "fetch failed");
+      return { ok: false, message: `${failLabel} → ${appBaseUrl}${path}: ${reason}` };
+    }
   };
 
-  // Poster provider: creates a poster from a Wikipedia thumbnail via the frontend API.
+  // Both poster providers create a poster the same way: POST to the frontend API
+  // with downloadToLocal so the image is saved as a local asset (not hotlinked).
+  const createPoster = ({ title, fileUrl }: { title: string; fileUrl: string }) =>
+    postJson("/api/assets/posters", { title, fileUrl, type: "image", downloadToLocal: true }, "poster create failed");
+
+  // Poster provider (Wikipedia): théâtre / spectacles / concerts.
+  registry.register(new PosterActionProvider(resolver, createPoster));
+
+  // Poster provider (TMDB): films / séries — official posters, no Wikipedia ambiguity.
   registry.register(
-    new PosterActionProvider(resolver, ({ title, fileUrl }) =>
-      postJson("/api/assets/posters", { title, fileUrl, type: "image", downloadToLocal: true }, "poster create failed"),
+    new PosterActionProvider(TmdbResolverService.getInstance(), createPoster, {
+      id: "poster-tmdb",
+      description: "Trouver l'affiche officielle d'un film / série cité (TMDB) et l'ajouter aux posters",
+      defaultKeywords: LIVE_ASSIST.DEFAULT_KEYWORDS["poster-tmdb"],
+      defaultContextPrompt: LIVE_ASSIST.DEFAULT_CONTEXT_PROMPTS["poster-tmdb"],
+    }),
+  );
+
+  // Definition provider:
+  //  - "Diffuser" (on-air) → shows a brief Wikipedia extract on the lower-third
+  //    overlay. Endpoint mirrored from mcp-server/src/tools/lower-third.ts:
+  //      POST /api/overlays/lower { action:'show', payload:{ contentType:'text', body } }
+  //  - "Valider" (pin) → saves the extract as a reusable « texte rapide » (text preset).
+  registry.register(
+    new DefinitionActionProvider(
+      resolver,
+      (text) =>
+        postJson("/api/overlays/lower", { action: "show", payload: { contentType: "text", body: text } }, "lower-third failed"),
+      ({ name, body }) => postJson("/api/assets/text-presets", { name, body }, "text-preset create failed"),
     ),
   );
 
-  // Definition provider: shows a brief Wikipedia extract on the lower-third overlay.
-  // Endpoint mirrored from mcp-server/src/tools/lower-third.ts (show-lower-third-text):
-  //   POST /api/overlays/lower  { action: 'show', payload: { contentType: 'text', body } }
+  // Local posters: fuzzy-match an existing poster's title spoken on air, then SHOW
+  // that poster (no creation, no LLM). Index all posters — incl. disabled — refreshed
+  // live below. apply() posts the same /api/overlays/poster show payload as the MCP tool.
+  const localPosterMatcher = new LocalPosterMatcher();
+  const refreshLocalPosters = (s: ReturnType<typeof getSettings>) =>
+    localPosterMatcher.setPosters(PosterRepository.getInstance().getAll(), s.localPosterMinSimilarity);
+  refreshLocalPosters(liveAssistSettings);
   registry.register(
-    new DefinitionActionProvider(resolver, (text) =>
-      postJson("/api/overlays/lower", { action: "show", payload: { contentType: "text", body: text } }, "lower-third failed"),
+    new LocalPosterProvider(
+      (payload) => postJson("/api/overlays/poster", { action: "show", payload }, "poster show failed"),
+      // Enable the poster (idempotent PATCH) so it lands in the Affiches panel.
+      (posterId) => postJson(`/api/assets/posters/${posterId}`, { isEnabled: true }, "poster enable failed", "PATCH"),
     ),
   );
 
   const store = new SuggestionStore((event: LiveAssistEvent) => cm.publishLiveAssist(event));
-  const extractor = new IntentExtractor(registry.ids(), registry.descriptions());
 
   // Merge each provider's defaultKeywords as fallback when settings is empty.
   const buildKeywords = (s: ReturnType<typeof getSettings>): Record<string, string[]> => {
@@ -83,6 +147,27 @@ export function buildOrchestrator(): {
     }
     return keywords;
   };
+
+  // Per-provider extraction prompts: provider defaults overlaid by any non-empty
+  // settings override (the IntentExtractor injects these as each intent's "Règle").
+  const buildContextPrompts = (s: ReturnType<typeof getSettings>): Record<string, string> => {
+    const merged: Record<string, string> = { ...registry.contextPrompts() };
+    for (const [id, prompt] of Object.entries(s.contextPromptsByProvider ?? {})) {
+      if (prompt && prompt.trim()) merged[id] = prompt;
+    }
+    return merged;
+  };
+
+  const initialContextPrompts = buildContextPrompts(liveAssistSettings);
+  // One-time visibility: confirms the per-provider "Règle" (incl. the TMDB inference
+  // guidance) is actually loaded into the extractor at boot.
+  logger.info(`Live Assist context prompts: ${JSON.stringify(initialContextPrompts)}`);
+  const extractor = new IntentExtractor(
+    registry.ids(),
+    registry.descriptions(),
+    undefined, // use the default LLM generate fn
+    initialContextPrompts,
+  );
 
   const detector = new KeywordDetector(buildKeywords(liveAssistSettings));
   const scheduler = new WindowScheduler(
@@ -108,6 +193,16 @@ export function buildOrchestrator(): {
     },
     // Gate ingest on the live settings flag (re-read each call).
     isEnabled: () => getSettings().enabled,
+    // Gate the live transcript re-broadcast on the debug flag (re-read each call,
+    // so toggling Settings > Live Assist takes effect without a backend restart).
+    isTranscriptDebugEnabled: () => getSettings().transcriptDebug,
+    // Non-LLM fast-path: a spoken poster title → a ready local-poster suggestion.
+    matchLocalPosters: (text) =>
+      getSettings().localPostersEnabled
+        ? localPosterMatcher.match(text).map((m) => LocalPosterProvider.toSuggestion(m.poster, text, m.score))
+        : [],
+    // Show the device's human label (e.g. "USB Mic") in status, not its id ("1").
+    resolveDeviceLabel: (id) => settingsService.getSttDevices().find((d) => d.id === id)?.label ?? id,
     // Publish STT connected/disconnected state to overlay subscribers.
     publishStatus: (connected, device) =>
       cm.publishLiveAssist({ type: "stt:status", payload: { connected, device } }),
@@ -126,6 +221,8 @@ export function buildOrchestrator(): {
   setInterval(() => {
     const s = getSettings();
     detector.setKeywords(buildKeywords(s));
+    extractor.setContextPrompts(buildContextPrompts(s));
+    refreshLocalPosters(s); // re-index posters (titles/sensitivity) from the DB, live
     scheduler.setAfterMs(s.windowAfterSec * 1000);
     orchestrator.tick(Date.now()).catch((error) => {
       logger.warn(`tick failed: ${error instanceof Error ? error.message : error}`);

--- a/server/api/liveAssistBoot.ts
+++ b/server/api/liveAssistBoot.ts
@@ -67,7 +67,11 @@ export function buildOrchestrator(): {
   // (NEXT_PUBLIC_APP_URL, e.g. https://edison:3000) here, falling back to the 127.0.0.1
   // loopback. localhost/127.0.0.1 both failed in the Tailscale-HTTPS setup because the
   // served cert is for the public host, not loopback.
-  const appBaseUrl = process.env.NEXT_PUBLIC_APP_URL || INTERNAL_APP_URL;
+  // Prefer runtime env (now that .env is loaded) over the imported constant, which
+  // captured its fallback before dotenvConfig() ran: NEXT_PUBLIC_APP_URL (real public
+  // origin) → INTERNAL_APP_URL env (explicit loopback override) → the stale import.
+  const appBaseUrl =
+    process.env.NEXT_PUBLIC_APP_URL || process.env.INTERNAL_APP_URL || INTERNAL_APP_URL;
   logger.info(`Live Assist provider calls target ${appBaseUrl}`);
 
   // Shared POST→ApplyResult helper for provider apply callbacks (one fetch shape).
@@ -125,8 +129,13 @@ export function buildOrchestrator(): {
   // that poster (no creation, no LLM). Index all posters — incl. disabled — refreshed
   // live below. apply() posts the same /api/overlays/poster show payload as the MCP tool.
   const localPosterMatcher = new LocalPosterMatcher();
-  const refreshLocalPosters = (s: ReturnType<typeof getSettings>) =>
+  // Re-index posters from the DB. Skipped when LocalPosters is disabled so the
+  // 5s tick doesn't run getAll()+re-tokenize for a feature nobody is using; the
+  // next tick after it's re-enabled repopulates the index.
+  const refreshLocalPosters = (s: ReturnType<typeof getSettings>) => {
+    if (!s.localPostersEnabled) return;
     localPosterMatcher.setPosters(PosterRepository.getInstance().getAll(), s.localPosterMinSimilarity);
+  };
   refreshLocalPosters(liveAssistSettings);
   registry.register(
     new LocalPosterProvider(

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -228,12 +228,15 @@ class BackendServer {
     this.logger.info("Starting backend server...");
 
     try {
-      // 0. Setup API routes (must be first)
-      this.setupApiRoutes();
-
-      // 1. Initialize database
+      // 0. Initialize database FIRST — setupApiRoutes() builds the Live Assist
+      // orchestrator (buildOrchestrator), which reads settings from the DB. With
+      // the DB up front, that read hits an initialized connection instead of
+      // relying on a fallback.
       DatabaseService.getInstance();
       this.logger.info("✓ Database initialized");
+
+      // 1. Setup API routes
+      this.setupApiRoutes();
 
       // 2. Start WebSocket Hub
       this.wsHub.start();


### PR DESCRIPTION
## Summary
A broad Live Assist pass: a better poster source (TMDB), a new no-AI "LocalPosters" matcher, and a string of correctness fixes uncovered during live testing.

### #116 — Better posters + smarter extraction
- **TMDB poster provider** for films/séries (official posters, no Wikipedia ambiguity), routed by keyword alongside the Wikipedia poster (théâtre/concerts) and definition providers.
- **Per-provider context prompts** injected into the IntentExtractor (each intent shapes its own entity), replacing the hard-coded poster rule.
- **Title inference**: when a film is described but not named ("le film avec Sharon Stone"), the LLM proposes the most likely title, gated behind a stricter confidence bar.
- **TMDB API key + "Test connection"** in Settings > AI.

### #120 — PR-review follow-ups
- **Honor `downloadToLocal`** in the poster routes (shared `downloadToLocal.ts`) → posters saved as local assets instead of hotlinking.
- **Server-authoritative apply**: the route reloads the stored suggestion by id and trusts only the client `target`.
- Settings hot-path cache (raw-string keyed), DB-initialized-before-routes boot order, device **label** in the STT status bar, stable transcript list keys, Python VAD buffer lock.

### Live-testing fixes
- **`fetch failed` (backend→frontend)**: the backend now targets `NEXT_PUBLIC_APP_URL` / a 127.0.0.1 loopback with a dev TLS bypass — the localhost/IPv6/Tailscale-cert combo was breaking every provider apply.
- **Data-sync never fired on server-side changes**: `useDataSync` read the DataChangedEvent at the top level, but `ChannelManager.publish` nests it under `.payload`. New `parseDataChangedEvent` unwraps it; panels now refresh without a reload (repairs cross-tab sync for all entities).
- **SuggestionCard** collapses to icon+title once acted on (chevron to expand); dismissed cards keep a re-validate button.

### New — LocalPosters provider
- Fuzzy-matches spoken words against **existing poster titles** (tiny Levenshtein helper, no dependency) on a **non-LLM fast-path** in `ingestSegment` — "Eclypsia" → `Rowanne - Eclypsia`, typo-tolerant.
- Matches all posters (incl. disabled); validate shows the poster on the chosen **side (Gauche/Droite)** and **enables** it so it lands in the Affiches panel.
- Toggle + sensitivity in Settings > Live Assist.

### Definition
- "Valider" on a definition now creates a reusable **texte rapide** (text preset); "À l'antenne" still shows the lower-third.

## Tests
Live Assist + related Jest suites are green (TMDB resolver, LocalPoster matcher/provider, fuzzy helper, IntentExtractor, orchestrator fast-path + inferred gate, apply route, data-sync parser, SuggestionCard, downloadToLocal, settings-integrations). `pnpm type-check` adds no new errors over the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)