### PR TITLE
feat(live-assist): STT prod hardening — unbuffered logs + hallucination filter

### DIFF
--- a/__tests__/services/liveassist/LiveAssistOrchestrator.test.ts
+++ b/__tests__/services/liveassist/LiveAssistOrchestrator.test.ts
@@ -129,20 +129,23 @@ describe("LiveAssistOrchestrator", () => {
     expect(events.some((e) => e.type === "suggestion:new")).toBe(false);
   });
 
-  it("drops a hallucination segment (no transcript, no keyword scan) but stays connected", async () => {
+  it("drops a hallucination segment (not recorded, not broadcast, no scan) but stays connected", async () => {
     const transcripts: string[] = [];
+    const recorded: string[] = [];
     const statusCalls: Array<[boolean, string | null]> = [];
     const { orch, events } = makeOrchestrator(
       { actionnable: true, intent: "poster", entite: "Le Cid", confiance: 0.9 },
       {
         isHallucination: (text: string) => text.startsWith("Sous-titrage"),
+        recordTranscript: (text: string) => recorded.push(text),
         publishTranscript: (text: string) => transcripts.push(text),
         publishStatus: (c: boolean, d: string | null) => statusCalls.push([c, d]),
       },
     );
     // Contains the fixture keyword "spectacle" — a non-hallucination segment would
-    // register a window. Being a hallucination, it's dropped before scan + publish.
+    // register a window. Being a hallucination, it's dropped before record/scan/publish.
     await orch.ingestSegment(seg("Sous-titrage spectacle Société Radio-Canada", 10000, 11000));
+    expect(recorded).toEqual([]); // not persisted to the transcript file
     expect(transcripts).toEqual([]); // not re-broadcast
     expect(events.some((e) => e.type === "suggestion:new")).toBe(false); // no window/suggestion
     expect(statusCalls[0]?.[0]).toBe(true); // STT still marked connected (alive)

--- a/__tests__/services/liveassist/LiveAssistOrchestrator.test.ts
+++ b/__tests__/services/liveassist/LiveAssistOrchestrator.test.ts
@@ -129,6 +129,25 @@ describe("LiveAssistOrchestrator", () => {
     expect(events.some((e) => e.type === "suggestion:new")).toBe(false);
   });
 
+  it("drops a hallucination segment (no transcript, no keyword scan) but stays connected", async () => {
+    const transcripts: string[] = [];
+    const statusCalls: Array<[boolean, string | null]> = [];
+    const { orch, events } = makeOrchestrator(
+      { actionnable: true, intent: "poster", entite: "Le Cid", confiance: 0.9 },
+      {
+        isHallucination: (text: string) => text.startsWith("Sous-titrage"),
+        publishTranscript: (text: string) => transcripts.push(text),
+        publishStatus: (c: boolean, d: string | null) => statusCalls.push([c, d]),
+      },
+    );
+    // Contains the fixture keyword "spectacle" — a non-hallucination segment would
+    // register a window. Being a hallucination, it's dropped before scan + publish.
+    await orch.ingestSegment(seg("Sous-titrage spectacle Société Radio-Canada", 10000, 11000));
+    expect(transcripts).toEqual([]); // not re-broadcast
+    expect(events.some((e) => e.type === "suggestion:new")).toBe(false); // no window/suggestion
+    expect(statusCalls[0]?.[0]).toBe(true); // STT still marked connected (alive)
+  });
+
   it("publishes the live transcript for the debug view by default", async () => {
     const transcripts: string[] = [];
     const { orch } = makeOrchestrator(

--- a/__tests__/services/liveassist/hallucinationFilter.test.ts
+++ b/__tests__/services/liveassist/hallucinationFilter.test.ts
@@ -11,11 +11,21 @@ describe("isHallucination", () => {
       expect(isHallucination(text)).toBe(true);
     });
 
+    // Matched by the brand/sign-off regex families (not the exact-phrase list).
     it.each([
       "Merci d'avoir regardé cette vidéo",
       "Amara.org",
       "SousTitreur.com",
-    ])("exact phrase: %s", (text) => {
+    ])("brand / sign-off family: %s", (text) => {
+      expect(isHallucination(text)).toBe(true);
+    });
+
+    // Matched by the exact HALLUCINATION_PHRASES list (whole-segment).
+    it.each([
+      "Abonnez-vous",
+      "[Musique]",
+      "Thanks for watching",
+    ])("exact phrase list: %s", (text) => {
       expect(isHallucination(text)).toBe(true);
     });
 

--- a/__tests__/services/liveassist/hallucinationFilter.test.ts
+++ b/__tests__/services/liveassist/hallucinationFilter.test.ts
@@ -1,0 +1,70 @@
+import { isHallucination } from "@/lib/services/liveassist/hallucinationFilter";
+
+describe("isHallucination", () => {
+  describe("drops Whisper silence-hallucinations", () => {
+    it.each([
+      "Sous-titrage ST' 501",
+      "Sous-titrage Société Radio-Canada",
+      "Sous-titrage FR 2021",
+      "Sous-titres réalisés par la communauté d'Amara.org",
+    ])("the subtitle-credit family: %s", (text) => {
+      expect(isHallucination(text)).toBe(true);
+    });
+
+    it.each([
+      "Merci d'avoir regardé cette vidéo",
+      "Amara.org",
+      "SousTitreur.com",
+    ])("exact phrase: %s", (text) => {
+      expect(isHallucination(text)).toBe(true);
+    });
+
+    it("ignores trailing punctuation", () => {
+      expect(isHallucination("Sous-titrage FR 2021.")).toBe(true);
+      expect(isHallucination("Merci d'avoir regardé cette vidéo !")).toBe(true);
+    });
+
+    it("ignores surrounding quotes / guillemets", () => {
+      expect(isHallucination("« Sous-titrage Société Radio-Canada »")).toBe(true);
+    });
+
+    it("is case- and accent-insensitive", () => {
+      expect(isHallucination("MERCI D'AVOIR REGARDÉ CETTE VIDÉO")).toBe(true);
+      expect(isHallucination("merci d'avoir regarde cette video")).toBe(true);
+    });
+
+    it("folds the typographic apostrophe (U+2019) Whisper emits", () => {
+      expect(isHallucination("Merci d’avoir regardé cette vidéo")).toBe(true);
+    });
+
+    it.each([
+      "Sous-titres réalisés para la communauté d'Amara.org", // malformed "para" variant
+      "❤️ par SousTitreur.com",
+      "Copyright WDR 2021",
+      "Merci d'avoir regardé la vidéo", // "la" instead of "cette"
+      "J'espère que vous avez apprécié la vidéo",
+      "Subtitles by the Amara.org community",
+      "Transcribed by https://otter.ai",
+      "(Rires)",
+    ])("extended families from web research: %s", (text) => {
+      expect(isHallucination(text)).toBe(true);
+    });
+  });
+
+  describe("keeps real speech", () => {
+    it.each([
+      "le spectacle Le Cid ce soir",
+      "on parle du film Basic Instinct",
+      "abonnez-vous à la newsletter du théâtre", // not the exact "Abonnez-vous"
+      "je regarde la vidéo de présentation", // contains words but not a credit phrase
+      "société radio-canada a produit ce documentaire", // 'sous-titrage' prefix absent
+    ])("does not drop: %s", (text) => {
+      expect(isHallucination(text)).toBe(false);
+    });
+
+    it("returns false for empty / punctuation-only text", () => {
+      expect(isHallucination("")).toBe(false);
+      expect(isHallucination("   ")).toBe(false);
+    });
+  });
+});

--- a/lib/config/Constants.ts
+++ b/lib/config/Constants.ts
@@ -737,6 +737,54 @@ export const LIVE_ASSIST = {
     "ce", "ces", "cette", "son", "sa", "ses", "leur", "leurs", "dans", "pour",
     "par", "sur", "avec", "sans", "que", "qui", "quoi",
   ] as string[],
+  /** Whisper "silence hallucination" filter. faster-whisper was trained on
+   *  YouTube/TV subtitles, so during silence/non-speech it emits subtitle credits
+   *  and boilerplate ("Sous-titrage Société Radio-Canada", "Merci d'avoir regardé
+   *  cette vidéo", …). These segments are dropped at ingest. Matched on the
+   *  normalized form (lowercase, accent-stripped, apostrophe-folded — same `norm()`
+   *  as keywords), ignoring surrounding punctuation/quotes. Store readable text
+   *  here (accents/apostrophes OK); normalization happens at match time. */
+  HALLUCINATION_PHRASES: [
+    // Matched whole-segment (exact, after normalization + punctuation strip), so a
+    // CTA like "Abonnez-vous" only drops a segment that IS exactly that — real speech
+    // ("abonnez-vous à la newsletter") is kept. Brand/credit families are handled by
+    // HALLUCINATION_PATTERNS below instead, to catch their many variants.
+    // FR
+    "Abonnez-vous",
+    "N'oubliez pas de vous abonner",
+    "[Musique]",
+    "[Applaudissements]",
+    "(Rires)",
+    "[Rires]",
+    // EN
+    "Thanks for watching",
+    "Thank you for watching",
+    "Please subscribe",
+    "[Music]",
+    "[Applause]",
+  ] as string[],
+  /** Regex families (run on the normalized — lowercased, accent-stripped,
+   *  apostrophe-folded — text). Brand/credit tokens never occur in genuine studio
+   *  speech, so these are matched anywhere; the `^…` ones assume the hallucination
+   *  is the whole segment. Sources: openai/whisper discussions #928/#1873, the
+   *  HF `whisper-hallucinations` dataset, whisper.cpp #2660. */
+  HALLUCINATION_PATTERNS: [
+    // "Sous-titrage ST' 501", "… Société Radio-Canada", "… FR 2021",
+    // "Sous-titres réalisés par la communauté d'Amara.org" (incl. the malformed "para" variant)
+    /^sous-?titr(age|es)\b/,
+    // Amara.org credit in any language wrapper (FR/EN/DE/ES/IT/PT/ZH…)
+    /amara\s*\.?\s*org/,
+    // SousTitreur.com credit ("❤️ par SousTitreur.com")
+    /soustitreur\s*\.?\s*com/,
+    // Cross-language TV/credit line ending in a year ("copyright wdr 2021", "… zdf … 2017")
+    /\b(copyright|untertitel|legendas?|sottotitoli|subtitulos)\b.*\b(19|20)\d{2}\b/,
+    // Transcription-service credits (Otter / CastingWords)
+    /\b(transcri(bed|ption|pt)|transcrit)\b.*\b(otter\s*\.?\s*ai|castingwords)\b/,
+    // FR sign-off family ("merci d'avoir regardé [cette|la] vidéo", "… regardé !")
+    /^merci d'avoir regard/,
+    // FR sign-off ("j'espère que vous avez apprécié [cette|la] vidéo")
+    /^j'espere que vous avez apprecie/,
+  ] as RegExp[],
 } as const;
 
 // ============================================================================

--- a/lib/services/liveassist/LiveAssistOrchestrator.ts
+++ b/lib/services/liveassist/LiveAssistOrchestrator.ts
@@ -9,6 +9,7 @@ import { SuggestionStore } from "./SuggestionStore";
 import { ProviderRegistry } from "./providers/ActionProvider";
 import type { BuiltSuggestion } from "./providers/ActionProvider";
 import type { IntentExtractor } from "./IntentExtractor";
+import { isHallucination as defaultIsHallucination } from "./hallucinationFilter";
 
 const logger = new Logger("LiveAssistOrchestrator");
 
@@ -50,6 +51,12 @@ interface Deps {
    * no extractor). Returns [] when disabled.
    */
   matchLocalPosters?: (text: string) => BuiltSuggestion[];
+  /**
+   * Drop a finalized segment that is a known Whisper "silence hallucination"
+   * (subtitle credits / boilerplate emitted during non-speech). Defaults to the
+   * shared `isHallucination` filter; injectable for tests.
+   */
+  isHallucination?: (text: string) => boolean;
   staleMs?: number;
 }
 
@@ -62,6 +69,7 @@ export class LiveAssistOrchestrator {
   private readonly publishTranscript: (text: string, t0: number, t1: number) => void;
   private readonly recordTranscript: (text: string) => void;
   private readonly resolveDeviceLabel: (id: string) => string;
+  private readonly isHallucination: (text: string) => boolean;
   private readonly staleMs: number;
   private lastSeenAt = 0;
 
@@ -73,6 +81,7 @@ export class LiveAssistOrchestrator {
     this.publishTranscript = deps.publishTranscript ?? (() => undefined);
     this.recordTranscript = deps.recordTranscript ?? (() => undefined);
     this.resolveDeviceLabel = deps.resolveDeviceLabel ?? ((id) => id);
+    this.isHallucination = deps.isHallucination ?? defaultIsHallucination;
     this.staleMs = deps.staleMs ?? LIVE_ASSIST.STT_STALE_MS;
   }
 
@@ -125,6 +134,12 @@ export class LiveAssistOrchestrator {
     if (!segment.final) return;
     if (!this.isEnabled()) return;
     this.markSttAlive();
+    // Drop known Whisper "silence hallucinations" (subtitle credits / boilerplate
+    // emitted during non-speech) BEFORE anything else — so they never reach the
+    // transcript file, the buffer, keyword detection, the debug view, or a
+    // suggestion. markSttAlive() above already ran: a hallucination still proves the
+    // STT service is producing output.
+    if (this.isHallucination(segment.text)) return;
     // Always persist to the transcript file (gated only by enabled/final above);
     // the debug flag below only governs the live websocket re-broadcast.
     this.recordTranscript(segment.text);

--- a/lib/services/liveassist/hallucinationFilter.ts
+++ b/lib/services/liveassist/hallucinationFilter.ts
@@ -20,8 +20,10 @@ const NORM_PHRASES = new Set(LIVE_ASSIST.HALLUCINATION_PHRASES.map(norm));
  * "Abonnez-vous" is dropped, but "abonnez-vous à la newsletter" is real speech and kept.
  */
 export function isHallucination(text: string): boolean {
+  // Strip surrounding whitespace/quotes/punctuation (NOT []() — those are
+  // significant for caption tags like "[Musique]").
   const t = norm(text)
-    .replace(/^[\s"'«».,!?…–—-]+|[\s"'«».,!?…–—-]+$/g, "")
+    .replace(/^[\s"'«».,;:!?…–—-]+|[\s"'«».,;:!?…–—-]+$/g, "")
     .trim();
   if (!t) return false; // empty / punctuation-only carries no signal — not flagged
   if (NORM_PHRASES.has(t)) return true;

--- a/lib/services/liveassist/hallucinationFilter.ts
+++ b/lib/services/liveassist/hallucinationFilter.ts
@@ -1,0 +1,29 @@
+// lib/services/liveassist/hallucinationFilter.ts
+import { LIVE_ASSIST } from "@/lib/config/Constants";
+import { norm } from "./KeywordDetector";
+
+// Pre-normalize the phrase blocklist once at module load. `norm` lowercases, strips
+// accents, and folds apostrophe variants — the same normalization the KeywordDetector
+// uses — so the list can be stored as readable French/English in Constants.
+const NORM_PHRASES = new Set(LIVE_ASSIST.HALLUCINATION_PHRASES.map(norm));
+
+/**
+ * True when a finalized STT segment is a known Whisper "silence hallucination":
+ * subtitle credits / boilerplate the model emits during non-speech (it was trained
+ * on YouTube/TV subtitles). Two layers, both on the normalized text with surrounding
+ * punctuation/quotes stripped (so "Merci." == "merci", "« … »" == "…"):
+ *   - exact match against LIVE_ASSIST.HALLUCINATION_PHRASES, and
+ *   - regex families in LIVE_ASSIST.HALLUCINATION_PATTERNS (e.g. the "Sous-titrage …"
+ *     family where a station/number/year varies).
+ *
+ * Exact-match (not substring) for the phrase list keeps false positives near zero:
+ * "Abonnez-vous" is dropped, but "abonnez-vous à la newsletter" is real speech and kept.
+ */
+export function isHallucination(text: string): boolean {
+  const t = norm(text)
+    .replace(/^[\s"'«».,!?…–—-]+|[\s"'«».,!?…–—-]+$/g, "")
+    .trim();
+  if (!t) return false; // empty / punctuation-only carries no signal — not flagged
+  if (NORM_PHRASES.has(t)) return true;
+  return LIVE_ASSIST.HALLUCINATION_PATTERNS.some((re) => re.test(t));
+}

--- a/realtime-stt/run.mjs
+++ b/realtime-stt/run.mjs
@@ -58,8 +58,16 @@ if (!upToDate) {
   log("requirements installed.");
 }
 
-// 3. run main.py with the venv python, forwarding signals + exit code
-const child = spawn(venvPy, ["main.py"], { cwd: here, stdio: "inherit" });
+// 3. run main.py with the venv python, forwarding signals + exit code.
+// `-u` + PYTHONUNBUFFERED force unbuffered stdout/stderr: under PM2 the child's
+// stdio is a pipe, so Python block-buffers (~8 KB) and a long-running service with
+// sparse output never flushes — leaving stt-out.log empty. Unbuffered makes each
+// print() land in the log immediately, like the (Node) backend/frontend do.
+const child = spawn(venvPy, ["-u", "main.py"], {
+  cwd: here,
+  stdio: "inherit",
+  env: { ...process.env, PYTHONUNBUFFERED: "1" },
+});
 child.on("exit", (code) => process.exit(code ?? 0));
 for (const sig of ["SIGINT", "SIGTERM"]) {
   process.on(sig, () => child.kill(sig));


### PR DESCRIPTION
## What & why
Two Live Assist STT fixes found while debugging why it "didn't work" in prod.

### 1. obs-stt was logging nothing
`obs-stt` runs Python (`realtime-stt/main.py`) via `run.mjs`. Under PM2 its stdout is a pipe, so Python **block-buffers** (~8 KB) and a sparse-output service never flushes → `stt-out.log` stayed empty (we were blind). Now launched with `-u` + `PYTHONUNBUFFERED=1`, so each `[stt] …` line lands in the PM2 log live, like the Node backend/frontend.

### 2. Whisper "silence hallucinations" leaked into the pipeline
faster-whisper was trained on YouTube/TV subtitles, so during silence it emits subtitle credits ("Sous-titrage Société Radio-Canada", "Sous-titrage FR 2021", "Merci d'avoir regardé cette vidéo", Amara.org, …). These now get dropped at ingest, **before** the transcript file, buffer, keyword detection, debug view, and any suggestion.

- New `isHallucination()` filter (`lib/services/liveassist/hallucinationFilter.ts`), reusing the shared `norm()` (lowercase / accent-strip / apostrophe-fold). Two layers: an exact phrase list + regex families (the `sous-titrage…` family, `amara.org`, `soustitreur.com`, credit-line+year, transcription services, FR sign-offs) in `LIVE_ASSIST.HALLUCINATION_PHRASES` / `HALLUCINATION_PATTERNS`.
- Low-confidence CTAs ("Abonnez-vous") are exact-match only, so real speech ("abonnez-vous à la newsletter") is kept.
- Injected into `LiveAssistOrchestrator.ingestSegment()` (default = the real filter; injectable for tests). Phrase list compiled from openai/whisper discussions #928/#1873, the HF `whisper-hallucinations` dataset, and whisper.cpp #2660.

## Tests
- `hallucinationFilter.test.ts` (25): the 3 in-the-wild examples, punctuation/accents/typographic-apostrophe, extended families, and non-hallucination speech kept.
- `LiveAssistOrchestrator.test.ts`: a hallucination segment is dropped (no transcript, no keyword scan) while STT stays "connected".
- All affected suites green (filter + orchestrator + recorder).

## Deploy note
Prod runs the local checkout via PM2 — after merge, `git pull` on the prod box + `pm2 restart obs-backend` to actually ship this (and the already-merged transcript recorder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)