### PR TITLE
feat(posters): support YouTube Shorts with vertical 9:16 rendering

### DIFF
--- a/__tests__/components/PosterDisplay.test.tsx
+++ b/__tests__/components/PosterDisplay.test.tsx
@@ -1,0 +1,80 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render } from "@testing-library/react";
+import { PosterDisplay } from "@/components/overlays/PosterDisplay";
+
+const YOUTUBE_URL = "https://www.youtube.com/embed/dQw4w9WgXcQ";
+
+function getYouTubeWrapper(container: HTMLElement): HTMLElement {
+  const iframe = container.querySelector('iframe[title="YouTube video"]');
+  expect(iframe).not.toBeNull();
+  return iframe!.parentElement as HTMLElement;
+}
+
+describe("PosterDisplay YouTube orientation", () => {
+  it("renders a vertical 9:16 box for portrait Shorts in center mode", () => {
+    const { container } = render(
+      <PosterDisplay
+        fileUrl={YOUTUBE_URL}
+        type="youtube"
+        aspectRatio={16 / 9}
+        positioning="center"
+        orientation="portrait"
+      />
+    );
+
+    const wrapper = getYouTubeWrapper(container);
+    expect(wrapper.style.aspectRatio).toBe("9 / 16");
+    // Portrait is height-driven; width must not be pinned to the full viewport.
+    expect(wrapper.style.width).not.toBe("100vw");
+    expect(wrapper.style.height).toBe("100vh");
+  });
+
+  it("renders a 16:9 box for landscape YouTube in center mode", () => {
+    const { container } = render(
+      <PosterDisplay
+        fileUrl={YOUTUBE_URL}
+        type="youtube"
+        aspectRatio={16 / 9}
+        positioning="center"
+        orientation="landscape"
+      />
+    );
+
+    const wrapper = getYouTubeWrapper(container);
+    expect(wrapper.style.aspectRatio).toBe("16 / 9");
+    expect(wrapper.style.width).toBe("100vw");
+  });
+
+  it("defaults to 16:9 landscape when no orientation is given", () => {
+    const { container } = render(
+      <PosterDisplay
+        fileUrl={YOUTUBE_URL}
+        type="youtube"
+        aspectRatio={16 / 9}
+        positioning="center"
+      />
+    );
+
+    const wrapper = getYouTubeWrapper(container);
+    expect(wrapper.style.aspectRatio).toBe("16 / 9");
+  });
+
+  it("renders a vertical 9:16 box for portrait Shorts in side mode", () => {
+    const { container } = render(
+      <PosterDisplay
+        fileUrl={YOUTUBE_URL}
+        type="youtube"
+        aspectRatio={16 / 9}
+        positioning="side"
+        side="left"
+        orientation="portrait"
+      />
+    );
+
+    const wrapper = getYouTubeWrapper(container);
+    expect(wrapper.style.aspectRatio).toBe("9 / 16");
+    // Portrait side mode is height-driven, not the 50% width used for landscape.
+    expect(wrapper.style.width).not.toBe("50%");
+  });
+});

