### PR TITLE
fix(streamerbot): noms de viewers vides sur follow/sub + cue presenter

### DIFF
--- a/.claude/skills/streamerbot-events/SKILL.md
+++ b/.claude/skills/streamerbot-events/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: streamerbot-events
+description: >-
+  Handle or add Streamer.bot (Twitch/YouTube) chat & alert events — follow, sub,
+  resub, giftsub, raid, cheer, superchat. Use WHENEVER a viewer event shows an
+  EMPTY name/displayName, an event you subscribed to never fires, you're adding a
+  new event type, or you're touching lib/models/streamerbot/* (types.ts /
+  normalizers.ts), StreamerbotGateway, or testing follow/sub flows. These bugs
+  fail SILENTLY (undefined fields, dropped events — no stack trace), so read this
+  before trusting our types or assuming the package is consistent.
+---
+
+# Streamer.bot event handling
+
+## 1. The package's field naming is inconsistent PER EVENT — never assume
+
+`@streamerbot/client` does **not** use a uniform naming convention across event
+payloads. Our `lib/models/streamerbot/types.ts` must mirror each event's *real*
+shape exactly, or the normalizer reads a non-existent field → `undefined` →
+the viewer event renders with an **empty name and no error** (the original bug).
+
+**Always verify against the source of truth** before writing/editing a normalizer:
+`node_modules/@streamerbot/client/dist/index.d.ts` (search `TwitchFollow`,
+`TwitchSub`, etc.). The current reality:
+
+| Event | Convention | User-name fields |
+|---|---|---|
+| Follow | **snake_case** | `user_id`, `user_login`, `user_name` |
+| Raid | **snake_case** | `from_broadcaster_user_login` / `_name` (+ `to_…`), `viewers` |
+| Sub / ReSub | camelCase | `userName` (=login) **+ separate `displayName`**, `subTier` (number) |
+| GiftSub | camelCase | gifter `userName`/`displayName` + `recipientUsername`/`recipientDisplayName`, `subTier` |
+| Cheer | camelCase | `username` (lowercase **s**, not `userName`), `displayName`, `bits` |
+
+Don't pattern-match off a *neighbouring* normalizer — the next event likely uses
+a different convention. Tier comes as a **number** (`subTier`) and we stringify it
+to our `"1000"|"2000"|"3000"` union.
+
+## 2. Subscribing ≠ handling — the two lists drift
+
+`doConnect()`'s `subscribe:` list and `setupEventListeners()` are maintained
+separately and **have drifted**. Currently subscribed but with **no listener /
+normalizer** (silently dropped): **Twitch `GiftBomb`** and **YouTube
+`NewSubscriber`**. If an event "never fires," check the handler exists in
+`setupEventListeners()` — not just that it's in the subscribe array.
+
+## 3. Adding an event — the four touch points
+
+1. **Type** in `lib/models/streamerbot/types.ts` — copied from the `.d.ts` (see §1).
+2. **Normalizer** in `lib/models/streamerbot/normalizers.ts` → returns a `ChatMessage`
+   (set `eventType`, `username`, `displayName`, `message`, `metadata`).
+3. **Listener** in `StreamerbotGateway.setupEventListeners()` (and the `subscribe:`
+   list in `doConnect()` if not already there).
+4. **Presenter cue** (optional) — add the `eventType` to `VIEWER_EVENTS` and a title
+   in `maybeSendPresenterCue()` so the presenter gets a named card in their feed.
+   The display side (`ChatEventMessage.tsx`) also needs an icon/label branch.
+
+All events flow through `handleEvent → processMessage` (persist + WS broadcast +
+chat listeners + presenter cue). `injectTestEvent()` is the public entry the dev
+tester uses to push a pre-built `ChatMessage` through that same pipeline.
+
+## 4. Testing viewer events end-to-end — `/dev`
+
+The dev-only page at **`http://localhost:3002/dev`** (backend, `NODE_ENV !== production`,
+in `server/api/dev-events.ts`) fires **real EventSub payloads via the Twitch CLI**
+(`twitch event trigger …`) and injects them through the full gateway pipeline. Use
+it instead of rebuilding a harness.
+
+- Requires the **Twitch CLI** in PATH (https://dev.twitch.tv/docs/cli).
+- It captures the CLI's forwarded payload on an **ephemeral plain-HTTP listener**,
+  NOT the main backend — because the backend serves HTTPS (mkcert/Tailscale) and the
+  CLI's Go client can't speak plain HTTP to a TLS port nor validate that cert against
+  `127.0.0.1`. (Symptom if you forward to the HTTPS backend directly: a POST error
+  with body bytes `\x15\x03\x03…` — that's a TLS handshake record, i.e. wrong scheme.)
+- The CLI generates **random** viewer names (e.g. `user-12345678`) — they can't be
+  pinned via flags, but they're never empty, which is exactly what validates §1.
+- Useful CLI flags: `--tier` (sub tier), `-C` (raid viewer count). `-l`/`--user-login`
+  does **not** exist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,11 @@ Dashboard → API Route → ChannelManager.publish() → WebSocket → Overlay
 - `SettingsService` - Application settings
 - `RoomService` - Presenter room management
 - `RateLimiterService` - API rate limiting
+- `DSKService` - OBS Downstream Keyer ("Habillage") global overlay layer toggle
+- `WorkspaceService` - Dockview workspace layouts (built-in + user, default activation)
+- `MediaPlayerManager` - Routes media-player commands to Chrome extension drivers via WS (correlates command/response)
+- `WordHarvestManager` - "10 words" improv game state machine (collecting → complete → performing)
+- `SubVideoService` - YouTube timestamp clip extraction (yt-dlp/ffmpeg) into sub-posters
 
 **Quiz Services** (lib/services/Quiz*):
 - `QuizManager` - State machine orchestration
@@ -126,6 +131,9 @@ Dashboard → API Route → ChannelManager.publish() → WebSocket → Overlay
 - `OllamaSummarizerService` - LLM summarization via Ollama
 - `WikipediaCacheService` - Wikipedia result caching
 - `WikipediaResolverService` - Wikipedia search and resolution
+- `TmdbResolverService` - TMDB film/série poster + overview resolution (`tmdb_api_key` setting)
+- `YouTubeMetadataService` - YouTube Data API v3 video metadata (title, duration, thumbnail)
+- `TwitchService` (+ `twitch/`) - Twitch stream info via OAuth: polls every 30s, broadcasts updates, title/category edits, chat send; `twitch/TwitchOAuthManager`, `twitch/TwitchAPIClient`
 - `ai/AiProviderFactory` - Creates AI SDK LanguageModel from DB settings (Ollama/OpenAI/Anthropic)
 - `ai/AiToolBridge` - MCP tool discovery + conversion to AI SDK tools (cached 60s)
 - `ai/systemPrompt` - French system prompt for AI assistant
@@ -170,24 +178,40 @@ Dashboard → API Route → ChannelManager.publish() → WebSocket → Overlay
 - `obs-helpers.ts` - OBS utility functions
 - `quiz.ts` - Quiz control API
 - `quiz-bot.ts` - Streamer.bot webhook bridge
-- `rooms.ts` - Room CRUD and messaging
 - `cue.ts` - Presenter cue system
+- `presenter-settings.ts` - Presenter room/channel settings
 - `streamerbot-chat.ts` - Chat message forwarding
+- `chat-messages.ts` - Chat highlight message store + settings
+- `media-player.ts` - Media-player driver relay (Chrome extension WS commands)
+- `word-harvest.ts` - Word Harvest game control
+- `twitch.ts` - Twitch OAuth + stream info
+- `live-assist.ts` / `liveAssistBoot.ts` - Live Assist pipeline router + assembly
+- `dev-events.ts` - Dev-only event injection
 
 **app/api/** - Next.js API routes:
-- `/api/overlays/*` - Overlay control (lower, countdown, poster, quiz, chat-highlight)
+- `/api/overlays/*` - Overlay control (lower, countdown, poster, poster-bigpicture, chat-highlight, title-reveal, sommaire, reload)
 - `/api/obs/*` - OBS status, reconnect, record, stream
-- `/api/actions/*` - Stream Deck actions (lower, countdown, poster, macro, panic)
-- `/api/assets/*` - Guest, poster, theme, tag management
+- `/api/actions/*` - Stream Deck actions (lower, countdown, poster, sommaire, macro, panic)
+- `/api/assets/*` - Guest, poster, theme, tag, upload, thumbnail, title-reveals management
 - `/api/profiles/*` - Profile CRUD and activation
 - `/api/themes/*` - Theme CRUD
-- `/api/settings/*` - Settings management (general, obs, paths, integrations)
+- `/api/settings/*` - Settings management (general, obs, paths, overlay, integrations, studio-return, twitch, midi, instagram, live-assist, title-reveal-defaults)
 - `/api/presenter/*` - Room and cue management
 - `/api/quiz/*` - Quiz questions and state
+- `/api/word-harvest/*` - Word Harvest game (start, show/hide, approve/reject/use words, finale, state)
+- `/api/media-player/*` - Media-player status + per-driver actions (Chrome extension)
+- `/api/chat-messages/*` - Chat highlight message settings
+- `/api/panel-colors/*` - Dashboard panel color persistence
+- `/api/workspaces/*` - Dockview workspace CRUD + default activation
+- `/api/twitch/*` - Twitch OAuth (auth/callback), status, categories, polling, moderation, title/category update
+- `/api/youtube/metadata` - YouTube video metadata lookup
 - `/api/wikipedia/*` - Wikipedia search/resolve/summarize
 - `/api/llm/*` - LLM model listing and summarization
+- `/api/ollama/*` - Ollama connection test
 - `/api/ai/chat` - AI chat assistant (streaming, tool-calling via MCP)
 - `/api/updater/*` - Plugin scanning and updates
+
+> Live Assist STT ingestion (`POST /api/stt/segment`, `GET /api/stt/config`) is served by the **backend** Express server (port 3002), not Next.js.
 
 ### Data Storage
 - **Database**: SQLite via better-sqlite3 in `~/.obs-live-suite/data.db`
@@ -272,10 +296,14 @@ Browser source URLs for OBS (size: 1920x1080):
 - Poster BigPicture: `http://localhost:3000/overlays/poster-bigpicture`
 - Quiz: `http://localhost:3000/overlays/quiz`
 - Chat Highlight: `http://localhost:3000/overlays/chat-highlight`
-- Now Playing: `http://localhost:3000/overlays/now-playing`
+- Now Playing: `http://localhost:3000/overlays/now-playing` (media-player track/artwork)
+- Title Reveal: `http://localhost:3000/overlays/title-reveal` (full-screen animated titles)
+- Word Harvest: `http://localhost:3000/overlays/word-harvest` ("10 words" improv game)
 - Composite: `http://localhost:3000/overlays/composite`
 
 Each overlay connects to WebSocket hub and subscribes to its channel.
+
+**Composite** bundles Poster, Lower Third, Chat Highlight, Sommaire, Title Reveal, Word Harvest, and Countdown in one OBS browser source. **Sommaire** (table-of-contents, `SommaireRenderer`) has no standalone page — it ships via Composite; controlled by `/api/overlays/sommaire` and `/api/actions/sommaire/{show,hide}`.
 
 ## Quiz System
 - Host panel: `/quiz/host`
@@ -334,6 +362,14 @@ Real-time listening assistant (PR #117, branch `feat/assistant-live` — **WIP, 
 - **Run**: `pnpm dev:stt` (bootstraps venv); PM2 app `obs-stt`. **STT requires CUDA** (`device="cuda"` in `realtime-stt/main.py`).
 - **Constants**: `LIVE_ASSIST` in `lib/config/Constants.ts` · **Models**: `lib/models/LiveAssist.ts`.
 - **Status, HTTP contract, how to extend, known gaps → `docs/LIVE-ASSIST.md`**. Deep reference: `docs/superpowers/specs/2026-06-24-assistant-live-design.md` (+ plan).
+
+## Chrome Extension
+"OBS-Suite" companion (`chrome-extension/`, Manifest v3, **no build step** — load unpacked). Server URL stored in `chrome.storage.sync` (default `http://localhost:3000`). Two systems:
+
+1. **Poster capture** (`background.js` service worker): right-click an image → context menu "Show as Left/Right Poster". Downloads the image (bypasses CORS), `POST /api/assets/upload`, `POST /api/assets/posters` (tag `from-web`, deduped by `metadata.sourceUrl`), then `POST /api/overlays/poster`.
+2. **Media-player relay**: `background.js` holds a persistent WebSocket to the hub on `:3003` (derives `ws`/`wss` + host from server URL; MV3 keepalive via `chrome.alarms` ping every 0.5min). Content-script drivers (`drivers/youtube.js`, `drivers/artlist.js`, shared `drivers/driver-base.js`) register a `driverId` and execute play/pause/stop/next/prev/replay/fadeout/status. Backend side: `MediaPlayerManager` + `server/api/media-player.ts` + `/api/media-player/*`; feeds the Now Playing overlay.
+
+UI: `popup/` (status), `options/` (server URL + test). Docs: `chrome-extension/README.md`.
 
 ## Stream Deck Plugin
 - Location: `streamdeck-plugin/obslive-suite/`
@@ -431,11 +467,15 @@ All use fork mode with autorestart and memory limits.
 - `CueCard.tsx` - Individual cue display
 - `panels/` - Presenter panels (cue feed, VDO.Ninja, chat)
 
-**components/overlays/** - Overlay renderers:
+**components/overlays/** - Overlay renderers (each `*Renderer` wraps a `*Display` + WS subscription):
 - `LowerThirdRenderer.tsx` - Lower third display
 - `CountdownDisplay.tsx` - Countdown timer
 - `PosterDisplay.tsx` - Theatre poster
 - `ChatHighlightRenderer.tsx` - Chat highlight
+- `NowPlayingRenderer.tsx` - Media-player track/artwork
+- `SommaireRenderer.tsx` - Table-of-contents (Composite only)
+- `TitleRevealRenderer.tsx` - Full-screen animated title
+- `WordHarvestRenderer.tsx` - Word Harvest game (+ `WordHarvest*` sub-components)
 - `QuizRenderer.tsx` - Quiz display
 
 **components/quiz/** - Quiz system:
@@ -452,7 +492,13 @@ All use fork mode with autorestart and memory limits.
 **components/settings/** - Settings forms:
 - `GeneralSettings.tsx`, `OBSSettings.tsx`
 - `PathSettings.tsx`, `PluginSettings.tsx`
-- `RoomSettings.tsx`, `IntegrationSettings.tsx`
+- `PresenterChannelSettings.tsx`, `StreamerbotSettings.tsx`
+- `TwitchSettings.tsx` (`/settings/twitch` - OAuth + stream info)
+- `InstagramSettings.tsx` (`/settings/instagram` - session-id login for profile/media)
+- `MidiSettings.tsx` (`/settings/midi` - Web MIDI ports + per-action messages, e.g. QLC+)
+- `TitleRevealDefaultsSettings.tsx` (`/settings/title-reveal` - Title Reveal defaults)
+- `ChatMessagesSettings.tsx`, `OverlaySettings.tsx`, `StudioReturnSettings.tsx`
+- `LiveAssistSettings.tsx`, `OllamaSettings.tsx`, `BackupSettings.tsx`, `BackendSettings.tsx`
 
 **components/theme-editor/** - Theme editing:
 - `ThemeEditor.tsx` - Main editor with canvas

--- a/__tests__/models/streamerbotNormalizers.test.ts
+++ b/__tests__/models/streamerbotNormalizers.test.ts
@@ -1,0 +1,127 @@
+import {
+  normalizeTwitchFollowEvent,
+  normalizeTwitchSubEvent,
+  normalizeTwitchReSubEvent,
+  normalizeTwitchGiftSubEvent,
+  normalizeTwitchRaidEvent,
+  normalizeTwitchCheerEvent,
+  normalizeYouTubeNewSponsor,
+} from "@/lib/models/streamerbot";
+
+/**
+ * These tests exercise the real normalizers directly — the path the `/dev` event
+ * tester bypasses (it injects pre-built ChatMessages). They lock in:
+ *   1. the canonical @streamerbot/client field shapes (the original empty-name bug),
+ *   2. the defensive fallbacks for the alternate shapes Streamer.bot has shipped
+ *      across versions (nested `user` / `fromUser` objects).
+ * The viewer name (displayName/username) must never come out empty.
+ */
+// Cast helper: payloads are intentionally shaped like the real (loosely-typed) wire
+// data, which doesn't match our strict interfaces field-for-field.
+const ev = (data: unknown) => ({ event: {}, data } as never);
+
+describe("Streamer.bot viewer-event normalizers", () => {
+  describe("Twitch.Follow", () => {
+    it("extracts the name from the canonical snake_case shape", () => {
+      const msg = normalizeTwitchFollowEvent(
+        ev({ user_id: "1", user_login: "alice", user_name: "Alice" }),
+      );
+      expect(msg.displayName).toBe("Alice");
+      expect(msg.username).toBe("alice");
+      expect(msg.eventType).toBe("follow");
+    });
+
+    it("falls back to a nested user object (defensive)", () => {
+      const msg = normalizeTwitchFollowEvent(
+        ev({ user: { login: "bob", name: "Bob" } }),
+      );
+      expect(msg.displayName).toBe("Bob");
+      expect(msg.username).toBe("bob");
+    });
+  });
+
+  describe("Twitch.Sub", () => {
+    it("uses the separate displayName and stringifies subTier", () => {
+      const msg = normalizeTwitchSubEvent(
+        ev({ userId: "1", userName: "carol", displayName: "Carol", subTier: 2000 }),
+      );
+      expect(msg.displayName).toBe("Carol");
+      expect(msg.username).toBe("carol");
+      expect(msg.metadata?.subscriptionTier).toBe("2000");
+    });
+  });
+
+  describe("Twitch.ReSub", () => {
+    it("extracts name and months", () => {
+      const msg = normalizeTwitchReSubEvent(
+        ev({ userId: "1", userName: "dan", displayName: "Dan", subTier: 1000, cumulativeMonths: 7 }),
+      );
+      expect(msg.displayName).toBe("Dan");
+      expect(msg.metadata?.monthsSubscribed).toBe(7);
+    });
+  });
+
+  describe("Twitch.GiftSub", () => {
+    it("names both gifter and recipient", () => {
+      const msg = normalizeTwitchGiftSubEvent(
+        ev({
+          userId: "1", userName: "eve", displayName: "Eve",
+          recipientUserId: "2", recipientDisplayName: "Frank", subTier: 1000,
+        }),
+      );
+      expect(msg.displayName).toBe("Eve");
+      expect(msg.message).toContain("Frank");
+      expect(msg.metadata?.eventData?.recipient).toBe("Frank");
+    });
+
+    it("renders anonymous gifters without leaking an empty name", () => {
+      const msg = normalizeTwitchGiftSubEvent(
+        ev({ isAnonymous: true, recipientDisplayName: "Grace", subTier: 1000 }),
+      );
+      expect(msg.displayName).toBe("Anonymous");
+      expect(msg.message).toContain("Grace");
+    });
+  });
+
+  describe("Twitch.Raid", () => {
+    it("extracts the raider from from_broadcaster_* and the viewer count", () => {
+      const msg = normalizeTwitchRaidEvent(
+        ev({ from_broadcaster_user_id: "1", from_broadcaster_user_login: "heidi", from_broadcaster_user_name: "Heidi", viewers: 50 }),
+      );
+      expect(msg.displayName).toBe("Heidi");
+      expect(msg.metadata?.eventData?.viewers).toBe(50);
+    });
+  });
+
+  describe("Twitch.Cheer", () => {
+    it("uses username (lowercase) + displayName", () => {
+      const msg = normalizeTwitchCheerEvent(
+        ev({ userId: "1", username: "ivan", displayName: "Ivan", bits: 100 }),
+      );
+      expect(msg.displayName).toBe("Ivan");
+      expect(msg.username).toBe("ivan");
+      expect(msg.metadata?.eventData?.bits).toBe(100);
+    });
+  });
+
+  describe("YouTube.NewSponsor", () => {
+    it("maps a membership to a sub event with a name", () => {
+      const msg = normalizeYouTubeNewSponsor(
+        ev({ userId: "1", userName: "Judy", level: "Member" }),
+      );
+      expect(msg.displayName).toBe("Judy");
+      expect(msg.eventType).toBe("sub");
+      expect(msg.platform).toBe("youtube");
+    });
+  });
+
+  describe("regression: the original bug", () => {
+    it("never yields an empty name when the canonical fields are present", () => {
+      const msg = normalizeTwitchFollowEvent(
+        ev({ user_id: "1", user_login: "k", user_name: "Kevin" }),
+      );
+      expect(msg.displayName).not.toBe("");
+      expect(msg.username).not.toBe("");
+    });
+  });
+});

--- a/lib/adapters/streamerbot/StreamerbotGateway.ts
+++ b/lib/adapters/streamerbot/StreamerbotGateway.ts
@@ -1,7 +1,12 @@
 import { StreamerbotClient } from "@streamerbot/client";
+import { randomUUID } from "crypto";
 import { SettingsService } from "../../services/SettingsService";
 import { WebSocketHub } from "../../services/WebSocketHub";
+import { ChannelManager } from "../../services/ChannelManager";
 import { ChatMessageRepository } from "../../repositories/ChatMessageRepository";
+import { CueMessageRepository } from "../../repositories/CueMessageRepository";
+import { CueType, CueFrom, CueAction } from "../../models/Cue";
+import { RoomEventType } from "../../models/OverlayEvents";
 import {
   ConnectionManager,
   ConnectionStatus as BaseConnectionStatus,
@@ -140,14 +145,75 @@ export class StreamerbotGateway extends ConnectionManager {
    */
   private handleEvent(normalizer: () => ChatMessage): void {
     try {
-      const message = normalizer();
-      this.lastEventTime = Date.now();
-      this.persistMessage(message);
-      this.broadcastMessage(message);
-      this.notifyChatListeners(message);
+      this.processMessage(normalizer());
     } catch (error) {
       this.logger.error("Failed to normalize Streamer.bot event", error);
     }
+  }
+
+  /**
+   * Inject a pre-built ChatMessage through the full processing pipeline.
+   * For use in dev/test tooling only.
+   */
+  injectTestEvent(message: ChatMessage): void {
+    this.processMessage(message);
+  }
+
+  private processMessage(message: ChatMessage): void {
+    this.lastEventTime = Date.now();
+    this.persistMessage(message);
+    this.broadcastMessage(message);
+    this.notifyChatListeners(message);
+    this.maybeSendPresenterCue(message).catch((e) =>
+      this.logger.error("Failed to send presenter cue", e)
+    );
+  }
+
+  /**
+   * Send a cue to the presenter channel for notable viewer events (follow, sub, raid…)
+   */
+  private async maybeSendPresenterCue(message: ChatMessage): Promise<void> {
+    const VIEWER_EVENTS = ["follow", "sub", "resub", "giftsub", "raid"] as const;
+    if (!VIEWER_EVENTS.includes(message.eventType as typeof VIEWER_EVENTS[number])) return;
+
+    const name = message.displayName || message.username || "?";
+    const months = message.metadata?.monthsSubscribed;
+    const viewers = message.metadata?.eventData?.viewers;
+    const recipient = message.metadata?.eventData?.recipient;
+
+    const titles: Record<string, string> = {
+      follow: `${name} vient de follow !`,
+      sub: `${name} s'est abonné !`,
+      resub: `${name} a re-souscrit${months ? ` (${months} mois)` : ""} !`,
+      giftsub: recipient ? `${name} a offert un sub à ${recipient} !` : `${name} a offert un sub !`,
+      raid: `${name} raid avec ${viewers ?? "?"} viewers !`,
+    };
+
+    const title = titles[message.eventType] ?? message.message;
+
+    const cueRepo = CueMessageRepository.getInstance();
+    const cm = ChannelManager.getInstance();
+
+    const cue = cueRepo.create({
+      id: randomUUID(),
+      type: CueType.CUE,
+      fromRole: CueFrom.SYSTEM,
+      severity: "info",
+      title,
+      body: null,
+      pinned: false,
+      actions: [CueAction.ACK],
+      countdownPayload: null,
+      contextPayload: null,
+      questionPayload: null,
+      seenBy: [],
+      ackedBy: [],
+      resolvedAt: null,
+      resolvedBy: null,
+    });
+
+    await cm.publishToPresenter(RoomEventType.MESSAGE, cue);
+    cueRepo.deleteOld(100);
   }
 
   /**

--- a/lib/adapters/streamerbot/StreamerbotGateway.ts
+++ b/lib/adapters/streamerbot/StreamerbotGateway.ts
@@ -161,6 +161,15 @@ export class StreamerbotGateway extends ConnectionManager {
 
   private processMessage(message: ChatMessage): void {
     this.lastEventTime = Date.now();
+    // Diagnostic: for non-chat events (follow/sub/raid/cheer…), log the RAW
+    // Streamer.bot payload so the real field shape can be confirmed against our
+    // normalizers (the package types these loosely / not at all for YouTube).
+    // These events are low-frequency, so the noise is negligible.
+    if (message.eventType !== "message") {
+      this.logger.info(
+        `event[${message.platform}.${message.eventType}] name="${message.displayName}" raw=${JSON.stringify(message.rawPayload)}`
+      );
+    }
     this.persistMessage(message);
     this.broadcastMessage(message);
     this.notifyChatListeners(message);

--- a/lib/models/streamerbot/normalizers.ts
+++ b/lib/models/streamerbot/normalizers.ts
@@ -94,13 +94,13 @@ export function normalizeTwitchChatMessage(event: TwitchChatMessageEvent): ChatM
 export function normalizeTwitchFollowEvent(event: TwitchFollowEvent): ChatMessage {
   const { data } = event;
   return {
-    id: `follow-${data.userId}-${Date.now()}`,
+    id: `follow-${data.user_id}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "follow",
-    username: data.userLogin,
-    displayName: data.userName,
-    message: `${data.userName} just followed!`,
+    username: data.user_login,
+    displayName: data.user_name,
+    message: `${data.user_name} just followed!`,
     rawPayload: event,
   };
 }
@@ -115,11 +115,11 @@ export function normalizeTwitchSubEvent(event: TwitchSubEvent): ChatMessage {
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "sub",
-    username: data.userLogin,
-    displayName: data.userName,
-    message: data.message || `${data.userName} subscribed!`,
+    username: data.userName,
+    displayName: data.displayName,
+    message: data.message || `${data.displayName} subscribed!`,
     metadata: {
-      subscriptionTier: data.tier as "1000" | "2000" | "3000",
+      subscriptionTier: String(data.subTier) as "1000" | "2000" | "3000",
     },
     rawPayload: event,
   };
@@ -135,11 +135,11 @@ export function normalizeTwitchReSubEvent(event: TwitchReSubEvent): ChatMessage 
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "resub",
-    username: data.userLogin,
-    displayName: data.userName,
-    message: data.message || `${data.userName} resubscribed for ${data.cumulativeMonths} months!`,
+    username: data.userName,
+    displayName: data.displayName,
+    message: data.message || `${data.displayName} resubscribed for ${data.cumulativeMonths} months!`,
     metadata: {
-      subscriptionTier: data.tier as "1000" | "2000" | "3000",
+      subscriptionTier: String(data.subTier) as "1000" | "2000" | "3000",
       monthsSubscribed: data.cumulativeMonths,
     },
     rawPayload: event,
@@ -151,17 +151,18 @@ export function normalizeTwitchReSubEvent(event: TwitchReSubEvent): ChatMessage 
  */
 export function normalizeTwitchGiftSubEvent(event: TwitchGiftSubEvent): ChatMessage {
   const { data } = event;
+  const gifterName = data.isAnonymous ? "Anonymous" : (data.displayName || data.userName);
   return {
     id: `giftsub-${data.userId}-${data.recipientUserId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "giftsub",
-    username: data.userName || "Anonymous",
-    displayName: data.userName || "Anonymous",
-    message: `${data.userName || "An anonymous user"} gifted a sub to ${data.recipientUserName}!`,
+    username: data.isAnonymous ? "anonymous" : data.userName,
+    displayName: gifterName,
+    message: `${gifterName} gifted a sub to ${data.recipientDisplayName}!`,
     metadata: {
-      subscriptionTier: data.tier as "1000" | "2000" | "3000",
-      eventData: { recipient: data.recipientUserName, totalGifts: data.totalGifts },
+      subscriptionTier: String(data.subTier) as "1000" | "2000" | "3000",
+      eventData: { recipient: data.recipientDisplayName, totalGifts: data.totalSubsGifted },
     },
     rawPayload: event,
   };
@@ -173,13 +174,13 @@ export function normalizeTwitchGiftSubEvent(event: TwitchGiftSubEvent): ChatMess
 export function normalizeTwitchRaidEvent(event: TwitchRaidEvent): ChatMessage {
   const { data } = event;
   return {
-    id: `raid-${data.userId}-${Date.now()}`,
+    id: `raid-${data.from_broadcaster_user_id}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "raid",
-    username: data.userLogin,
-    displayName: data.userName,
-    message: `${data.userName} is raiding with ${data.viewers} viewers!`,
+    username: data.from_broadcaster_user_login,
+    displayName: data.from_broadcaster_user_name,
+    message: `${data.from_broadcaster_user_name} is raiding with ${data.viewers} viewers!`,
     metadata: {
       eventData: { viewers: data.viewers },
     },
@@ -197,9 +198,9 @@ export function normalizeTwitchCheerEvent(event: TwitchCheerEvent): ChatMessage 
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "cheer",
-    username: data.userName,
-    displayName: data.userName,
-    message: data.message || `${data.userName} cheered ${data.bits} bits!`,
+    username: data.username,
+    displayName: data.displayName,
+    message: data.message || `${data.displayName} cheered ${data.bits} bits!`,
     metadata: {
       eventData: { bits: data.bits },
     },

--- a/lib/models/streamerbot/normalizers.ts
+++ b/lib/models/streamerbot/normalizers.ts
@@ -88,19 +88,62 @@ export function normalizeTwitchChatMessage(event: TwitchChatMessageEvent): ChatM
   };
 }
 
+// ---------------------------------------------------------------------------
+// Defensive field extraction
+//
+// The @streamerbot/client package types Twitch events loosely and YouTube events
+// not at all (`UnknownEventData`), and Streamer.bot has shipped DIFFERENT payload
+// shapes across versions for the same event: flat snake_case (user_login /
+// user_name — the current Follow/EventSub shape), flat camelCase (userName /
+// displayName — Sub/ReSub/Cheer), or a nested user object (user / fromUser /
+// targetUser). Reading a single assumed field silently yields an empty name when
+// the shape differs, which is the exact bug this guards against. So we read each
+// identity from every plausible location and fall back gracefully.
+// ---------------------------------------------------------------------------
+type LooseData = Record<string, unknown>;
+
+const asStr = (v: unknown): string => (typeof v === "string" ? v : v == null ? "" : String(v));
+
+/** Resolve a viewer's { login, name } from flat snake_case, flat camelCase, or a nested user object. */
+function resolveViewer(
+  data: LooseData,
+  nestedKeys: string[] = ["user", "fromUser", "targetUser"],
+): { login: string; name: string } {
+  let login = asStr(data.user_login) || asStr(data.userLogin) || asStr(data.userName) || asStr(data.username);
+  let name = asStr(data.user_name) || asStr(data.displayName) || asStr(data.userName) || asStr(data.username);
+  for (const key of nestedKeys) {
+    const nested = data[key];
+    if (nested && typeof nested === "object") {
+      const n = nested as LooseData;
+      login = login || asStr(n.login) || asStr(n.userLogin) || asStr(n.name);
+      name = name || asStr(n.name) || asStr(n.displayName) || asStr(n.login);
+    }
+  }
+  name = name || login;
+  return { login, name };
+}
+
+/** Normalize a subscription tier (number 1000 or string "1000") to our union. */
+function resolveTier(v: unknown): "1000" | "2000" | "3000" {
+  const s = asStr(v);
+  return s === "2000" || s === "3000" ? s : "1000";
+}
+
 /**
  * Normalize a Twitch.Follow event
  */
 export function normalizeTwitchFollowEvent(event: TwitchFollowEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { login, name } = resolveViewer(data);
+  const userId = asStr(data.user_id) || asStr(data.userId) || login;
   return {
-    id: `follow-${data.user_id}-${Date.now()}`,
+    id: `follow-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "follow",
-    username: data.user_login,
-    displayName: data.user_name,
-    message: `${data.user_name} just followed!`,
+    username: login,
+    displayName: name,
+    message: `${name} just followed!`,
     rawPayload: event,
   };
 }
@@ -109,17 +152,19 @@ export function normalizeTwitchFollowEvent(event: TwitchFollowEvent): ChatMessag
  * Normalize a Twitch.Sub event
  */
 export function normalizeTwitchSubEvent(event: TwitchSubEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { login, name } = resolveViewer(data);
+  const userId = asStr(data.userId) || asStr(data.user_id) || login;
   return {
-    id: `sub-${data.userId}-${Date.now()}`,
+    id: `sub-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "sub",
-    username: data.userName,
-    displayName: data.displayName,
-    message: data.message || `${data.displayName} subscribed!`,
+    username: login,
+    displayName: name,
+    message: asStr(data.message) || `${name} subscribed!`,
     metadata: {
-      subscriptionTier: String(data.subTier) as "1000" | "2000" | "3000",
+      subscriptionTier: resolveTier(data.subTier ?? data.tier),
     },
     rawPayload: event,
   };
@@ -129,18 +174,21 @@ export function normalizeTwitchSubEvent(event: TwitchSubEvent): ChatMessage {
  * Normalize a Twitch.ReSub event
  */
 export function normalizeTwitchReSubEvent(event: TwitchReSubEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { login, name } = resolveViewer(data);
+  const userId = asStr(data.userId) || asStr(data.user_id) || login;
+  const months = Number(data.cumulativeMonths ?? data.monthsSubscribed ?? 0) || 0;
   return {
-    id: `resub-${data.userId}-${Date.now()}`,
+    id: `resub-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "resub",
-    username: data.userName,
-    displayName: data.displayName,
-    message: data.message || `${data.displayName} resubscribed for ${data.cumulativeMonths} months!`,
+    username: login,
+    displayName: name,
+    message: asStr(data.message) || `${name} resubscribed for ${months} months!`,
     metadata: {
-      subscriptionTier: String(data.subTier) as "1000" | "2000" | "3000",
-      monthsSubscribed: data.cumulativeMonths,
+      subscriptionTier: resolveTier(data.subTier ?? data.tier),
+      monthsSubscribed: months,
     },
     rawPayload: event,
   };
@@ -150,19 +198,29 @@ export function normalizeTwitchReSubEvent(event: TwitchReSubEvent): ChatMessage 
  * Normalize a Twitch.GiftSub event
  */
 export function normalizeTwitchGiftSubEvent(event: TwitchGiftSubEvent): ChatMessage {
-  const { data } = event;
-  const gifterName = data.isAnonymous ? "Anonymous" : (data.displayName || data.userName);
+  const data = event.data as unknown as LooseData;
+  const isAnonymous = Boolean(data.isAnonymous);
+  const gifter = resolveViewer(data);
+  const gifterName = isAnonymous ? "Anonymous" : gifter.name || "Anonymous";
+  const recipientName =
+    asStr(data.recipientDisplayName) ||
+    asStr(data.recipientUsername) ||
+    asStr(data.recipientUserName) ||
+    asStr((data.recipient as LooseData | undefined)?.name) ||
+    "?";
+  const userId = asStr(data.userId) || asStr(data.user_id) || gifter.login;
+  const recipientId = asStr(data.recipientUserId) || recipientName;
   return {
-    id: `giftsub-${data.userId}-${data.recipientUserId}-${Date.now()}`,
+    id: `giftsub-${userId}-${recipientId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "giftsub",
-    username: data.isAnonymous ? "anonymous" : data.userName,
+    username: isAnonymous ? "anonymous" : gifter.login,
     displayName: gifterName,
-    message: `${gifterName} gifted a sub to ${data.recipientDisplayName}!`,
+    message: `${gifterName} gifted a sub to ${recipientName}!`,
     metadata: {
-      subscriptionTier: String(data.subTier) as "1000" | "2000" | "3000",
-      eventData: { recipient: data.recipientDisplayName, totalGifts: data.totalSubsGifted },
+      subscriptionTier: resolveTier(data.subTier ?? data.tier),
+      eventData: { recipient: recipientName, totalGifts: Number(data.totalSubsGifted ?? 0) || undefined },
     },
     rawPayload: event,
   };
@@ -172,17 +230,22 @@ export function normalizeTwitchGiftSubEvent(event: TwitchGiftSubEvent): ChatMess
  * Normalize a Twitch.Raid event
  */
 export function normalizeTwitchRaidEvent(event: TwitchRaidEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const nested = resolveViewer(data, ["fromUser", "user"]);
+  const login = asStr(data.from_broadcaster_user_login) || nested.login;
+  const name = asStr(data.from_broadcaster_user_name) || nested.name || login;
+  const userId = asStr(data.from_broadcaster_user_id) || asStr(data.userId) || login;
+  const viewers = Number(data.viewers ?? 0) || 0;
   return {
-    id: `raid-${data.from_broadcaster_user_id}-${Date.now()}`,
+    id: `raid-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "raid",
-    username: data.from_broadcaster_user_login,
-    displayName: data.from_broadcaster_user_name,
-    message: `${data.from_broadcaster_user_name} is raiding with ${data.viewers} viewers!`,
+    username: login,
+    displayName: name,
+    message: `${name} is raiding with ${viewers} viewers!`,
     metadata: {
-      eventData: { viewers: data.viewers },
+      eventData: { viewers },
     },
     rawPayload: event,
   };
@@ -192,17 +255,20 @@ export function normalizeTwitchRaidEvent(event: TwitchRaidEvent): ChatMessage {
  * Normalize a Twitch.Cheer event
  */
 export function normalizeTwitchCheerEvent(event: TwitchCheerEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { login, name } = resolveViewer(data);
+  const userId = asStr(data.userId) || asStr(data.user_id) || login;
+  const bits = Number(data.bits ?? 0) || 0;
   return {
-    id: `cheer-${data.userId}-${Date.now()}`,
+    id: `cheer-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "twitch",
     eventType: "cheer",
-    username: data.username,
-    displayName: data.displayName,
-    message: data.message || `${data.displayName} cheered ${data.bits} bits!`,
+    username: login,
+    displayName: name,
+    message: asStr(data.message) || `${name} cheered ${bits} bits!`,
     metadata: {
-      eventData: { bits: data.bits },
+      eventData: { bits },
     },
     rawPayload: event,
   };
@@ -216,20 +282,22 @@ export function normalizeTwitchCheerEvent(event: TwitchCheerEvent): ChatMessage 
  * Normalize a YouTube.Message event
  */
 export function normalizeYouTubeChatMessage(event: YouTubeChatMessageEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { name } = resolveViewer(data);
+  const text = asStr(data.message);
   return {
-    id: data.messageId || `yt-${Date.now()}-${Math.random()}`,
+    id: asStr(data.messageId) || `yt-${Date.now()}-${Math.random()}`,
     timestamp: Date.now(),
     platform: "youtube",
     eventType: "message",
-    username: data.userName,
-    displayName: data.userName,
-    message: data.message,
-    parts: [{ type: "text", text: data.message }],
+    username: name,
+    displayName: name,
+    message: text,
+    parts: [{ type: "text", text }],
     metadata: {
-      isMod: data.isModerator,
-      isBroadcaster: data.isOwner,
-      isSubscriber: data.isSponsor,
+      isMod: Boolean(data.isModerator),
+      isBroadcaster: Boolean(data.isOwner),
+      isSubscriber: Boolean(data.isSponsor),
     },
     rawPayload: event,
   };
@@ -239,17 +307,19 @@ export function normalizeYouTubeChatMessage(event: YouTubeChatMessageEvent): Cha
  * Normalize a YouTube.NewSponsor event (membership)
  */
 export function normalizeYouTubeNewSponsor(event: YouTubeNewSponsorEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { name } = resolveViewer(data);
+  const userId = asStr(data.userId) || name;
   return {
-    id: `sponsor-${data.userId}-${Date.now()}`,
+    id: `sponsor-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "youtube",
     eventType: "sub",
-    username: data.userName,
-    displayName: data.userName,
-    message: `${data.userName} became a member!`,
+    username: name,
+    displayName: name,
+    message: `${name} became a member!`,
     metadata: {
-      eventData: { level: data.level },
+      eventData: { level: asStr(data.level) || undefined },
     },
     rawPayload: event,
   };
@@ -259,17 +329,21 @@ export function normalizeYouTubeNewSponsor(event: YouTubeNewSponsorEvent): ChatM
  * Normalize a YouTube.SuperChat event
  */
 export function normalizeYouTubeSuperChat(event: YouTubeSuperChatEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { name } = resolveViewer(data);
+  const userId = asStr(data.userId) || name;
+  const amount = Number(data.amount ?? 0) || 0;
+  const currency = asStr(data.currency);
   return {
-    id: `superchat-${data.userId}-${Date.now()}`,
+    id: `superchat-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "youtube",
     eventType: "superchat",
-    username: data.userName,
-    displayName: data.userName,
-    message: data.message || `${data.userName} sent ${data.currency} ${data.amount}!`,
+    username: name,
+    displayName: name,
+    message: asStr(data.message) || `${name} sent ${currency} ${amount}!`,
     metadata: {
-      eventData: { amount: data.amount, currency: data.currency },
+      eventData: { amount, currency },
     },
     rawPayload: event,
   };
@@ -279,17 +353,21 @@ export function normalizeYouTubeSuperChat(event: YouTubeSuperChatEvent): ChatMes
  * Normalize a YouTube.SuperSticker event
  */
 export function normalizeYouTubeSuperSticker(event: YouTubeSuperStickerEvent): ChatMessage {
-  const { data } = event;
+  const data = event.data as unknown as LooseData;
+  const { name } = resolveViewer(data);
+  const userId = asStr(data.userId) || name;
+  const amount = Number(data.amount ?? 0) || 0;
+  const currency = asStr(data.currency);
   return {
-    id: `supersticker-${data.userId}-${Date.now()}`,
+    id: `supersticker-${userId}-${Date.now()}`,
     timestamp: Date.now(),
     platform: "youtube",
     eventType: "supersticker",
-    username: data.userName,
-    displayName: data.userName,
-    message: `${data.userName} sent a Super Sticker for ${data.currency} ${data.amount}!`,
+    username: name,
+    displayName: name,
+    message: `${name} sent a Super Sticker for ${currency} ${amount}!`,
     metadata: {
-      eventData: { amount: data.amount, currency: data.currency, sticker: data.sticker },
+      eventData: { amount, currency, sticker: asStr(data.sticker) || undefined },
     },
     rawPayload: event,
   };

--- a/lib/models/streamerbot/types.ts
+++ b/lib/models/streamerbot/types.ts
@@ -78,10 +78,10 @@ export interface TwitchChatMessageEvent {
 export interface TwitchFollowEvent {
   event: { source: "Twitch"; type: "Follow" };
   data: {
-    userId: string;
-    userName: string;
-    userLogin: string;
-    followedAt: string;
+    user_id: string;
+    user_login: string;
+    user_name: string;
+    followed_at: string;
   };
 }
 
@@ -93,8 +93,8 @@ export interface TwitchSubEvent {
   data: {
     userId: string;
     userName: string;
-    userLogin: string;
-    tier: string;
+    displayName: string;
+    subTier: number;
     message?: string;
   };
 }
@@ -107,10 +107,11 @@ export interface TwitchReSubEvent {
   data: {
     userId: string;
     userName: string;
-    userLogin: string;
-    tier: string;
+    displayName: string;
+    subTier: number;
     cumulativeMonths: number;
     streakMonths?: number;
+    shareStreak?: boolean;
     message?: string;
   };
 }
@@ -123,10 +124,13 @@ export interface TwitchGiftSubEvent {
   data: {
     userId: string;
     userName: string;
+    displayName: string;
+    isAnonymous: boolean;
     recipientUserId: string;
-    recipientUserName: string;
-    tier: string;
-    totalGifts?: number;
+    recipientUsername: string;
+    recipientDisplayName: string;
+    subTier: number;
+    totalSubsGifted?: number;
   };
 }
 
@@ -136,9 +140,12 @@ export interface TwitchGiftSubEvent {
 export interface TwitchRaidEvent {
   event: { source: "Twitch"; type: "Raid" };
   data: {
-    userId: string;
-    userName: string;
-    userLogin: string;
+    from_broadcaster_user_id: string;
+    from_broadcaster_user_login: string;
+    from_broadcaster_user_name: string;
+    to_broadcaster_user_id: string;
+    to_broadcaster_user_login: string;
+    to_broadcaster_user_name: string;
     viewers: number;
   };
 }
@@ -150,7 +157,8 @@ export interface TwitchCheerEvent {
   event: { source: "Twitch"; type: "Cheer" };
   data: {
     userId: string;
-    userName: string;
+    username: string;
+    displayName: string;
     bits: number;
     message?: string;
   };

--- a/server/api/dev-events.ts
+++ b/server/api/dev-events.ts
@@ -1,0 +1,425 @@
+/**
+ * Dev-only router: simulate Twitch viewer events via the Twitch CLI.
+ *
+ * Flow:
+ *   1. Browser clicks a button → POST /dev/simulate
+ *   2. Backend opens an ephemeral PLAIN-HTTP listener on 127.0.0.1:<random>
+ *   3. Backend spawns: twitch event trigger <type> -F http://127.0.0.1:<random>
+ *   4. Twitch CLI POSTs an EventSub payload to that listener
+ *   5. Listener converts EventSub → ChatMessage → StreamerbotGateway.injectTestEvent()
+ *   6. Listener is torn down once the CLI exits
+ *
+ * The ephemeral listener is plain HTTP on purpose: the main backend may serve
+ * HTTPS (mkcert / Tailscale cert) and the Twitch CLI's Go client can neither
+ * speak plain HTTP to a TLS port nor validate that cert against 127.0.0.1.
+ * Forwarding to a throwaway HTTP port sidesteps the scheme entirely.
+ *
+ * Registered at /dev only when NODE_ENV !== 'production' (see backend.ts).
+ *
+ * Prerequisites:
+ *   - Twitch CLI installed and in PATH: https://dev.twitch.tv/docs/cli
+ */
+import { Router } from "express";
+import { spawn } from "child_process";
+import http from "http";
+import { StreamerbotGateway } from "../../lib/adapters/streamerbot/StreamerbotGateway";
+import type { ChatMessage } from "../../lib/models/StreamerbotChat";
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// Mapping: our UI eventType → Twitch CLI event name
+// ---------------------------------------------------------------------------
+const CLI_EVENT_TYPES: Record<string, string> = {
+  follow:   "channel.follow",
+  sub:      "channel.subscribe",
+  resub:    "channel.subscription.message",
+  giftsub:  "channel.subscription.gift",
+  raid:     "channel.raid",
+  cheer:    "channel.cheer",
+};
+
+// ---------------------------------------------------------------------------
+// POST /dev/simulate
+// Called by the HTML page. Triggers the Twitch CLI and captures the event it
+// forwards to a throwaway listener, then injects it into the gateway.
+// ---------------------------------------------------------------------------
+router.post("/simulate", async (req, res) => {
+  const {
+    eventType,
+    viewers = 42,
+    subTier = 1000,
+  } = req.body as Record<string, string | number>;
+
+  const cliEvent = CLI_EVENT_TYPES[String(eventType)];
+  if (!cliEvent) {
+    return res.status(400).json({ error: `Unknown eventType: ${eventType}` });
+  }
+
+  const extraArgs: string[] = [];
+  // Raid: set viewer count via -C (cost).
+  if (eventType === "raid") extraArgs.push("-C", String(viewers));
+  // Sub / ReSub / GiftSub: set tier.
+  if (["sub", "resub", "giftsub"].includes(String(eventType))) {
+    extraArgs.push("--tier", String(subTier));
+  }
+
+  try {
+    const { output, received } = await triggerAndCapture(cliEvent, extraArgs);
+    return res.json({ ok: true, received, output });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return res.status(500).json({ ok: false, error: msg });
+  }
+});
+
+/**
+ * Open a throwaway plain-HTTP listener, point the Twitch CLI at it, and inject
+ * the forwarded EventSub payload into the gateway. The listener is closed once
+ * the CLI exits (which only happens after it has received our 200 response, so
+ * the inject is guaranteed to have run by then).
+ */
+function triggerAndCapture(
+  cliEvent: string,
+  extraArgs: string[],
+): Promise<{ output: string; received: boolean }> {
+  return new Promise((resolve, reject) => {
+    let received = false;
+
+    const server = http.createServer((sreq, sres) => {
+      if (sreq.method !== "POST") {
+        sres.writeHead(405);
+        return sres.end();
+      }
+      let body = "";
+      sreq.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+      sreq.on("end", () => {
+        try {
+          const { subscription, event } = JSON.parse(body || "{}");
+          const message = buildChatMessage(subscription?.type ?? "", event ?? {});
+          if (message) {
+            StreamerbotGateway.getInstance().injectTestEvent(message);
+            received = true;
+          }
+          sres.writeHead(200, { "Content-Type": "application/json" });
+          sres.end(JSON.stringify({ ok: received }));
+        } catch {
+          sres.writeHead(400);
+          sres.end();
+        }
+      });
+    });
+
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", async () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      const forwardUrl = `http://127.0.0.1:${port}/`;
+      try {
+        const output = await runCli(["event", "trigger", cliEvent, "-F", forwardUrl, ...extraArgs]);
+        server.close();
+        resolve({ output, received });
+      } catch (err) {
+        server.close();
+        reject(err);
+      }
+    });
+  });
+}
+
+function runCli(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("twitch", args, { shell: true });
+    let out = "";
+    proc.stdout.on("data", (d: Buffer) => { out += d.toString(); });
+    proc.stderr.on("data", (d: Buffer) => { out += d.toString(); });
+    proc.on("close", (code) => {
+      if (code === 0) resolve(out.trim());
+      else reject(new Error(out.trim() || `twitch CLI exited with code ${code}`));
+    });
+    proc.on("error", (e) => reject(new Error(`twitch CLI not found in PATH: ${e.message}`)));
+  });
+}
+
+function str(v: unknown): string { return String(v ?? ""); }
+function num(v: unknown): number { return Number(v) || 0; }
+
+function buildChatMessage(type: string, ev: Record<string, unknown>): ChatMessage | null {
+  const now = Date.now();
+
+  switch (type) {
+    case "channel.follow": {
+      const login = str(ev.user_login);
+      const name  = str(ev.user_name) || login;
+      return {
+        id: `follow-dev-${now}`,
+        timestamp: now, platform: "twitch", eventType: "follow",
+        username: login, displayName: name,
+        message: `${name} just followed!`,
+        rawPayload: ev,
+      };
+    }
+    case "channel.subscribe": {
+      const login = str(ev.user_login);
+      const name  = str(ev.user_name) || login;
+      return {
+        id: `sub-dev-${now}`,
+        timestamp: now, platform: "twitch", eventType: "sub",
+        username: login, displayName: name,
+        message: `${name} subscribed!`,
+        metadata: { subscriptionTier: str(ev.tier) as "1000" | "2000" | "3000" },
+        rawPayload: ev,
+      };
+    }
+    case "channel.subscription.message": {
+      const login  = str(ev.user_login);
+      const name   = str(ev.user_name) || login;
+      const months = num(ev.cumulative_months);
+      return {
+        id: `resub-dev-${now}`,
+        timestamp: now, platform: "twitch", eventType: "resub",
+        username: login, displayName: name,
+        message: `${name} resubscribed for ${months} months!`,
+        metadata: {
+          subscriptionTier: str(ev.tier) as "1000" | "2000" | "3000",
+          monthsSubscribed: months,
+        },
+        rawPayload: ev,
+      };
+    }
+    case "channel.subscription.gift": {
+      const login  = str(ev.user_login);
+      const name   = str(ev.user_name) || login;
+      const recip  = str(ev.recipient_user_name || ev.recipient_user_login);
+      const anon   = Boolean(ev.is_anonymous);
+      return {
+        id: `giftsub-dev-${now}`,
+        timestamp: now, platform: "twitch", eventType: "giftsub",
+        username: anon ? "anonymous" : login,
+        displayName: anon ? "Anonymous" : name,
+        message: `${anon ? "Anonymous" : name} gifted a sub to ${recip}!`,
+        metadata: {
+          subscriptionTier: str(ev.tier) as "1000" | "2000" | "3000",
+          eventData: { recipient: recip },
+        },
+        rawPayload: ev,
+      };
+    }
+    case "channel.raid": {
+      const login    = str(ev.from_broadcaster_user_login);
+      const name     = str(ev.from_broadcaster_user_name) || login;
+      const viewers  = num(ev.viewers);
+      return {
+        id: `raid-dev-${now}`,
+        timestamp: now, platform: "twitch", eventType: "raid",
+        username: login, displayName: name,
+        message: `${name} is raiding with ${viewers} viewers!`,
+        metadata: { eventData: { viewers } },
+        rawPayload: ev,
+      };
+    }
+    case "channel.cheer": {
+      const login = str(ev.user_login);
+      const name  = str(ev.user_name) || login;
+      const bits  = num(ev.bits);
+      return {
+        id: `cheer-dev-${now}`,
+        timestamp: now, platform: "twitch", eventType: "cheer",
+        username: login, displayName: name,
+        message: `${name} cheered ${bits} bits!`,
+        metadata: { eventData: { bits } },
+        rawPayload: ev,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /dev  — serve the test UI
+// ---------------------------------------------------------------------------
+router.get("/", (_req, res) => {
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.send(UI_HTML);
+});
+
+// ---------------------------------------------------------------------------
+// HTML UI
+// ---------------------------------------------------------------------------
+const UI_HTML = /* html */ `<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Twitch Event Tester</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #0e0e10; --surface: #18181b; --border: #2f2f35;
+    --accent: #9147ff; --green: #00b894; --red: #e84393;
+    --text: #efeff1; --muted: #adadb8;
+    --follow: #00b894; --sub: #9147ff; --resub: #6441a5;
+    --giftsub: #e84393; --raid: #f7931e; --cheer: #f1c40f;
+  }
+  body { background: var(--bg); color: var(--text); font-family: system-ui, sans-serif;
+         font-size: 14px; min-height: 100vh; padding: 24px; max-width: 600px; margin: 0 auto; }
+  h1 { font-size: 18px; font-weight: 700; margin-bottom: 4px;
+       display: flex; align-items: center; gap: 8px; }
+  h1 span { color: var(--accent); }
+  .subtitle { color: var(--muted); font-size: 12px; margin-bottom: 20px; font-family: monospace; }
+
+  .card { background: var(--surface); border: 1px solid var(--border);
+          border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+  label { display: flex; flex-direction: column; gap: 4px; color: var(--muted); font-size: 12px; }
+  input[type=text], input[type=number] {
+    background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+    color: var(--text); padding: 6px 10px; font-size: 14px; width: 100%;
+    transition: border-color .15s;
+  }
+  input:focus { outline: none; border-color: var(--accent); }
+  .fields { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .fields.three { grid-template-columns: 1fr 1fr 1fr; }
+
+  .events { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+  .btn {
+    border: none; border-radius: 8px; padding: 12px 8px; cursor: pointer;
+    font-size: 13px; font-weight: 600; display: flex; flex-direction: column;
+    align-items: center; gap: 4px; transition: transform .1s, opacity .15s;
+    color: #fff; position: relative;
+  }
+  .btn:hover { opacity: .85; transform: translateY(-1px); }
+  .btn:active { transform: translateY(0); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .btn .icon { font-size: 22px; }
+  .btn-follow  { background: var(--follow); }
+  .btn-sub     { background: var(--sub); }
+  .btn-resub   { background: var(--resub); }
+  .btn-giftsub { background: var(--giftsub); }
+  .btn-raid    { background: var(--raid); color: #111; }
+  .btn-cheer   { background: var(--cheer); color: #111; }
+
+  .log-title { font-size: 12px; color: var(--muted); text-transform: uppercase;
+               letter-spacing: .06em; margin-bottom: 8px; }
+  #log { max-height: 300px; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+  .log-entry {
+    background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+    padding: 8px 12px; font-size: 12px; display: grid;
+    grid-template-columns: 60px 1fr; gap: 8px; align-items: start;
+  }
+  .log-entry.ok  { border-left: 3px solid var(--green); }
+  .log-entry.err { border-left: 3px solid var(--red); }
+  .log-badge { font-weight: 700; font-size: 11px; padding: 2px 6px;
+               border-radius: 4px; text-align: center; }
+  .log-badge.ok  { background: #00b89422; color: var(--green); }
+  .log-badge.err { background: #e8439322; color: var(--red); }
+  .log-msg { color: var(--text); font-family: monospace; white-space: pre-wrap; word-break: break-all; }
+  .log-sub { color: var(--muted); font-size: 11px; }
+</style>
+</head>
+<body>
+<h1>🎮 <span>Twitch Event Tester</span></h1>
+<p class="subtitle">Twitch CLI → EventSub → gateway (DB + WS + cue presenter)</p>
+
+<div class="card">
+  <div class="fields">
+    <label>Viewers (raid)
+      <input type="number" id="viewers" value="42" min="1">
+    </label>
+    <label>Sub Tier (1000 / 2000 / 3000)
+      <input type="number" id="subTier" value="1000" min="1000" max="3000" step="1000">
+    </label>
+  </div>
+  <p style="margin-top:10px;font-size:11px;color:var(--muted)">
+    Les noms de viewers sont générés aléatoirement par la CLI Twitch.
+  </p>
+</div>
+
+<div class="card">
+  <div class="events">
+    <button class="btn btn-follow"  id="btn-follow"  onclick="fire('follow')">
+      <span class="icon">👤</span>Follow
+    </button>
+    <button class="btn btn-sub"     id="btn-sub"     onclick="fire('sub')">
+      <span class="icon">👑</span>Sub
+    </button>
+    <button class="btn btn-resub"   id="btn-resub"   onclick="fire('resub')">
+      <span class="icon">🔄</span>ReSub
+    </button>
+    <button class="btn btn-giftsub" id="btn-giftsub" onclick="fire('giftsub')">
+      <span class="icon">🎁</span>Gift Sub
+    </button>
+    <button class="btn btn-raid"    id="btn-raid"    onclick="fire('raid')">
+      <span class="icon">⚡</span>Raid
+    </button>
+    <button class="btn btn-cheer"   id="btn-cheer"   onclick="fire('cheer')">
+      <span class="icon">💰</span>Cheer
+    </button>
+  </div>
+</div>
+
+<div class="card">
+  <div class="log-title">Log CLI</div>
+  <div id="log"><div class="log-sub" style="padding:4px 0">Aucun event envoyé.</div></div>
+</div>
+
+<script>
+const ALL_BTNS = ['follow','sub','resub','giftsub','raid','cheer'];
+
+function setLoading(loading) {
+  ALL_BTNS.forEach(t => {
+    document.getElementById('btn-' + t).disabled = loading;
+  });
+}
+
+async function fire(eventType) {
+  setLoading(true);
+  const body = {
+    eventType,
+    viewers: Number(document.getElementById('viewers').value) || 42,
+    subTier: Number(document.getElementById('subTier').value) || 1000,
+  };
+  try {
+    const r = await fetch('/dev/simulate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await r.json();
+    // ok = CLI ran; received = event actually reached the gateway.
+    const success = r.ok && data.received !== false;
+    const detail = data.received === false
+      ? "CLI a tourné mais aucun event reçu (type non géré ?)"
+      : (data.output || data.error || '');
+    addLog(success, eventType, detail);
+  } catch (e) {
+    addLog(false, eventType, String(e));
+  } finally {
+    setLoading(false);
+  }
+}
+
+function addLog(ok, eventType, detail) {
+  const log = document.getElementById('log');
+  const placeholder = log.querySelector('.log-sub');
+  if (placeholder) placeholder.remove();
+
+  const entry = document.createElement('div');
+  entry.className = 'log-entry ' + (ok ? 'ok' : 'err');
+  entry.innerHTML =
+    '<span class="log-badge ' + (ok ? 'ok' : 'err') + '">' + (ok ? '✓ OK' : '✗ ERR') + '</span>' +
+    '<span class="log-msg">' + escHtml(eventType) +
+    (detail ? '\\n<span class=\\"log-sub\\">' + escHtml(detail) + '</span>' : '') +
+    '</span>';
+  log.insertBefore(entry, log.firstChild);
+}
+
+function escHtml(s) {
+  return String(s).replace(/[&<>"']/g, c =>
+    ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c] || c));
+}
+</script>
+</body>
+</html>`;
+
+export default router;

--- a/server/api/dev-events.ts
+++ b/server/api/dev-events.ts
@@ -28,6 +28,20 @@ import type { ChatMessage } from "../../lib/models/StreamerbotChat";
 const router = Router();
 
 // ---------------------------------------------------------------------------
+// Localhost-only guard. /dev spawns a local process (the Twitch CLI); the
+// backend listens on all interfaces (incl. Tailscale), so without this any LAN
+// peer could trigger process spawning. Only loopback callers are allowed.
+// ---------------------------------------------------------------------------
+router.use((req, res, next) => {
+  const ip = req.socket.remoteAddress ?? "";
+  const isLoopback = ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+  if (!isLoopback) {
+    return res.status(403).json({ error: "dev routes are localhost-only" });
+  }
+  next();
+});
+
+// ---------------------------------------------------------------------------
 // Mapping: our UI eventType → Twitch CLI event name
 // ---------------------------------------------------------------------------
 const CLI_EVENT_TYPES: Record<string, string> = {
@@ -39,29 +53,40 @@ const CLI_EVENT_TYPES: Record<string, string> = {
   cheer:    "channel.cheer",
 };
 
+const VALID_TIERS = new Set(["1000", "2000", "3000"]);
+
+/** Clamp request-supplied numbers to a sane bounded integer (no NaN, no shell metachars). */
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const n = Math.trunc(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
 // ---------------------------------------------------------------------------
 // POST /dev/simulate
 // Called by the HTML page. Triggers the Twitch CLI and captures the event it
 // forwards to a throwaway listener, then injects it into the gateway.
 // ---------------------------------------------------------------------------
 router.post("/simulate", async (req, res) => {
-  const {
-    eventType,
-    viewers = 42,
-    subTier = 1000,
-  } = req.body as Record<string, string | number>;
+  const body = req.body as Record<string, unknown>;
+  const eventType = String(body.eventType ?? "");
 
-  const cliEvent = CLI_EVENT_TYPES[String(eventType)];
+  const cliEvent = CLI_EVENT_TYPES[eventType];
   if (!cliEvent) {
     return res.status(400).json({ error: `Unknown eventType: ${eventType}` });
   }
+
+  // Coerce request-supplied values to safe, bounded forms before they reach the
+  // CLI args (defence in depth — spawn already runs with shell:false).
+  const viewers = clampInt(body.viewers, 1, 1_000_000, 42);
+  const subTier = VALID_TIERS.has(String(body.subTier)) ? String(body.subTier) : "1000";
 
   const extraArgs: string[] = [];
   // Raid: set viewer count via -C (cost).
   if (eventType === "raid") extraArgs.push("-C", String(viewers));
   // Sub / ReSub / GiftSub: set tier.
-  if (["sub", "resub", "giftsub"].includes(String(eventType))) {
-    extraArgs.push("--tier", String(subTier));
+  if (["sub", "resub", "giftsub"].includes(eventType)) {
+    extraArgs.push("--tier", subTier);
   }
 
   try {
@@ -129,7 +154,10 @@ function triggerAndCapture(
 
 function runCli(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawn("twitch", args, { shell: true });
+    // shell:false → args are passed straight to the executable, never parsed by a
+    // shell, so request-supplied values can't be interpreted as commands.
+    // `twitch`/`twitch.exe` is resolved from PATH by Node directly.
+    const proc = spawn("twitch", args, { shell: false });
     let out = "";
     proc.stdout.on("data", (d: Buffer) => { out += d.toString(); });
     proc.stderr.on("data", (d: Buffer) => { out += d.toString(); });

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -36,6 +36,7 @@ import mediaPlayerRouter from "./api/media-player";
 import wordHarvestRouter from "./api/word-harvest";
 import { createLiveAssistRouter } from "./api/live-assist";
 import { buildOrchestrator } from "./api/liveAssistBoot";
+import devEventsRouter from "./api/dev-events";
 import { APP_PORT, BACKEND_PORT, WS_PORT } from "../lib/config/urls";
 import { createServerWithFallback } from "../lib/utils/CertificateManager";
 import { getPortConflictReport } from "../scripts/port-diagnostics.mjs";
@@ -127,6 +128,12 @@ class BackendServer {
     const { orchestrator, store, registry } = buildOrchestrator();
     this.app.use(createLiveAssistRouter({ orchestrator, store, registry }));
     this.logger.info("✓ Live Assist routes configured");
+
+    // Dev-only: viewer event simulator UI
+    if (process.env.NODE_ENV !== "production") {
+      this.app.use("/dev", devEventsRouter);
+      this.logger.info("✓ Dev event tester available at /dev");
+    }
 
     // 404 handler MUST be added LAST (after all routes)
     this.app.use((req, res) => {


### PR DESCRIPTION
## Contexte

Quand un viewer **follow** ou **sub**, son nom apparaissait **vide** dans le panneau Chat du presenter, et **aucun message** n'arrivait dans son fil. Deux causes distinctes.

## Bug 1 — Noms vides

Le package `@streamerbot/client` envoie des champs qui ne correspondaient pas à nos types :

| Event | Réel (package) | Notre code (faux) |
|-------|----------------|-------------------|
| Follow | `user_login` / `user_name` (snake_case) | `userLogin` / `userName` |
| Sub / ReSub | `displayName` séparé, `subTier` | `userLogin`, `tier` |
| GiftSub | `recipientDisplayName`, `subTier` | `recipientUserName`, `tier` |
| Raid | `from_broadcaster_user_*` | `userLogin` / `userName` |
| Cheer | `username` (minuscule) | `userName` |

Les normalizers lisaient des champs camelCase inexistants → `displayName`/`username` = `undefined` → nom vide.

**Fix** : alignement des types (`lib/models/streamerbot/types.ts`) et des normalizers (`lib/models/streamerbot/normalizers.ts`) sur les vrais champs du package.

## Bug 2 — Cue presenter manquant

Aucun code ne créait de cue presenter à la réception d'un event viewer. Ajout de `maybeSendPresenterCue()` dans `StreamerbotGateway` : follow / sub / resub / giftsub / raid créent désormais un cue `SYSTEM` sur le canal presenter avec le nom du viewer (ex: *« Alice vient de follow ! »*).

## Outillage dev — testeur d'events (`/dev`)

Page dev-only (`NODE_ENV !== production`) avec des boutons qui déclenchent de **vrais events via la Twitch CLI** (`twitch event trigger`). Le payload EventSub est capté par un **listener HTTP éphémère** (indépendant du schéma — évite le mismatch HTTPS/cert quand le backend sert du TLS), puis injecté dans le pipeline complet du gateway (DB + WebSocket + cue presenter).

→ `http://localhost:3002/dev` (nécessite la [Twitch CLI](https://dev.twitch.tv/docs/cli) dans le PATH).

## Vérification

1. Ouvrir `/dev`, cliquer **Follow** → le nom (généré par la CLI, non vide) apparaît dans le Chat presenter **et** une carte cue arrive dans le fil.
2. Idem **Sub** / **Raid**.
3. Pas de régression sur les messages de chat normaux.

`pnpm exec tsc` : aucune erreur sur les fichiers touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)