### PR TITLE
feat(live-assist): gate STT silence/low-confidence at the source (RMS + confidence + VAD)

### DIFF
--- a/docs/LIVE-ASSIST.md
+++ b/docs/LIVE-ASSIST.md
@@ -136,11 +136,23 @@ Current providers:
 
 ## Known gaps / TODO before production
 
-- **VAD is a placeholder.** `realtime-stt/main.py` batches a fixed ~2 s window (`time.sleep(2.0)`) instead of
-  detecting silence boundaries (inline comment: "replace with VAD silence detection" / "Use silero-vad or
-  webrtcvad here"). Replace with real silence-boundary VAD so
-  segment timestamps align with utterance ends. *Mitigated today* by the backend wall-clock `WINDOW_MAX_WAIT_MS`
-  — no suggestion is lost, only latency varies.
+- **~~VAD is a placeholder.~~ Done — three upstream gates in `realtime-stt/`.** The fixed `time.sleep(2.0)`
+  batch is replaced by Silero-VAD silence-boundary segmentation, plus two cheaper gates that kill faster-whisper's
+  silence hallucinations at the source (the upstream complement to the downstream `hallucinationFilter.ts`
+  text blocklist). Pure helpers live in `realtime-stt/stt/gates.py` (unit-tested in `tests/test_gates.py`);
+  the loop in `main.py` wires them to live audio:
+    - **(a) RMS gate** (`is_silence`) — skip `model.transcribe()` on a near-silent span (saves GPU).
+    - **(b) Confidence gate** (`keep_segment`) — drop segments by `no_speech_prob` / `avg_logprob` /
+      `compression_ratio` (faster-whisper computes these; they used to be discarded). Mapped per-utterance
+      confidence is forwarded into the `POST /api/stt/segment` `confidence` field.
+    - **(c) VAD segmentation** (`decide_flush`) — a ~300 ms tick accumulates audio into a bounded `pending`
+      buffer and flushes on a real end-of-utterance silence boundary via `faster_whisper.vad.get_speech_timestamps`
+      (no new dependency), or on a max-length cap. `transcribe()` now runs with `vad_filter=False` (already
+      pre-trimmed) and `condition_on_previous_text=False` (stops a hallucinated credit line bleeding forward).
+  All thresholds are named constants in `main.py` (`GATE_DEFAULTS`), overridable via `config.json`. **Residual
+  coupling:** Silero's `min_silence_duration_ms` (set from `vad_silence_ms`) doubles as both the end-of-utterance
+  hangover *and* the intra-utterance phrase-merge threshold, and the invariant `vad_silence_ms > vad_speech_pad_ms`
+  must hold or boundaries never fire. The backend wall-clock `WINDOW_MAX_WAIT_MS` still backstops latency.
 - **Poster source quality → issue #116.** Wikipedia (especially FR) is a poor poster source (copyright, ambiguity).
   Disambiguation + Google-images fallback are in place, but a real source (TMDB / EN-wiki / web search) is tracked
   in #116. Related idea: per-keyword contextualization prompts.
@@ -156,7 +168,8 @@ Current providers:
 - **Jest** — `__tests__/services/liveassist/**` (buffer, detector, scheduler, extractor, store, orchestrator,
   providers + registry), `__tests__/api/live-assist.backend.test.ts`, `__tests__/api/live-assist.proxy.test.ts`,
   `__tests__/models/LiveAssist.test.ts`, `__tests__/components/LiveAssistSettings.test.tsx`. Run: `pnpm test`.
-- **pytest** — `realtime-stt/tests/test_segmenter.py` (segment payload builder). Run: `cd realtime-stt && pytest`.
+- **pytest** — `realtime-stt/tests/test_segmenter.py` (segment payload builder) and `realtime-stt/tests/test_gates.py`
+  (the silence/confidence/VAD-boundary gate helpers). Run: `cd realtime-stt && pytest`.
 
 ## Reuse (DRY)
 

--- a/realtime-stt/conftest.py
+++ b/realtime-stt/conftest.py
@@ -1,0 +1,6 @@
+"""Pytest root marker for the realtime-stt package.
+
+Its presence makes pytest treat this directory as the import root (added to
+sys.path in the default `prepend` import mode), so tests can `from stt.gates
+import ...` whether they're run as `pytest` or `python -m pytest` from here.
+"""

--- a/realtime-stt/main.py
+++ b/realtime-stt/main.py
@@ -150,13 +150,15 @@ def run():
     silence_hangover_ms = int(cfg["silence_hangover_ms"])
     vad_idle_ms = int(cfg["vad_idle_ms"])
     vad_preroll_ms = int(cfg["vad_preroll_ms"])
-    # Invariant: vad_silence_ms must exceed vad_speech_pad_ms. Silero pads each
-    # speech region by speech_pad_ms, which under-reports trailing silence by that
-    # pad; if the pad >= the hangover, padding eats the whole gap and an
-    # end-of-utterance boundary can never be detected (see docs/LIVE-ASSIST.md).
-    if vad_silence_ms <= vad_speech_pad_ms:
-        print(f"[stt] WARN vad_silence_ms ({vad_silence_ms}) <= vad_speech_pad_ms "
-              f"({vad_speech_pad_ms}); silence boundaries may never fire")
+    # Invariant: at end-of-utterance the measured trailing silence is about
+    # vad_silence_ms − vad_speech_pad_ms (Silero pads each region by speech_pad_ms,
+    # which under-reports the gap). That must clear silence_hangover_ms (and be > 0),
+    # else no end-of-utterance boundary can ever be detected (see docs/LIVE-ASSIST.md).
+    effective_trailing_ms = vad_silence_ms - vad_speech_pad_ms
+    if effective_trailing_ms <= max(silence_hangover_ms, 0):
+        print(f"[stt] WARN vad_silence_ms({vad_silence_ms}) - vad_speech_pad_ms({vad_speech_pad_ms}) "
+              f"= {effective_trailing_ms}ms <= silence_hangover_ms({silence_hangover_ms}); "
+              f"silence boundaries may never fire")
 
     vad_options = VadOptions(
         threshold=vad_threshold,

--- a/realtime-stt/main.py
+++ b/realtime-stt/main.py
@@ -5,16 +5,43 @@ import numpy as np
 import sounddevice as sd
 import httpx
 from faster_whisper import WhisperModel
+from faster_whisper.vad import VadOptions, get_speech_timestamps
 from stt.segmenter import build_segment
+from stt.gates import decide_flush, is_silence, keep_segment, segment_confidence, span_to_ms
 
 # The dev backend serves self-signed mkcert/Tailscale certs over HTTPS, so we
 # skip certificate verification (mirrors the app's NODE_TLS_REJECT_UNAUTHORIZED=0
 # dev posture). One shared client for all calls.
 CLIENT = httpx.Client(verify=False, timeout=5)
 
+# Gate thresholds — sane defaults in code so a missing config.json still works.
+# config.json overrides any of these (alongside "backend"). The remote
+# /api/stt/config only carries enabled/inputDevice/whisperModel; these tuning
+# knobs are local because they describe this machine's mic/room, not the show.
+GATE_DEFAULTS = {
+    "silence_rms": 0.008,            # (a) RMS below this ⇒ skip Whisper
+    "no_speech_prob_max": 0.6,       # (b) drop segments above this no_speech_prob
+    "avg_logprob_min": -1.0,         # (b) drop segments below this avg_logprob
+    "compression_ratio_max": 2.4,    # (b) drop segments above this (repetition)
+    "vad_threshold": 0.5,            # (c) Silero speech probability threshold
+    "vad_silence_ms": 700,           # (c) end-of-utterance hangover; MUST be > vad_speech_pad_ms
+    "vad_min_speech_ms": 250,        # (c) drop speech blips shorter than this
+    "vad_speech_pad_ms": 200,        # (c) onset/offset context kept around speech
+    "vad_max_utterance_ms": 12000,   # (c) force-flush cap (bounds memory + VAD cost)
+    "vad_tick_ms": 300,              # (c) loop cadence; adds to end-of-utterance latency
+    "config_poll_ms": 2000,          # heartbeat: /api/stt/config poll cadence
+    "silence_hangover_ms": 0,        # (c) extra trailing silence; VAD owns the hangover
+    "vad_idle_ms": 3000,             # (c) trim pending after this much speech-free audio
+    "vad_preroll_ms": 200,           # (c) tail kept on idle-trim / forced-flush overlap
+}
+
+# Rate-limit the "still gating silence" heartbeat so long silences don't flood
+# stt-out.log while still proving the gate is alive.
+IDLE_LOG_INTERVAL_MS = 30_000
+
 
 def load_config():
-    cfg = {"backend": "https://127.0.0.1:3002"}
+    cfg = {"backend": "https://127.0.0.1:3002", **GATE_DEFAULTS}
     path = os.path.join(os.path.dirname(__file__), "config.json")
     if os.path.exists(path):
         with open(path, encoding="utf-8") as f:
@@ -106,51 +133,154 @@ def run():
     remote = fetch_config(backend) or {"enabled": False, "inputDevice": None, "whisperModel": "large-v3"}
     model = WhisperModel(remote.get("whisperModel", "large-v3"), device="cuda", compute_type="int8")
     sample_rate = 16000
-    capture_start = time.monotonic()
     device_index = int(remote["inputDevice"]) if remote.get("inputDevice") else None
 
-    # VAD-gated chunking: accumulate speech, transcribe on a silence boundary.
-    # (Use silero-vad or webrtcvad here; pseudocode loop kept minimal.)
-    # The callback runs on PortAudio's audio thread while the main loop drains the
-    # buffer, so all buffer access is guarded by a lock to avoid losing a frame
-    # that arrives between concatenate() and clear().
+    # Resolve gate thresholds once at startup (local config.json over GATE_DEFAULTS).
+    silence_rms = float(cfg["silence_rms"])
+    no_speech_prob_max = float(cfg["no_speech_prob_max"])
+    avg_logprob_min = float(cfg["avg_logprob_min"])
+    compression_ratio_max = float(cfg["compression_ratio_max"])
+    vad_threshold = float(cfg["vad_threshold"])
+    vad_silence_ms = int(cfg["vad_silence_ms"])
+    vad_min_speech_ms = int(cfg["vad_min_speech_ms"])
+    vad_speech_pad_ms = int(cfg["vad_speech_pad_ms"])
+    vad_max_utterance_ms = int(cfg["vad_max_utterance_ms"])
+    vad_tick_ms = int(cfg["vad_tick_ms"])
+    config_poll_ms = int(cfg["config_poll_ms"])
+    silence_hangover_ms = int(cfg["silence_hangover_ms"])
+    vad_idle_ms = int(cfg["vad_idle_ms"])
+    vad_preroll_ms = int(cfg["vad_preroll_ms"])
+    # Invariant: vad_silence_ms must exceed vad_speech_pad_ms. Silero pads each
+    # speech region by speech_pad_ms, which under-reports trailing silence by that
+    # pad; if the pad >= the hangover, padding eats the whole gap and an
+    # end-of-utterance boundary can never be detected (see docs/LIVE-ASSIST.md).
+    if vad_silence_ms <= vad_speech_pad_ms:
+        print(f"[stt] WARN vad_silence_ms ({vad_silence_ms}) <= vad_speech_pad_ms "
+              f"({vad_speech_pad_ms}); silence boundaries may never fire")
+
+    vad_options = VadOptions(
+        threshold=vad_threshold,
+        min_speech_duration_ms=vad_min_speech_ms,
+        speech_pad_ms=vad_speech_pad_ms,
+        min_silence_duration_ms=vad_silence_ms,  # this is the end-of-utterance hangover
+    )
+    # Don't bother running VAD until pending could hold one emittable utterance.
+    min_emit_samples = (vad_min_speech_ms + vad_speech_pad_ms) * sample_rate // 1000
+    preroll_samples = vad_preroll_ms * sample_rate // 1000
+    idle_samples = vad_idle_ms * sample_rate // 1000
+
+    # The PortAudio callback fills `buffer` on its own thread; the main loop drains
+    # it under the lock. `captured_samples` is the absolute count of samples seen so
+    # far — it anchors segment timestamps (immune to tick/scheduling jitter).
     buffer = []
     buffer_lock = threading.Lock()
+    captured_samples = 0
+
     def callback(indata, frames, t, status):
+        nonlocal captured_samples
+        if status:
+            print(f"[stt] audio status: {status}")
         with buffer_lock:
             buffer.append(indata.copy())
+            captured_samples += len(indata)
+
+    # `pending` accumulates captured audio between flushes; `pending_start_sample`
+    # is the absolute index of pending[0], so a span maps back to relative-ms.
+    pending = np.empty(0, dtype=np.float32)
+    pending_start_sample = 0
 
     with sd.InputStream(samplerate=sample_rate, channels=1, dtype="float32",
                         device=device_index, callback=callback):
         print(f"[stt] listening on device {device_index}")
         last_cfg = remote
+        last_cfg_ms = 0.0
+        last_idle_log_ms = 0.0
+
         while True:
-            time.sleep(2.0)  # batch ~2s of audio; replace with VAD silence detection
-            # Re-poll config each iteration so toggling enabled takes effect within
-            # one loop. Keep the last known config when the backend is momentarily
-            # unreachable so a blip doesn't disable capture and discard speech.
-            cfg_now = fetch_config(backend) or last_cfg
-            last_cfg = cfg_now
-            if not cfg_now.get("enabled", False):
+            time.sleep(vad_tick_ms / 1000.0)
+            now_ms = time.monotonic() * 1000.0
+
+            # Heartbeat: poll /api/stt/config on its own cadence (not every tick, or
+            # a 300ms loop would hammer the backend). Keep last_cfg on a blip so a
+            # transient failure isn't read as "disabled" and doesn't drop speech.
+            if now_ms - last_cfg_ms >= config_poll_ms:
+                last_cfg = fetch_config(backend) or last_cfg
+                last_cfg_ms = now_ms
+
+            if not last_cfg.get("enabled", False):
                 with buffer_lock:
                     buffer.clear()
+                pending = np.empty(0, dtype=np.float32)
                 continue
-            # Atomically swap out the captured chunks so a frame arriving mid-drain
-            # is preserved for the next iteration instead of being cleared away.
+
+            # Drain newly captured chunks under the lock; snapshot the absolute
+            # sample count so a fresh `pending` gets the right start index.
             with buffer_lock:
-                if not buffer:
-                    continue
                 chunks = buffer[:]
                 buffer.clear()
-            audio = np.concatenate(chunks).flatten()
-            t1_ms = int((time.monotonic() - capture_start) * 1000)
-            t0_ms = t1_ms - int(len(audio) / sample_rate * 1000)
-            segments, _ = model.transcribe(audio, language="fr", vad_filter=True)
-            text = " ".join(s.text.strip() for s in segments).strip()
-            if not text:
+                captured_at_drain = captured_samples
+            if chunks:
+                new_audio = np.concatenate(chunks).flatten().astype(np.float32, copy=False)
+                if pending.size == 0:
+                    pending_start_sample = captured_at_drain - len(new_audio)
+                    pending = new_audio
+                else:
+                    pending = np.concatenate((pending, new_audio))
+
+            # Skip the O(n) VAD recompute when nothing new arrived or there isn't
+            # yet enough audio to contain an utterance.
+            if not chunks or pending.size < min_emit_samples:
                 continue
+
+            regions = get_speech_timestamps(pending, vad_options, sampling_rate=sample_rate)
+
+            if not regions:
+                # Pure silence accumulating: bound memory by keeping only a short
+                # pre-roll tail (so a word onset right after isn't clipped).
+                if pending.size > idle_samples:
+                    drop = pending.size - preroll_samples
+                    pending = pending[drop:]
+                    pending_start_sample += drop
+                if now_ms - last_idle_log_ms >= IDLE_LOG_INTERVAL_MS:
+                    print("[stt] silence — no speech, transcription gated")
+                    last_idle_log_ms = now_ms
+                continue
+
+            fd = decide_flush(regions, pending.size, sample_rate,
+                              silence_hangover_ms, vad_max_utterance_ms)
+            if fd is None:
+                continue
+
+            # Plain contiguous slice (NOT collect_chunks, which drops internal
+            # silences and would desync the sample→ms mapping).
+            emit = pending[fd.start:fd.end]
+            t0_ms, t1_ms = span_to_ms(fd.start, fd.end, pending_start_sample, sample_rate)
+            # On a clean silence boundary, cut at the speech end (retained trailing
+            # silence becomes the next utterance's padded lead-in). On a forced
+            # max-length flush, speech is still live, so keep a pre-roll overlap so
+            # the word straddling the cut isn't lost.
+            cut = fd.end if fd.reason == "silence" else max(fd.end - preroll_samples, 0)
+            pending = pending[cut:]
+            pending_start_sample += cut
+
+            # Gate (a): cheap RMS guard before paying for a GPU transcribe.
+            if is_silence(emit, silence_rms):
+                print(f"[stt] gated: near-silent span ({fd.reason}, {t1_ms - t0_ms}ms)")
+                continue
+
+            segments, _ = model.transcribe(
+                emit, language="fr", vad_filter=False, condition_on_previous_text=False)
+            # Gate (b): keep only confident, non-hallucinated segments.
+            kept = [s for s in segments
+                    if keep_segment(s.no_speech_prob, s.avg_logprob, s.compression_ratio,
+                                    no_speech_prob_max, avg_logprob_min, compression_ratio_max)]
+            text = " ".join(s.text.strip() for s in kept).strip()
+            if not text:
+                print(f"[stt] gated: low-confidence/empty transcript ({fd.reason}, {t1_ms - t0_ms}ms)")
+                continue
+            conf = segment_confidence([s.avg_logprob for s in kept])
             print(f"[stt] » {text}")
-            seg = build_segment(text, t0_ms, t1_ms, True)
+            seg = build_segment(text, t0_ms, t1_ms, True, conf)
             try:
                 CLIENT.post(f"{backend}/api/stt/segment", json=seg)
             except Exception as e:

--- a/realtime-stt/stt/gates.py
+++ b/realtime-stt/stt/gates.py
@@ -1,0 +1,130 @@
+"""Pure, hardware-free gates for the STT capture loop.
+
+These functions hold the silence/low-confidence/segmentation logic so it can be
+unit-tested without audio hardware or the ONNX VAD model (see tests/test_gates.py).
+The loop in main.py wires them to live audio. Three layered gates:
+
+  (a) is_silence       — skip Whisper on near-silent audio (energy/RMS).
+  (b) keep_segment     — drop hallucinated/low-confidence segments after Whisper.
+  (c) decide_flush     — drive segment flushing off VAD speech regions, not a clock.
+
+`segment_confidence` and `span_to_ms` are small pure helpers used alongside them.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+def is_silence(audio: np.ndarray, threshold: float) -> bool:
+    """True when `audio` is empty or its RMS amplitude is below `threshold`.
+
+    Gate (a): a cheap pre-Whisper guard. RMS is accumulated in float64 for
+    numerical stability on long float32 spans.
+    """
+    if audio is None or len(audio) == 0:
+        return True
+    arr = np.asarray(audio, dtype=np.float64)
+    rms = float(np.sqrt(np.mean(arr * arr)))
+    return rms < threshold
+
+
+def keep_segment(
+    no_speech_prob: float,
+    avg_logprob: float,
+    compression_ratio: float,
+    no_speech_prob_max: float = 0.6,
+    avg_logprob_min: float = -1.0,
+    compression_ratio_max: float = 2.4,
+) -> bool:
+    """True when a faster-whisper segment looks like real speech.
+
+    Gate (b): faster-whisper already computes these per-segment scores; the
+    loop used to throw them away. A segment is kept only when it clears all
+    three bars (the defaults match faster-whisper's own internal thresholds):
+      - no_speech_prob <= max   (high ⇒ the model thinks it's silence)
+      - avg_logprob    >= min   (low  ⇒ low-confidence decode)
+      - compression_ratio <= max (high ⇒ repetitive hallucination)
+    """
+    return (
+        no_speech_prob <= no_speech_prob_max
+        and avg_logprob >= avg_logprob_min
+        and compression_ratio <= compression_ratio_max
+    )
+
+
+def segment_confidence(avg_logprobs: Sequence[float]) -> Optional[float]:
+    """Map kept segments' avg_logprob to a [0, 1] confidence, or None if empty.
+
+    avg_logprob is a (mostly negative) log-probability; exp() maps it into (0, 1].
+    The mean is clamped to [0, 1] so it satisfies the backend's `confidence` schema.
+    """
+    if avg_logprobs is None or len(avg_logprobs) == 0:
+        return None
+    mean_exp = float(np.mean([math.exp(lp) for lp in avg_logprobs]))
+    return max(0.0, min(1.0, mean_exp))
+
+
+@dataclass(frozen=True)
+class FlushDecision:
+    """A request to flush `pending[start:end]` as one utterance.
+
+    `reason` is "silence" (a clean end-of-utterance boundary) or "max" (a forced
+    flush because the utterance hit the max-length cap while still ongoing).
+    """
+
+    start: int  # local sample index into pending (inclusive)
+    end: int  # local sample index into pending (exclusive)
+    reason: str  # "silence" | "max"
+
+
+def decide_flush(
+    regions: List[Dict[str, int]],
+    total_samples: int,
+    sr: int,
+    silence_hangover_ms: int,
+    max_utterance_ms: int,
+) -> Optional[FlushDecision]:
+    """Decide whether to flush the pending buffer, given Silero VAD speech regions.
+
+    Gate (c), pure core. `regions` is the output of `get_speech_timestamps` (a
+    list of {"start","end"} sample indices over a buffer of `total_samples`).
+
+    While speech is *ongoing* at the buffer tail, Silero pins the last region's
+    end to the buffer end, so `total_samples - end == 0`. Once a silence longer
+    than the VAD's own `min_silence_duration_ms` terminates the region, the end
+    falls back and trailing silence appears (> 0). That transition — not a wall
+    clock — is the end-of-utterance signal. An external `silence_hangover_ms`
+    can require extra trailing silence on top (the VAD already owns the hangover,
+    so it defaults to 0). A force-flush fires when the buffer reaches the
+    max-length cap even though speech is still live.
+    """
+    if not regions:
+        return None
+    span_start = regions[0]["start"]
+    span_end = regions[-1]["end"]
+    trailing = total_samples - span_end
+    hangover_samples = silence_hangover_ms * sr // 1000
+    if trailing > 0 and trailing >= hangover_samples:
+        return FlushDecision(span_start, span_end, "silence")
+    if total_samples >= max_utterance_ms * sr // 1000:
+        return FlushDecision(span_start, span_end, "max")
+    return None
+
+
+def span_to_ms(
+    span_start: int, span_end: int, pending_start_sample: int, sr: int
+) -> Tuple[int, int]:
+    """Map a [start, end) sample span within `pending` to relative-ms (t0, t1).
+
+    `pending_start_sample` is the absolute index of pending[0] in the continuous
+    capture stream, so timestamps stay aligned even as `pending` is trimmed.
+    """
+    t0 = int(round((pending_start_sample + span_start) / sr * 1000))
+    t1 = int(round((pending_start_sample + span_end) / sr * 1000))
+    if t1 < t0:
+        t1 = t0
+    return t0, t1

--- a/realtime-stt/tests/test_gates.py
+++ b/realtime-stt/tests/test_gates.py
@@ -1,0 +1,162 @@
+import math
+
+import numpy as np
+import pytest
+
+from stt.gates import (
+    FlushDecision,
+    decide_flush,
+    is_silence,
+    keep_segment,
+    segment_confidence,
+    span_to_ms,
+)
+
+SR = 16000
+
+
+# --- is_silence (gate a) -----------------------------------------------------
+
+def test_is_silence_empty_is_silent():
+    assert is_silence(np.empty(0, dtype=np.float32), 0.008) is True
+
+
+def test_is_silence_all_zeros_is_silent():
+    assert is_silence(np.zeros(1600, dtype=np.float32), 0.008) is True
+
+
+def test_is_silence_loud_sine_is_not_silent():
+    t = np.arange(1600, dtype=np.float32)
+    sine = (0.2 * np.sin(2 * np.pi * 440 * t / SR)).astype(np.float32)  # RMS ~0.14
+    assert is_silence(sine, 0.008) is False
+
+
+def test_is_silence_low_noise_is_silent():
+    noise = np.full(1600, 0.002, dtype=np.float32)  # RMS 0.002 < 0.008
+    assert is_silence(noise, 0.008) is True
+
+
+def test_is_silence_at_threshold_is_not_silent():
+    # RMS of a constant array equals its magnitude; exactly == threshold ⇒ not silent (strict <).
+    arr = np.full(1600, 0.008, dtype=np.float32)
+    assert is_silence(arr, 0.008) is False
+
+
+# --- keep_segment (gate b) ---------------------------------------------------
+
+def test_keep_segment_all_pass():
+    assert keep_segment(0.1, -0.3, 1.5) is True
+
+
+def test_keep_segment_no_speech_prob_boundary():
+    assert keep_segment(0.60, -0.3, 1.5) is True
+    assert keep_segment(0.61, -0.3, 1.5) is False
+
+
+def test_keep_segment_avg_logprob_boundary():
+    assert keep_segment(0.1, -1.00, 1.5) is True
+    assert keep_segment(0.1, -1.01, 1.5) is False
+
+
+def test_keep_segment_compression_ratio_boundary():
+    assert keep_segment(0.1, -0.3, 2.40) is True
+    assert keep_segment(0.1, -0.3, 2.41) is False
+
+
+def test_keep_segment_drops_silence_credit_hallucination():
+    # High no_speech_prob — classic "Sous-titrage…" on room tone.
+    assert keep_segment(0.85, -0.2, 1.4) is False
+
+
+def test_keep_segment_drops_repetition():
+    assert keep_segment(0.1, -0.2, 3.0) is False
+
+
+def test_keep_segment_custom_thresholds():
+    assert keep_segment(0.7, -1.5, 2.6, no_speech_prob_max=0.8,
+                        avg_logprob_min=-2.0, compression_ratio_max=3.0) is True
+
+
+# --- segment_confidence ------------------------------------------------------
+
+def test_segment_confidence_empty_is_none():
+    assert segment_confidence([]) is None
+
+
+def test_segment_confidence_single():
+    assert segment_confidence([-0.1]) == pytest.approx(math.exp(-0.1))  # ~0.905
+
+
+def test_segment_confidence_mean_of_exps():
+    expected = (math.exp(-0.1) + math.exp(-0.7)) / 2
+    assert segment_confidence([-0.1, -0.7]) == pytest.approx(expected)
+
+
+def test_segment_confidence_clamps_positive_to_one():
+    assert segment_confidence([0.5]) == 1.0
+
+
+def test_segment_confidence_in_unit_range():
+    c = segment_confidence([-2.0, -0.5, -1.0])
+    assert 0.0 <= c <= 1.0
+
+
+# --- decide_flush (gate c) ---------------------------------------------------
+
+def test_decide_flush_no_regions_below_max_is_none():
+    assert decide_flush([], 10_000, SR, 0, 12_000) is None
+
+
+def test_decide_flush_no_regions_at_max_is_none():
+    # No speech ⇒ nothing to emit even past the cap (caller idle-trims instead).
+    assert decide_flush([], 200_000, SR, 0, 12_000) is None
+
+
+def test_decide_flush_terminated_region_flushes_silence():
+    regions = [{"start": 1600, "end": 32_000}]
+    fd = decide_flush(regions, 48_000, SR, 0, 12_000)
+    assert fd == FlushDecision(1600, 32_000, "silence")
+
+
+def test_decide_flush_ongoing_region_is_none():
+    # Last region end pinned to buffer end ⇒ trailing == 0 ⇒ still speaking.
+    assert decide_flush([{"start": 1600, "end": 48_000}], 48_000, SR, 0, 12_000) is None
+
+
+def test_decide_flush_ongoing_past_max_force_flushes():
+    fd = decide_flush([{"start": 0, "end": 200_000}], 200_000, SR, 0, 12_000)
+    assert fd == FlushDecision(0, 200_000, "max")
+
+
+def test_decide_flush_hangover_boundary():
+    hangover_ms = 300
+    hangover_samples = hangover_ms * SR // 1000  # 4800
+    total = 50_000
+    end_at_threshold = total - hangover_samples           # trailing == hangover ⇒ flush
+    end_below_threshold = total - (hangover_samples - 1)   # trailing == hangover-1 ⇒ none
+    assert decide_flush([{"start": 0, "end": end_at_threshold}], total, SR,
+                        hangover_ms, 12_000) == FlushDecision(0, end_at_threshold, "silence")
+    assert decide_flush([{"start": 0, "end": end_below_threshold}], total, SR,
+                        hangover_ms, 12_000) is None
+
+
+def test_decide_flush_multi_region_spans_first_to_last():
+    regions = [{"start": 1000, "end": 5000}, {"start": 8000, "end": 20_000}]
+    fd = decide_flush(regions, 40_000, SR, 0, 12_000)
+    assert fd == FlushDecision(1000, 20_000, "silence")
+
+
+# --- span_to_ms --------------------------------------------------------------
+
+def test_span_to_ms_basic_mapping():
+    assert span_to_ms(0, 16_000, 0, SR) == (0, 1000)
+
+
+def test_span_to_ms_applies_pending_offset():
+    # pending starts 2s into the stream; a [0, 0.5s) span → [2000, 2500] ms.
+    assert span_to_ms(0, 8000, 32_000, SR) == (2000, 2500)
+
+
+def test_span_to_ms_is_monotonic():
+    t0, t1 = span_to_ms(5000, 5001, 100, SR)
+    assert t1 >= t0


### PR DESCRIPTION
## What & why

faster-whisper was trained on YouTube/TV subtitles, so on silence/room-tone it hallucinates subtitle credits ("Sous-titrage Société Radio-Canada", "Merci d'avoir regardé cette vidéo", Amara.org…). PR #125 added the **downstream** text blocklist (`hallucinationFilter.ts`) as the final net. This PR adds the **upstream** complement — entirely inside the Python STT service — to kill the cause and cut GPU load during silence.

Three layered gates, all in `realtime-stt/`:

- **(a) RMS gate** (`is_silence`) — skip `model.transcribe()` on a near-silent span (saves GPU).
- **(b) Confidence gate** (`keep_segment`) — drop segments by `no_speech_prob` / `avg_logprob` / `compression_ratio`. faster-whisper already computes these per segment; the loop used to discard them (`segments, _ = …`, read only `.text`). Defaults match faster-whisper's own internal thresholds (`0.6` / `-1.0` / `2.4`). A mapped per-utterance confidence is forwarded into the `POST /api/stt/segment` `confidence` field.
- **(c) VAD silence-boundary segmentation** (`decide_flush`) — replaces the fixed `time.sleep(2.0)` batch with a ~300 ms tick loop that accumulates audio into a bounded `pending` buffer and flushes on a **real end-of-utterance silence boundary** via `faster_whisper.vad.get_speech_timestamps` (the Silero VAD already bundled with faster-whisper — **no new dependency**), or on a max-length cap. `transcribe()` now runs `vad_filter=False` (already pre-trimmed) + `condition_on_previous_text=False` (stops a hallucinated credit line bleeding into the next emit).

## Design notes

- Pure, hardware-free logic lives in **`realtime-stt/stt/gates.py`** and is unit-tested (`tests/test_gates.py`, 27 cases) without audio/ONNX. The capture loop in `main.py` wires them to live audio.
- Thresholds are named constants (`GATE_DEFAULTS` in `main.py`), each overridable via `config.json`; sane defaults in code so a missing config still works.
- Segment timestamps are anchored to an **absolute sample counter** (not the wall clock), so relative-ms `t0`/`t1` stay aligned through tick jitter and buffer trims.
- **Invariant** `vad_silence_ms − vad_speech_pad_ms > silence_hangover_ms` (warned at startup): Silero pads each region by `speech_pad_ms`, which under-reports trailing silence, so the pad can't exceed the hangover or a boundary never fires.
- **Residual coupling** (documented in `docs/LIVE-ASSIST.md`): Silero's `min_silence_duration_ms` (from `vad_silence_ms`) doubles as both the end-of-utterance hangover and the intra-utterance phrase-merge threshold.

## Contract preserved

No backend / blocklist / `POST /api/stt/segment` changes. Body shape unchanged (`{text, t0, t1, final, confidence?}`, `confidence ∈ [0,1]`, `t1 ≥ t0`, relative-ms). `device="cuda"`, the `/api/stt/config` `enabled` heartbeat, and unbuffered logging are intact. The downstream `hallucinationFilter.ts` stays as the final text-level net.

## Expected effect

- Near-zero hallucination lines during silence (gated at three layers instead of decoding room tone every 2 s).
- Lower idle GPU usage (no constant 2 s transcribe on silence).
- Segments posted on **speech boundaries** rather than a rigid 2 s grid.

## Tests

`cd realtime-stt && pytest` → **30 passed** (27 new gate tests + 3 existing segmenter). A root `conftest.py` makes the documented command resolve the `stt` package whether run as `pytest` or `python -m pytest`.

The full audio loop needs hardware (CUDA + mic) and is covered by manual verification:
1. `pnpm dev:stt`, enable Live Assist in `/settings/live-assist`.
2. Stay silent → no `[stt] » …` lines; rate-limited gate log in `stt-out.log`; GPU drops vs the old constant-transcribe.
3. Speak → utterances transcribed and posted on speech boundaries (one `POST /api/stt/segment` per utterance).

## Code review

Reviewed via `pr-review-toolkit:code-reviewer` (API verified against installed `faster_whisper` v1.2.1): no Critical/High issues — thread-safety, VAD boundary logic, timestamp/confidence mapping all confirmed correct. One Low finding addressed (folded `silence_hangover_ms` into the invariant warning); two Low findings (bounded O(n²) VAD recompute, intentional self-contained `gates.py` defaults) left as documented tradeoffs.

> **Deploy note:** STT reads its setup once at startup — prod needs `git pull` then `pm2 restart obs-stt` to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)