--- a/__tests__/repositories/PosterRepository.test.ts
+++ b/__tests__/repositories/PosterRepository.test.ts
@@ -79,6 +79,7 @@ describe("PosterRepository", () => {
     endTime: null,
     thumbnailUrl: null,
     endBehavior: null,
+    orientation: null,
     createdAt: "2024-01-15T10:00:00.000Z",
     updatedAt: "2024-01-15T12:00:00.000Z",
   };
@@ -102,6 +103,7 @@ describe("PosterRepository", () => {
     endTime: null,
     thumbnailUrl: null,
     endBehavior: null,
+    orientation: null,
     createdAt: new Date("2024-01-15T10:00:00.000Z"),
     updatedAt: new Date("2024-01-15T12:00:00.000Z"),
   };
@@ -275,6 +277,7 @@ describe("PosterRepository", () => {
         null, // endTime
         null, // thumbnailUrl
         null, // endBehavior
+        null, // orientation
         expect.any(String), // createdAt ISO string
         expect.any(String)  // updatedAt ISO string
       );
@@ -315,6 +318,7 @@ describe("PosterRepository", () => {
         null, // endTime
         null, // thumbnailUrl
         null, // endBehavior
+        null, // orientation
         expect.any(String),
         expect.any(String)
       );
@@ -340,10 +344,10 @@ describe("PosterRepository", () => {
 
       repository.create(posterInput);
 
-      // Verify the date strings are passed correctly (positions 17 and 18 with new sub-video fields)
+      // Verify the date strings are passed correctly (positions 18 and 19 with sub-video + orientation fields)
       const runArgs = mockStmt.run.mock.calls[0];
-      expect(runArgs[17]).toBe("2024-06-01T00:00:00.000Z"); // createdAt
-      expect(runArgs[18]).toBe("2024-06-01T00:00:00.000Z"); // updatedAt
+      expect(runArgs[18]).toBe("2024-06-01T00:00:00.000Z"); // createdAt
+      expect(runArgs[19]).toBe("2024-06-01T00:00:00.000Z"); // updatedAt
     });
 
     it("should convert isEnabled boolean to integer", () => {
@@ -384,6 +388,29 @@ describe("PosterRepository", () => {
       runArgs = mockStmt.run.mock.calls[1];
       expect(runArgs[11]).toBe(0); // isEnabled = false -> 0
     });
+
+    it("should persist orientation when provided", () => {
+      const portraitPoster: DbPosterInput = {
+        id: "short-poster",
+        title: "A Short",
+        description: null,
+        source: null,
+        fileUrl: "https://www.youtube.com/embed/dQw4w9WgXcQ",
+        type: "youtube",
+        duration: 30,
+        tags: [],
+        profileIds: [],
+        chatMessage: null,
+        isEnabled: true,
+        orientation: "portrait",
+      };
+
+      repository.create(portraitPoster);
+
+      // orientation is at position 17 (after endBehavior, before createdAt)
+      const runArgs = mockStmt.run.mock.calls[0];
+      expect(runArgs[17]).toBe("portrait");
+    });
   });
 
   describe("update", () => {
@@ -415,6 +442,7 @@ describe("PosterRepository", () => {
         null, // endTime
         null, // thumbnailUrl
         null, // endBehavior
+        null, // orientation
         expect.any(String), // updatedAt
         "poster-1"
       );
@@ -455,6 +483,7 @@ describe("PosterRepository", () => {
         null, // endTime
         null, // thumbnailUrl
         null, // endBehavior
+        null, // orientation
         expect.any(String),
         "poster-1"
       );
@@ -474,6 +503,25 @@ describe("PosterRepository", () => {
       expect(runArgs[8]).toBe('{"key":"value"}'); // metadata preserved
     });
 
+    it("should update orientation when provided", () => {
+      mockStmt.get.mockReturnValue(sampleDbRow);
+
+      repository.update("poster-1", { orientation: "portrait" });
+
+      // orientation is at position 16 (after endBehavior, before updatedAt)
+      const runArgs = mockStmt.run.mock.calls[0];
+      expect(runArgs[16]).toBe("portrait");
+    });
+
+    it("should keep existing orientation when not provided", () => {
+      mockStmt.get.mockReturnValue({ ...sampleDbRow, orientation: "portrait" });
+
+      repository.update("poster-1", { title: "New Title" });
+
+      const runArgs = mockStmt.run.mock.calls[0];
+      expect(runArgs[16]).toBe("portrait");
+    });
+
     it("should use provided updatedAt date", () => {
       mockStmt.get.mockReturnValue(sampleDbRow);
       const specificDate = new Date("2024-12-25T00:00:00.000Z");
@@ -485,11 +533,11 @@ describe("PosterRepository", () => {
 
       repository.update("poster-1", updates);
 
-      // updatedAt is at position 16 (second to last before id)
+      // updatedAt is at position 17 (second to last before id, after orientation)
       const runArgs = mockStmt.run.mock.calls[0];
       expect(runArgs[0]).toBe("Holiday Update");
-      expect(runArgs[16]).toBe("2024-12-25T00:00:00.000Z");
-      expect(runArgs[17]).toBe("poster-1");
+      expect(runArgs[17]).toBe("2024-12-25T00:00:00.000Z");
+      expect(runArgs[18]).toBe("poster-1");
     });
 
     it("should handle clearing optional fields with null", () => {
@@ -512,7 +560,7 @@ describe("PosterRepository", () => {
       expect(runArgs[5]).toBe(30);
       expect(runArgs[9]).toBe(null); // chatMessage cleared
       expect(runArgs[10]).toBe(1); // isEnabled
-      expect(runArgs[17]).toBe("poster-1"); // id at end
+      expect(runArgs[18]).toBe("poster-1"); // id at end
     });
   });
 
@@ -557,6 +605,24 @@ describe("PosterRepository", () => {
       const result = repository.getById("poster-1");
 
       expect(result!.isEnabled).toBe(false);
+    });
+
+    it("should pass through portrait orientation", () => {
+      const portraitRow = { ...sampleDbRow, orientation: "portrait" };
+      mockStmt.get.mockReturnValue(portraitRow);
+
+      const result = repository.getById("poster-1");
+
+      expect(result!.orientation).toBe("portrait");
+    });
+
+    it("should handle null orientation", () => {
+      const result = (() => {
+        mockStmt.get.mockReturnValue({ ...sampleDbRow, orientation: null });
+        return repository.getById("poster-1");
+      })();
+
+      expect(result!.orientation).toBeNull();
     });
 
     it("should correctly parse complex metadata", () => {

--- a/__tests__/utils/urlDetection.test.ts
+++ b/__tests__/utils/urlDetection.test.ts
@@ -2,6 +2,8 @@ import {
   isValidUrl,
   isYouTubeUrl,
   extractYouTubeId,
+  isYouTubeShortsUrl,
+  detectOrientationFromUrl,
   isDirectMediaUrl,
   getMediaTypeFromUrl,
   getFilenameFromUrl,
@@ -71,6 +73,18 @@ describe("extractYouTubeId", () => {
     ).toBe("dQw4w9WgXcQ");
   });
 
+  it("extracts ID from /shorts/ format", () => {
+    expect(
+      extractYouTubeId("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+    ).toBe("dQw4w9WgXcQ");
+  });
+
+  it("extracts ID from /shorts/ format with query params", () => {
+    expect(
+      extractYouTubeId("https://www.youtube.com/shorts/dQw4w9WgXcQ?feature=share")
+    ).toBe("dQw4w9WgXcQ");
+  });
+
   it("returns null for bare 11-char ID (parsed as hostname with https prefix)", () => {
     // "dQw4w9WgXcQ" becomes a valid URL as "https://dQw4w9WgXcQ",
     // so the bare ID regex fallback is never reached
@@ -87,6 +101,57 @@ describe("extractYouTubeId", () => {
 
   it("returns null for null", () => {
     expect(extractYouTubeId(null as unknown as string)).toBeNull();
+  });
+});
+
+describe("isYouTubeShortsUrl", () => {
+  it("detects /shorts/ URLs", () => {
+    expect(
+      isYouTubeShortsUrl("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+    ).toBe(true);
+  });
+
+  it("detects /shorts/ URLs without protocol", () => {
+    expect(isYouTubeShortsUrl("youtube.com/shorts/dQw4w9WgXcQ")).toBe(true);
+  });
+
+  it("returns false for regular watch URLs", () => {
+    expect(
+      isYouTubeShortsUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    ).toBe(false);
+  });
+
+  it("returns false for youtu.be URLs", () => {
+    expect(isYouTubeShortsUrl("https://youtu.be/dQw4w9WgXcQ")).toBe(false);
+  });
+
+  it("returns false for non-YouTube URLs", () => {
+    expect(isYouTubeShortsUrl("https://vimeo.com/shorts/123")).toBe(false);
+  });
+
+  it("returns false for empty or null inputs", () => {
+    expect(isYouTubeShortsUrl("")).toBe(false);
+    expect(isYouTubeShortsUrl(null as unknown as string)).toBe(false);
+  });
+});
+
+describe("detectOrientationFromUrl", () => {
+  it("returns portrait for YouTube Shorts URLs", () => {
+    expect(
+      detectOrientationFromUrl("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+    ).toBe("portrait");
+  });
+
+  it("returns landscape for regular YouTube URLs", () => {
+    expect(
+      detectOrientationFromUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    ).toBe("landscape");
+  });
+
+  it("returns landscape for non-YouTube inputs", () => {
+    expect(detectOrientationFromUrl("https://example.com/video.mp4")).toBe(
+      "landscape"
+    );
   });
 });
 

--- a/__tests__/utils/urlDetection.test.ts
+++ b/__tests__/utils/urlDetection.test.ts
@@ -91,6 +91,21 @@ describe("extractYouTubeId", () => {
     expect(extractYouTubeId("dQw4w9WgXcQ")).toBeNull();
   });
 
+  it("returns null for look-alike spoofed domains", () => {
+    expect(
+      extractYouTubeId("https://notyoutube.com/watch?v=dQw4w9WgXcQ")
+    ).toBeNull();
+    expect(
+      extractYouTubeId("https://youtube.com.evil.tld/shorts/dQw4w9WgXcQ")
+    ).toBeNull();
+  });
+
+  it("extracts ID from youtube.com subdomains", () => {
+    expect(extractYouTubeId("https://m.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(
+      "dQw4w9WgXcQ"
+    );
+  });
+
   it("returns null for invalid input", () => {
     expect(extractYouTubeId("not-a-video")).toBeNull();
   });
@@ -127,6 +142,13 @@ describe("isYouTubeShortsUrl", () => {
 
   it("returns false for non-YouTube URLs", () => {
     expect(isYouTubeShortsUrl("https://vimeo.com/shorts/123")).toBe(false);
+  });
+
+  it("returns false for look-alike spoofed domains", () => {
+    expect(isYouTubeShortsUrl("https://notyoutube.com/shorts/abc")).toBe(false);
+    expect(isYouTubeShortsUrl("https://youtube.com.evil.tld/shorts/abc")).toBe(
+      false
+    );
   });
 
   it("returns false for empty or null inputs", () => {

--- a/app/api/actions/poster/show/[id]/route.ts
+++ b/app/api/actions/poster/show/[id]/route.ts
@@ -27,6 +27,7 @@ export const POST = withErrorHandler<{ id: string }>(
       fileUrl: poster.fileUrl,
       type: poster.type as "image" | "video" | "youtube",
       transition: 'fade' as const,
+      ...(poster.orientation ? { orientation: poster.orientation } : {}),
     };
 
     const enrichedPayload = enrichPosterPayload(basePayload);

--- a/components/assets/PosterManager.tsx
+++ b/components/assets/PosterManager.tsx
@@ -105,7 +105,8 @@ export function PosterManager() {
   const handleUploadComplete = async (
     url: string,
     type: "image" | "video" | "youtube",
-    duration?: number
+    duration?: number,
+    orientation?: "landscape" | "portrait"
   ) => {
     // Create the poster directly
     try {
@@ -123,6 +124,7 @@ export function PosterManager() {
         type,
         tags: [],
         duration: duration ?? null,
+        orientation: orientation ?? null,
       });
 
       // Navigate to detail page for editing

--- a/components/assets/PosterQuickAdd.tsx
+++ b/components/assets/PosterQuickAdd.tsx
@@ -11,6 +11,7 @@ import { Upload, Loader2, Image as ImageIcon, Video, Youtube, AlertCircle } from
 import {
   isYouTubeUrl,
   extractYouTubeId,
+  detectOrientationFromUrl,
   getInstagramUrlType,
   isDirectMediaUrl,
   getMediaTypeFromUrl,
@@ -48,6 +49,7 @@ interface PreviewState {
   source?: string;
   thumbnailUrl?: string;
   duration?: number | null;
+  orientation?: "landscape" | "portrait";
 }
 
 /**
@@ -196,6 +198,9 @@ export function PosterQuickAdd({
         needsManualDuration = true;
       }
 
+      // YouTube Shorts are vertical (9:16) — flag them so the overlay renders portrait.
+      const orientation = detectOrientationFromUrl(url);
+
       setPreview({
         fileUrl: embedUrl,
         type: "youtube",
@@ -203,6 +208,7 @@ export function PosterQuickAdd({
         source,
         thumbnailUrl: `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`,
         duration,
+        orientation,
       });
       setYoutubeNeedsManualDuration(needsManualDuration);
       setManualDuration("");
@@ -391,6 +397,7 @@ export function PosterQuickAdd({
         duration: preview.duration || null,
         tags: [],
         isEnabled: true,
+        orientation: preview.orientation ?? null,
       });
 
       return data.poster;

--- a/components/assets/PosterUploader.tsx
+++ b/components/assets/PosterUploader.tsx
@@ -7,12 +7,17 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Upload, Link2, Loader2, AlertCircle } from "lucide-react";
-import { extractYouTubeId } from "@/lib/utils/urlDetection";
+import { extractYouTubeId, detectOrientationFromUrl } from "@/lib/utils/urlDetection";
 import { parseDurationString } from "@/lib/utils/durationParser";
 import { useToast } from "@/hooks/use-toast";
 
 interface PosterUploaderProps {
-  onUpload: (url: string, type: "image" | "video" | "youtube", duration?: number) => void;
+  onUpload: (
+    url: string,
+    type: "image" | "video" | "youtube",
+    duration?: number,
+    orientation?: "landscape" | "portrait"
+  ) => void;
   onCancel: () => void;
 }
 
@@ -30,6 +35,7 @@ export function PosterUploader({ onUpload, onCancel }: PosterUploaderProps) {
   const [youtubeNeedsManualDuration, setYoutubeNeedsManualDuration] = useState(false);
   const [manualDuration, setManualDuration] = useState("");
   const [pendingYoutubeUrl, setPendingYoutubeUrl] = useState("");
+  const [pendingOrientation, setPendingOrientation] = useState<"landscape" | "portrait">("landscape");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleDrag = (e: DragEvent) => {
@@ -99,6 +105,9 @@ export function PosterUploader({ onUpload, onCancel }: PosterUploaderProps) {
     }
 
     const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+    // YouTube Shorts are vertical (9:16) — flag them so the overlay renders portrait.
+    // Detect from the raw input now; embedUrl below has lost the /shorts/ signal.
+    const orientation = detectOrientationFromUrl(youtubeUrl);
     setUploading(true);
 
     try {
@@ -109,7 +118,7 @@ export function PosterUploader({ onUpload, onCancel }: PosterUploaderProps) {
         const data = await response.json();
         if (data.success && data.metadata?.duration) {
           // Successfully got duration, create poster directly
-          onUpload(embedUrl, "youtube", data.metadata.duration);
+          onUpload(embedUrl, "youtube", data.metadata.duration, orientation);
           setYoutubeUrl("");
           return;
         }
@@ -117,10 +126,12 @@ export function PosterUploader({ onUpload, onCancel }: PosterUploaderProps) {
 
       // API call failed or no duration - request manual input
       setPendingYoutubeUrl(embedUrl);
+      setPendingOrientation(orientation);
       setYoutubeNeedsManualDuration(true);
     } catch (error) {
       // Network error or API unavailable - request manual input
       setPendingYoutubeUrl(embedUrl);
+      setPendingOrientation(orientation);
       setYoutubeNeedsManualDuration(true);
     } finally {
       setUploading(false);
@@ -138,9 +149,10 @@ export function PosterUploader({ onUpload, onCancel }: PosterUploaderProps) {
       return;
     }
 
-    onUpload(pendingYoutubeUrl, "youtube", duration);
+    onUpload(pendingYoutubeUrl, "youtube", duration, pendingOrientation);
     setYoutubeNeedsManualDuration(false);
     setPendingYoutubeUrl("");
+    setPendingOrientation("landscape");
     setManualDuration("");
     setYoutubeUrl("");
   };

--- a/components/dashboard/cards/PosterCard.tsx
+++ b/components/dashboard/cards/PosterCard.tsx
@@ -51,6 +51,7 @@ interface Poster {
   startTime?: number | null;
   endTime?: number | null;
   endBehavior?: "stop" | "loop" | null;
+  orientation?: "landscape" | "portrait" | null;
   metadata?: {
     chapters?: VideoChapter[];
     [key: string]: unknown;
@@ -242,6 +243,7 @@ export function PosterContent({ className }: PosterContentProps) {
           source: poster.source,
           chapters: poster.metadata?.chapters,
           duration: poster.duration ?? undefined,
+          orientation: poster.orientation ?? undefined,
         },
         mode
       );

--- a/components/overlays/BigPicturePosterRenderer.tsx
+++ b/components/overlays/BigPicturePosterRenderer.tsx
@@ -23,6 +23,7 @@ interface PosterData {
   initialTime?: number; // Initial seek position (resumeFrom from cue, else sub-video startTime)
   initialPlaying?: boolean; // If false, media starts paused (armed-to-air carrying a paused state)
   showId: string; // Unique ID to force React remount on each show
+  orientation?: "landscape" | "portrait"; // "portrait" = vertical 9:16 (YouTube Shorts)
   subVideoConfig?: {
     startTime?: number;
     endTime?: number;
@@ -128,6 +129,7 @@ export function BigPicturePosterRenderer() {
               initialTime: capturedStartTime,
               initialPlaying: capturedPlaying,
               showId: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+              orientation: data.payload.orientation,
               subVideoConfig: data.payload.startTime !== undefined ? {
                 startTime: data.payload.startTime,
                 endTime: data.payload.endTime,
@@ -219,6 +221,7 @@ export function BigPicturePosterRenderer() {
                 initialTime={state.current.initialTime}
                 initialPlaying={state.current.initialPlaying}
                 videoKey={state.current.showId}
+                orientation={state.current.orientation}
                 subVideoConfig={state.current.subVideoConfig}
                 onYouTubeIframeLoad={state.current.type === "youtube" ? playback.handleYouTubeIframeLoad : undefined}
               />

--- a/components/overlays/PosterDisplay.tsx
+++ b/components/overlays/PosterDisplay.tsx
@@ -8,6 +8,7 @@ interface PosterDisplayProps {
   aspectRatio: number;
   positioning: "side" | "center"; // side = left/right positioning, center = big-picture centered
   side?: "left" | "right"; // only used when positioning="side"
+  orientation?: "landscape" | "portrait"; // "portrait" = vertical 9:16 (YouTube Shorts)
   videoRef?: React.RefObject<HTMLVideoElement | null>;
   youtubeRef?: React.RefObject<HTMLIFrameElement | null>;
   initialTime?: number; // Initial seek position (resumeFrom from cue, else sub-video clip start)
@@ -31,6 +32,7 @@ export function PosterDisplay({
   aspectRatio,
   positioning,
   side = "left",
+  orientation = "landscape",
   videoRef,
   youtubeRef,
   initialTime,
@@ -40,6 +42,7 @@ export function PosterDisplay({
   onYouTubeIframeLoad,
 }: PosterDisplayProps) {
   const isLeftSide = side === "left";
+  const isPortrait = orientation === "portrait";
   const localVideoRef = useRef<HTMLVideoElement>(null);
   const effectiveVideoRef = videoRef || localVideoRef;
 
@@ -82,11 +85,14 @@ export function PosterDisplay({
             left: '50%',
             top: '50%',
             transform: 'translate(-50%, -50%)',
-            width: '100vw',
-            height: '100vh',
-            aspectRatio: '16 / 9',
             margin: 0,
             padding: 0,
+            // Portrait (Shorts): drive off height and let width derive from the
+            // 9:16 ratio so the vertical video fills the screen height, centered
+            // as a pillar (no side letterboxing). Landscape fills the viewport 16:9.
+            ...(isPortrait
+              ? { height: '100vh', aspectRatio: '9 / 16' }
+              : { width: '100vw', height: '100vh', aspectRatio: '16 / 9' }),
           }
         : {
             // Side mode: positioned left or right, centered vertically
@@ -105,8 +111,11 @@ export function PosterDisplay({
                 }),
             top: '50%',
             transform: 'translate(0%, -50%)',
-            width: '50%',
-            aspectRatio: '16 / 9',
+            // Portrait (Shorts): tall 9:16 pillar hugging the side; landscape keeps
+            // the half-width 16:9 box.
+            ...(isPortrait
+              ? { height: '90%', aspectRatio: '9 / 16' }
+              : { width: '50%', aspectRatio: '16 / 9' }),
           };
 
     return (

--- a/components/overlays/PosterRenderer.tsx
+++ b/components/overlays/PosterRenderer.tsx
@@ -34,6 +34,7 @@ interface PosterData {
   initialTime?: number; // Initial seek position (resumeFrom from cue, else sub-video startTime)
   initialPlaying?: boolean; // If false, poster starts paused (cued-to-air carrying a paused state)
   showId: string; // Unique ID to force React remount on each show
+  orientation?: "landscape" | "portrait"; // "portrait" = vertical 9:16 (YouTube Shorts)
   subVideoConfig?: {
     startTime?: number;
     endTime?: number;
@@ -181,6 +182,7 @@ export function PosterRenderer() {
               initialTime: capturedStartTime,
               initialPlaying: capturedPlaying,
               showId: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+              orientation: data.payload!.orientation,
               subVideoConfig: data.payload!.startTime !== undefined ? {
                 startTime: data.payload!.startTime,
                 endTime: data.payload!.endTime,
@@ -273,6 +275,7 @@ export function PosterRenderer() {
                 initialTime={state.current.initialTime}
                 initialPlaying={state.current.initialPlaying}
                 videoKey={state.current.showId}
+                orientation={state.current.orientation}
                 subVideoConfig={state.current.subVideoConfig}
                 onYouTubeIframeLoad={state.current.type === "youtube" ? playback.handleYouTubeIframeLoad : undefined}
               />

--- a/hooks/useArmedVideoPoster.ts
+++ b/hooks/useArmedVideoPoster.ts
@@ -39,6 +39,8 @@ export interface ArmedVideoPoster {
   endBehavior?: "stop" | "loop";
   source?: string;
   chapters?: VideoChapter[];
+  /** "portrait" for YouTube Shorts / vertical videos (9:16). */
+  orientation?: "landscape" | "portrait";
 
   /** false while staging locally, true after Go Live. */
   isLive: boolean;
@@ -62,6 +64,7 @@ export interface PosterInput {
   source?: string;
   chapters?: VideoChapter[];
   duration?: number;
+  orientation?: "landscape" | "portrait";
 }
 
 const VALID_DISPLAY_MODES: ReadonlySet<DisplayMode> = new Set(["left", "right", "bigpicture"]);
@@ -93,6 +96,7 @@ function loadInitial(): ArmedVideoPoster | null {
       endBehavior: parsed.endBehavior,
       source: parsed.source,
       chapters: parsed.chapters,
+      orientation: parsed.orientation,
       isLive: false, // Persistence is staging-only; never restore as live.
       currentTime: parsed.currentTime,
       isPlaying: parsed.isPlaying,
@@ -192,6 +196,7 @@ function buildShowPayload(armed: ArmedVideoPoster): Record<string, unknown> {
   if (armed.startTime != null) payload.startTime = armed.startTime;
   if (armed.endTime != null) payload.endTime = armed.endTime;
   if (armed.endBehavior) payload.endBehavior = armed.endBehavior;
+  if (armed.orientation) payload.orientation = armed.orientation;
   if (armed.displayMode !== "bigpicture") payload.side = armed.displayMode;
   return payload;
 }
@@ -231,6 +236,7 @@ export function useArmedVideoPoster(): UseArmedVideoPosterReturn {
         endBehavior: poster.endBehavior,
         source: poster.source,
         chapters: poster.chapters,
+        orientation: poster.orientation,
         isLive: false,
         currentTime: poster.startTime ?? 0,
         isPlaying: false,
@@ -402,6 +408,7 @@ export function useArmedVideoPosterSync(): void {
           endBehavior: p.endBehavior as "stop" | "loop" | undefined,
           source: typeof p.source === "string" ? p.source : undefined,
           chapters: Array.isArray(p.chapters) ? (p.chapters as VideoChapter[]) : undefined,
+          orientation: p.orientation as "landscape" | "portrait" | undefined,
           currentTime: typeof p.resumeFrom === "number" ? p.resumeFrom : 0,
           isPlaying: typeof p.resumePlaying === "boolean" ? p.resumePlaying : false,
           isMuted: true,

--- a/lib/models/Database.ts
+++ b/lib/models/Database.ts
@@ -41,6 +41,7 @@ export interface DbPoster {
   endTime: number | null;         // End time in seconds for sub-video clip
   thumbnailUrl: string | null;    // Custom thumbnail URL for sub-video
   endBehavior: "stop" | "loop" | null;  // Behavior at end of sub-video clip
+  orientation: "landscape" | "portrait" | null;  // Video orientation (portrait = YouTube Shorts / vertical)
   createdAt: Date;
   updatedAt: Date;
 }

--- a/lib/models/OverlayEvents.ts
+++ b/lib/models/OverlayEvents.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { videoChapterSchema, endBehaviorSchema, VideoChapter } from "./Poster";
+import { videoChapterSchema, endBehaviorSchema, orientationSchema, VideoChapter } from "./Poster";
 import type { WordHarvestEvent } from "./WordHarvest";
 export type { WordHarvestEvent } from "./WordHarvest";
 export { isWordHarvestEvent, WordHarvestEventType } from "./WordHarvest";
@@ -228,6 +228,8 @@ export const posterShowPayloadSchema = z.object({
   posterId: z.string().uuid().optional(),
   fileUrl: z.string(),
   type: z.enum(["image", "video", "youtube"]).optional(),
+  // Video orientation: "portrait" for YouTube Shorts / vertical videos (9:16).
+  orientation: orientationSchema.optional(),
   transition: z.enum(["fade", "slide", "cut", "blur-sm"]).default("fade"),
   duration: z.number().int().positive().optional(),
   side: z.enum(["left", "right"]).optional(),

--- a/lib/models/Poster.ts
+++ b/lib/models/Poster.ts
@@ -20,6 +20,13 @@ export const endBehaviorSchema = z.enum(["stop", "loop"]);
 export type EndBehavior = z.infer<typeof endBehaviorSchema>;
 
 /**
+ * Video orientation: "portrait" for vertical 9:16 videos (YouTube Shorts),
+ * "landscape" otherwise. Single source of truth for the union across the app.
+ */
+export const orientationSchema = z.enum(["landscape", "portrait"]);
+export type Orientation = z.infer<typeof orientationSchema>;
+
+/**
  * Video chapter schema - markers in the timeline for navigation
  */
 export const videoChapterSchema = z.object({
@@ -57,6 +64,8 @@ export const posterSchema = z.object({
   endTime: z.number().min(0).nullable().default(null),
   thumbnailUrl: z.string().nullable().default(null),
   endBehavior: endBehaviorSchema.nullable().default(null),
+  // Video orientation: "portrait" for YouTube Shorts / vertical videos (9:16), "landscape" otherwise
+  orientation: orientationSchema.nullable().default(null),
   createdAt: z.date().default(() => new Date()),
   updatedAt: z.date().default(() => new Date()),
 });

--- a/lib/queries/usePosters.ts
+++ b/lib/queries/usePosters.ts
@@ -22,6 +22,7 @@ export interface Poster {
   startTime?: number | null;
   endTime?: number | null;
   thumbnailUrl?: string | null;
+  orientation?: "landscape" | "portrait" | null;
 }
 
 interface PostersResponse {
@@ -47,6 +48,7 @@ export interface CreatePosterInput {
   startTime?: number | null;
   endTime?: number | null;
   thumbnailUrl?: string | null;
+  orientation?: "landscape" | "portrait" | null;
 }
 
 export interface UpdatePosterInput {
@@ -64,6 +66,7 @@ export interface UpdatePosterInput {
   startTime?: number | null;
   endTime?: number | null;
   thumbnailUrl?: string | null;
+  orientation?: "landscape" | "portrait" | null;
 }
 
 export function usePosters() {

--- a/lib/repositories/PosterRepository.ts
+++ b/lib/repositories/PosterRepository.ts
@@ -11,13 +11,14 @@ import type {
  */
 type DbPosterRow = Omit<
   DbPoster,
-  "tags" | "profileIds" | "metadata" | "isEnabled" | "endBehavior" | "createdAt" | "updatedAt"
+  "tags" | "profileIds" | "metadata" | "isEnabled" | "endBehavior" | "orientation" | "createdAt" | "updatedAt"
 > & {
   tags: string;
   profileIds: string;
   metadata: string | null;
   isEnabled: number;
   endBehavior: string | null;
+  orientation: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -65,13 +66,14 @@ export class PosterRepository extends EnabledBaseRepository<
   }
 
   /**
-   * Override transformRow to handle endBehavior type casting
+   * Override transformRow to handle endBehavior / orientation type casting
    */
   protected override transformRow(row: DbPosterRow): DbPoster {
     const base = super.transformRow(row);
     return {
       ...base,
       endBehavior: row.endBehavior as DbPoster["endBehavior"],
+      orientation: row.orientation as DbPoster["orientation"],
     };
   }
 
@@ -81,8 +83,8 @@ export class PosterRepository extends EnabledBaseRepository<
   create(poster: DbPosterInput): void {
     const now = new Date();
     const stmt = this.rawDb.prepare(`
-      INSERT INTO posters (id, title, description, source, fileUrl, type, duration, tags, profileIds, metadata, chatMessage, isEnabled, parentPosterId, startTime, endTime, thumbnailUrl, endBehavior, createdAt, updatedAt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO posters (id, title, description, source, fileUrl, type, duration, tags, profileIds, metadata, chatMessage, isEnabled, parentPosterId, startTime, endTime, thumbnailUrl, endBehavior, orientation, createdAt, updatedAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       poster.id,
@@ -102,6 +104,7 @@ export class PosterRepository extends EnabledBaseRepository<
       poster.endTime ?? null,
       poster.thumbnailUrl || null,
       poster.endBehavior || null,
+      poster.orientation || null,
       this.prepareValue(poster.createdAt || now),
       this.prepareValue(poster.updatedAt || now)
     );
@@ -135,12 +138,13 @@ export class PosterRepository extends EnabledBaseRepository<
       endTime: updates.endTime !== undefined ? updates.endTime : existing.endTime,
       thumbnailUrl: updates.thumbnailUrl !== undefined ? updates.thumbnailUrl : existing.thumbnailUrl,
       endBehavior: updates.endBehavior !== undefined ? updates.endBehavior : existing.endBehavior,
+      orientation: updates.orientation !== undefined ? updates.orientation : existing.orientation,
       updatedAt: updates.updatedAt || new Date(),
     };
 
     const stmt = this.rawDb.prepare(`
       UPDATE posters
-      SET title = ?, description = ?, source = ?, fileUrl = ?, type = ?, duration = ?, tags = ?, profileIds = ?, metadata = ?, chatMessage = ?, isEnabled = ?, parentPosterId = ?, startTime = ?, endTime = ?, thumbnailUrl = ?, endBehavior = ?, updatedAt = ?
+      SET title = ?, description = ?, source = ?, fileUrl = ?, type = ?, duration = ?, tags = ?, profileIds = ?, metadata = ?, chatMessage = ?, isEnabled = ?, parentPosterId = ?, startTime = ?, endTime = ?, thumbnailUrl = ?, endBehavior = ?, orientation = ?, updatedAt = ?
       WHERE id = ?
     `);
     stmt.run(
@@ -160,6 +164,7 @@ export class PosterRepository extends EnabledBaseRepository<
       merged.endTime ?? null,
       merged.thumbnailUrl || null,
       merged.endBehavior || null,
+      merged.orientation || null,
       this.prepareValue(merged.updatedAt),
       id
     );

--- a/lib/services/DatabaseService.ts
+++ b/lib/services/DatabaseService.ts
@@ -155,6 +155,12 @@ export class DatabaseService {
         column: "endBehavior",
         definition: "TEXT",
       },
+      {
+        name: "posters_orientation",
+        table: "posters",
+        column: "orientation",
+        definition: "TEXT", // 'landscape' | 'portrait' | NULL (NULL = landscape)
+      },
 
       // Wikipedia cache columns
       {

--- a/lib/services/SubVideoService.ts
+++ b/lib/services/SubVideoService.ts
@@ -134,6 +134,7 @@ export class SubVideoService {
       endTime,
       thumbnailUrl: thumbnailUrl || null,
       endBehavior,
+      orientation: parentPoster.orientation, // Inherit vertical/landscape orientation from parent
       createdAt: now,
       updatedAt: now,
     };

--- a/lib/utils/urlDetection.ts
+++ b/lib/utils/urlDetection.ts
@@ -5,6 +5,15 @@
 import type { Orientation } from "@/lib/models/Poster";
 
 /**
+ * True only for the youtube.com registrable domain or its subdomains
+ * (youtube.com, www./m./music.youtube.com). Anchored so look-alike hosts
+ * like notyoutube.com or youtube.com.evil.tld are rejected.
+ */
+function isYouTubeHostname(hostname: string): boolean {
+  return /(^|\.)youtube\.com$/i.test(hostname);
+}
+
+/**
  * Validates if a string is a valid URL
  */
 export function isValidUrl(url: string): boolean {
@@ -53,7 +62,7 @@ export function extractYouTubeId(url: string): string | null {
 
   // Helper to extract ID from URL object
   const getIdFromUrl = (urlObj: URL): string | null => {
-    if (urlObj.hostname.includes('youtube.com')) {
+    if (isYouTubeHostname(urlObj.hostname)) {
       // Check for /watch?v=ID format
       const videoId = urlObj.searchParams.get('v');
       if (videoId) return videoId;
@@ -104,7 +113,7 @@ export function isYouTubeShortsUrl(url: string): boolean {
 
   try {
     const urlObj = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
-    return urlObj.hostname.includes('youtube.com') && urlObj.pathname.startsWith('/shorts/');
+    return isYouTubeHostname(urlObj.hostname) && urlObj.pathname.startsWith('/shorts/');
   } catch {
     return false;
   }

--- a/lib/utils/urlDetection.ts
+++ b/lib/utils/urlDetection.ts
@@ -2,6 +2,8 @@
  * URL detection utilities for PosterQuickAdd
  */
 
+import type { Orientation } from "@/lib/models/Poster";
+
 /**
  * Validates if a string is a valid URL
  */
@@ -41,6 +43,7 @@ export function isYouTubeUrl(url: string): boolean {
  * - https://www.youtube.com/watch?v=VIDEO_ID
  * - https://youtu.be/VIDEO_ID
  * - https://www.youtube.com/embed/VIDEO_ID
+ * - https://www.youtube.com/shorts/VIDEO_ID
  * - VIDEO_ID (bare ID)
  */
 export function extractYouTubeId(url: string): string | null {
@@ -58,6 +61,10 @@ export function extractYouTubeId(url: string): string | null {
       // Check for /embed/ID format
       const embedMatch = urlObj.pathname.match(/\/embed\/([^/?]+)/);
       if (embedMatch) return embedMatch[1];
+
+      // Check for /shorts/ID format (YouTube Shorts)
+      const shortsMatch = urlObj.pathname.match(/\/shorts\/([^/?]+)/);
+      if (shortsMatch) return shortsMatch[1];
     } else if (urlObj.hostname === 'youtu.be') {
       // Short URL format: youtu.be/ID
       return urlObj.pathname.slice(1).split('?')[0];
@@ -83,6 +90,33 @@ export function extractYouTubeId(url: string): string | null {
       return null;
     }
   }
+}
+
+/**
+ * Detects if a URL is a YouTube Shorts URL (youtube.com/shorts/VIDEO_ID).
+ * Shorts are vertical (9:16) videos and are rendered in portrait orientation.
+ */
+export function isYouTubeShortsUrl(url: string): boolean {
+  if (!url || typeof url !== 'string') return false;
+
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+
+  try {
+    const urlObj = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
+    return urlObj.hostname.includes('youtube.com') && urlObj.pathname.startsWith('/shorts/');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Determines the orientation a video URL should be displayed in.
+ * Vertical sources (YouTube Shorts) are "portrait"; everything else "landscape".
+ * Single source of truth so all ingestion paths classify URLs identically.
+ */
+export function detectOrientationFromUrl(url: string): Orientation {
+  return isYouTubeShortsUrl(url) ? "portrait" : "landscape";
 }
 
 const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif'];


### PR DESCRIPTION
## Contexte

Coller une URL de **YouTube Short** (`youtube.com/shorts/VIDEO_ID`) échouait avec « URL YouTube invalide » : `extractYouTubeId()` ne gérait que les formats `watch?v=`, `youtu.be/` et `/embed/`. De plus, les Shorts sont **verticaux (9:16)** alors que l'overlay poster rend en 16:9.

## Ce que fait cette PR

**1. Parsing** — `extractYouTubeId()` reconnaît désormais `/shorts/`. Ajout de `isYouTubeShortsUrl()` et `detectOrientationFromUrl()` dans `lib/utils/urlDetection.ts`.

**2. Affichage vertical** — comme l'ingestion normalise vers `/embed/` (ce qui efface le signal « short »), l'orientation est détectée à l'ingestion et **persistée** via une nouvelle colonne `orientation` (`"landscape" | "portrait"`) sur les posters. Elle est propagée DB → API create → payload `show` (chemin Stream Deck **et** cue-to-air) → renderers d'overlay. La branche YouTube de `PosterDisplay` pilote alors la boîte par la **hauteur** avec `aspectRatio: 9/16` en portrait (vidéo pleine hauteur, centrée, sans bandes noires latérales) ; le mode landscape est inchangé.

**3. Sous-vidéos** — un clip hérite de l'orientation de son parent.

## Compatibilité

`orientation` est nullable/optionnel partout → les posters existants et toutes les autres sources (uploads, Instagram, Stream Deck, mcp-server) restent en `landscape`, inchangés. La migration de colonne est additive et idempotente (`columnExists`).

## Qualité

- Type partagé `orientationSchema`/`Orientation` (calqué sur `endBehaviorSchema`/`EndBehavior`) — pas de duplication du union literal dans les schémas Zod.
- Détection centralisée dans un seul helper `detectOrientationFromUrl`.
- Développé en TDD ; code review high-effort passée (2 findings DRY appliqués, 2 écartés avec justification).

## Tests

- `__tests__/utils/urlDetection.test.ts` — parsing `/shorts/`, `isYouTubeShortsUrl`, `detectOrientationFromUrl`.
- `__tests__/repositories/PosterRepository.test.ts` — colonne `orientation` en INSERT/UPDATE/transform.
- `__tests__/components/PosterDisplay.test.tsx` (nouveau) — boîte 9:16 portrait vs 16:9 landscape, center & side.
- `__tests__/components/PosterRenderer.test.tsx` — non-régression.

Suites ciblées : **99/99 ✓**. Suite Jest hors-mcp : 1382 ✓ (les seuls échecs sont pré-existants et sans rapport — quiz functional + suites qui ne chargent pas pour raisons ESM ; mcp-server se lance via `pnpm test:mcp`).

## Vérification manuelle

1. Ajouter un poster via `https://www.youtube.com/shorts/<id>` → accepté, miniature/durée OK.
2. Envoyer à l'antenne (`/overlays/poster`) → lecture **verticale 9:16**, centrée, sans bandes latérales (modes center & side).
3. Une URL YouTube classique reste en 16:9 (non-régression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)