### PR TITLE
fix(twitch): sync OAuth state across processes (dashboard stuck "non connecté")

### DIFF
--- a/__tests__/services/TwitchOAuthManager.test.ts
+++ b/__tests__/services/TwitchOAuthManager.test.ts
@@ -66,6 +66,10 @@ import { TwitchOAuthManager } from "@/lib/services/twitch/TwitchOAuthManager";
 
 const REFRESH_OWNER_ENV = "TWITCH_REFRESH_OWNER";
 
+// Captured before any test overwrites global.fetch, so afterEach can restore it
+// and avoid leaking a mock into other test files.
+const realFetch = global.fetch;
+
 function validTokens(overrides: Record<string, unknown> = {}) {
   return {
     accessToken: "access-abc",
@@ -103,6 +107,7 @@ describe("TwitchOAuthManager — dual-process robustness", () => {
       manager = null;
     }
     delete process.env[REFRESH_OWNER_ENV];
+    global.fetch = realFetch;
   });
 
   describe("Fix 1 — sole refresh owner", () => {
@@ -123,6 +128,24 @@ describe("TwitchOAuthManager — dual-process robustness", () => {
 
       expect(manager.isAuthenticated()).toBe(true);
       expect(manager.hasActiveRefreshTimer()).toBe(true);
+    });
+
+    it("a non-owner never calls Twitch's token endpoint on refreshToken()", async () => {
+      // No env → non-owner (Next.js). Even invoked directly (e.g. via expired-token
+      // init or getValidAccessToken), it must not hit Twitch and must not touch the
+      // shared tokens — otherwise it could rotate the single-use refresh token and
+      // trip the backend into wrongly clearing them.
+      mockTwitchState.tokens = validTokens();
+      manager = await freshManager();
+
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof fetch;
+
+      await manager.refreshToken();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockSaveTokens).not.toHaveBeenCalledWith(null);
+      expect(mockTwitchState.tokens).not.toBeNull();
     });
   });
 

--- a/__tests__/services/TwitchOAuthManager.test.ts
+++ b/__tests__/services/TwitchOAuthManager.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for TwitchOAuthManager — dual-process OAuth robustness.
+ *
+ * These encode the three fixes for the "admin says connected, dashboard says
+ * not connected" bug caused by two independent OAuthManager singletons (Next.js
+ * + Express backend) sharing one SQLite DB:
+ *
+ *  1. Sole refresh owner   — only the process flagged as owner (the backend)
+ *                            schedules the background token-refresh timer, so the
+ *                            two processes can't race on the single-use refresh
+ *                            token.
+ *  2. Non-destructive fail — a failed refresh must NOT wipe the shared DB tokens
+ *                            (which would log both processes out).
+ *  3. Self-heal recovery   — reloadFromDatabase() must restore "authorized" from
+ *                            ANY prior state (incl. "error"), so a stuck process
+ *                            recovers from valid tokens already in the DB.
+ */
+
+// --- Mocks -----------------------------------------------------------------
+
+jest.mock("@/lib/utils/Logger", () => ({
+  Logger: jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+const mockBroadcast = jest.fn();
+jest.mock("@/lib/services/WebSocketHub", () => ({
+  WebSocketHub: { getInstance: jest.fn(() => ({ broadcast: mockBroadcast })) },
+}));
+
+const mockCheckpoint = jest.fn();
+jest.mock("@/lib/services/DatabaseService", () => ({
+  DatabaseService: { getInstance: jest.fn(() => ({ checkpoint: mockCheckpoint })) },
+}));
+
+// Mutable fake DB state, controlled per test.
+const mockTwitchState: {
+  tokens: Record<string, unknown> | null;
+  clientId: string | undefined;
+  clientSecret: string | undefined;
+} = { tokens: null, clientId: "test-client-id", clientSecret: "test-secret" };
+
+const mockSaveTokens = jest.fn((tokens: Record<string, unknown> | null) => {
+  mockTwitchState.tokens = tokens;
+});
+
+jest.mock("@/lib/services/SettingsService", () => ({
+  SettingsService: {
+    getInstance: jest.fn(() => ({
+      getTwitchOAuthTokens: jest.fn(() => mockTwitchState.tokens),
+      saveTwitchOAuthTokens: mockSaveTokens,
+      getTwitchSettings: jest.fn(() => ({ clientId: mockTwitchState.clientId, enabled: true, pollIntervalMs: 30000 })),
+      getTwitchClientSecret: jest.fn(() => mockTwitchState.clientSecret),
+      saveTwitchOAuthState: jest.fn(),
+    })),
+  },
+}));
+
+import { TwitchOAuthManager } from "@/lib/services/twitch/TwitchOAuthManager";
+
+// --- Helpers ---------------------------------------------------------------
+
+const REFRESH_OWNER_ENV = "TWITCH_REFRESH_OWNER";
+
+function validTokens(overrides: Record<string, unknown> = {}) {
+  return {
+    accessToken: "access-abc",
+    refreshToken: "refresh-xyz",
+    expiresAt: Date.now() + 60 * 60 * 1000, // +1h, not near expiry
+    scope: ["chat:read"],
+    user: { id: "1310603235", login: "la_scene_avolo", displayName: "la_scene_avolo" },
+    ...overrides,
+  };
+}
+
+/** Reset the singleton and construct a fresh manager with current mock state. */
+async function freshManager(): Promise<TwitchOAuthManager> {
+  (TwitchOAuthManager as unknown as { instance?: TwitchOAuthManager }).instance = undefined;
+  const manager = TwitchOAuthManager.getInstance();
+  await manager.ensureInitialized();
+  return manager;
+}
+
+describe("TwitchOAuthManager — dual-process robustness", () => {
+  let manager: TwitchOAuthManager | null = null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTwitchState.tokens = null;
+    mockTwitchState.clientId = "test-client-id";
+    mockTwitchState.clientSecret = "test-secret";
+    delete process.env[REFRESH_OWNER_ENV];
+  });
+
+  afterEach(() => {
+    // Clean up any real interval created by startRefreshTimer.
+    if (manager) {
+      (manager as unknown as { stopRefreshTimer: () => void }).stopRefreshTimer();
+      manager = null;
+    }
+    delete process.env[REFRESH_OWNER_ENV];
+  });
+
+  describe("Fix 1 — sole refresh owner", () => {
+    it("does NOT schedule a refresh timer when not the owner (e.g. Next.js process)", async () => {
+      mockTwitchState.tokens = validTokens();
+      manager = await freshManager();
+
+      // Tokens are valid → it should still report authenticated...
+      expect(manager.isAuthenticated()).toBe(true);
+      // ...but as a non-owner it must NOT run the background refresh timer.
+      expect(manager.hasActiveRefreshTimer()).toBe(false);
+    });
+
+    it("schedules a refresh timer when flagged as the owner (the backend)", async () => {
+      process.env[REFRESH_OWNER_ENV] = "1";
+      mockTwitchState.tokens = validTokens();
+      manager = await freshManager();
+
+      expect(manager.isAuthenticated()).toBe(true);
+      expect(manager.hasActiveRefreshTimer()).toBe(true);
+    });
+  });
+
+  describe("Fix 2 — refresh failure token handling", () => {
+    it("keeps the stored tokens on a TRANSIENT failure (network/5xx)", async () => {
+      process.env[REFRESH_OWNER_ENV] = "1";
+      mockTwitchState.tokens = validTokens();
+      manager = await freshManager();
+
+      // A network-level rejection is transient — tokens must be preserved so the
+      // next retry can succeed (and so we never log out the other process).
+      global.fetch = jest.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+      await manager.refreshToken();
+
+      expect(mockSaveTokens).not.toHaveBeenCalledWith(null);
+      expect(mockTwitchState.tokens).not.toBeNull();
+    });
+
+    it("clears the stored tokens on a PERMANENT failure (400/401 invalid refresh token)", async () => {
+      process.env[REFRESH_OWNER_ENV] = "1";
+      mockTwitchState.tokens = validTokens();
+      manager = await freshManager();
+
+      // 400 invalid_grant means the refresh token is dead — only re-OAuth fixes it.
+      // Clearing stops the auth-watch from retrying a dead token forever.
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => "invalid_grant",
+      }) as unknown as typeof fetch;
+
+      await manager.refreshToken();
+
+      expect(mockSaveTokens).toHaveBeenCalledWith(null);
+      expect(mockTwitchState.tokens).toBeNull();
+    });
+  });
+
+  describe("Fix 3 — self-heal recovery from a stuck 'error' state", () => {
+    it("restores 'authorized' on reloadFromDatabase when valid tokens exist in the DB", async () => {
+      mockTwitchState.tokens = validTokens();
+      manager = await freshManager();
+      expect(manager.isAuthenticated()).toBe(true);
+
+      // Simulate the process having fallen into the terminal "error" state
+      // (e.g. a transient init/refresh failure). The DB still has valid tokens.
+      (manager as unknown as { status: Record<string, unknown> }).status = {
+        state: "error",
+        user: null,
+        expiresAt: null,
+        scopes: null,
+        error: { type: "api_error", message: "boom", timestamp: 1, recoverable: true },
+      };
+      expect(manager.isAuthenticated()).toBe(false);
+
+      await manager.reloadFromDatabase();
+
+      // Must recover — error → authorized is otherwise blocked by the state machine.
+      expect(manager.getStatus().state).toBe("authorized");
+      expect(manager.isAuthenticated()).toBe(true);
+    });
+  });
+});

--- a/app/api/settings/twitch/route.ts
+++ b/app/api/settings/twitch/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { SettingsService } from "@/lib/services/SettingsService";
 import { TwitchOAuthManager } from "@/lib/services/twitch/TwitchOAuthManager";
 import { SaveTwitchCredentialsSchema } from "@/lib/models/TwitchAuth";
@@ -18,6 +18,11 @@ export const GET = withSimpleErrorHandler(async () => {
   const settings = settingsService.getTwitchSettings();
   const clientSecret = settingsService.getTwitchClientSecret();
   const authStatus = oauthManager.getStatus();
+  // Time-sensitive token fields come from the DB (the shared source of truth the
+  // backend keeps fresh). This Next.js process does not own the refresh timer,
+  // so its in-memory expiry/scopes/user can drift — fall back to them only if the
+  // DB has no token row.
+  const tokens = settingsService.getTwitchOAuthTokens();
 
   return ApiResponses.ok({
     // Credentials (secret masked)
@@ -32,9 +37,9 @@ export const GET = withSimpleErrorHandler(async () => {
     // Auth status
     authStatus: {
       state: authStatus.state,
-      user: authStatus.user,
-      expiresAt: authStatus.expiresAt,
-      scopes: authStatus.scopes,
+      user: tokens?.user ?? authStatus.user,
+      expiresAt: tokens?.expiresAt ?? authStatus.expiresAt,
+      scopes: tokens?.scope ?? authStatus.scopes,
       error: authStatus.error,
     },
 

--- a/lib/config/Constants.ts
+++ b/lib/config/Constants.ts
@@ -448,7 +448,25 @@ export const TWITCH = {
    * @see lib/services/TwitchService.ts
    */
   TOKEN_REFRESH_BUFFER_MS: 300000,
+
+  /**
+   * Interval for the backend "auth watch" self-heal loop (30 seconds).
+   * While unauthenticated, the backend periodically reloads OAuth tokens from
+   * the DB so it recovers tokens written by another process (e.g. the Next.js
+   * OAuth callback) without needing a restart.
+   * @see lib/services/TwitchService.ts
+   */
+  AUTH_WATCH_INTERVAL_MS: 30000,
 } as const;
+
+/**
+ * Env var name flagging the single process that owns the Twitch token-refresh
+ * timer. Set to "1" in the Express backend only. Twitch rotates (single-use)
+ * refresh tokens, so two processes refreshing the same token would race and
+ * invalidate each other — only the owner runs the background refresh.
+ * @see lib/services/twitch/TwitchOAuthManager.ts · server/backend.ts
+ */
+export const TWITCH_REFRESH_OWNER_ENV = "TWITCH_REFRESH_OWNER";
 
 // ============================================================================
 // MEDIA PLAYER CONSTANTS

--- a/lib/services/TwitchService.ts
+++ b/lib/services/TwitchService.ts
@@ -45,6 +45,7 @@ export class TwitchService {
   private lastPollTime: number | null = null;
   private isPolling = false;
   private broadcasterId: string | null = null;
+  private authWatch: NodeJS.Timeout | null = null;
 
   private constructor() {
     this.logger = new Logger("TwitchService");
@@ -119,6 +120,48 @@ export class TwitchService {
       this.pollInterval = null;
       this.isPolling = false;
       this.logger.info("Stopped Twitch polling");
+    }
+  }
+
+  // ==========================================================================
+  // AUTH-WATCH (self-heal)
+  // ==========================================================================
+
+  /**
+   * Start a self-heal loop that keeps the in-memory OAuth state in sync with the
+   * shared DB. While unauthenticated, it reloads tokens from the DB (forcing a
+   * WAL checkpoint) so the backend recovers tokens written by another process
+   * (e.g. the Next.js OAuth callback) without needing a restart. Once
+   * authenticated each tick is a cheap no-op.
+   */
+  startAuthWatch(intervalMs: number = TWITCH.AUTH_WATCH_INTERVAL_MS): void {
+    if (this.authWatch) return;
+    this.authWatch = setInterval(() => {
+      void this.runAuthWatchTick();
+    }, intervalMs);
+    this.logger.info("Started Twitch auth-watch self-heal loop", { intervalMs });
+  }
+
+  /**
+   * Stop the auth-watch self-heal loop.
+   */
+  stopAuthWatch(): void {
+    if (this.authWatch) {
+      clearInterval(this.authWatch);
+      this.authWatch = null;
+      this.logger.debug("Stopped Twitch auth-watch loop");
+    }
+  }
+
+  private async runAuthWatchTick(): Promise<void> {
+    if (this.isAvailable()) return; // already authenticated → nothing to do
+    try {
+      await this.reloadOAuth(); // checkpoint + reinit; starts polling if now authed
+      if (this.isAvailable()) {
+        this.logger.info("Twitch auth-watch recovered authentication from stored tokens");
+      }
+    } catch (error) {
+      this.logger.debug("Twitch auth-watch reload failed (will retry)", error);
     }
   }
 

--- a/lib/services/TwitchService.ts
+++ b/lib/services/TwitchService.ts
@@ -139,6 +139,8 @@ export class TwitchService {
     this.authWatch = setInterval(() => {
       void this.runAuthWatchTick();
     }, intervalMs);
+    // Best-effort self-heal; don't keep the process alive on its own.
+    this.authWatch.unref?.();
     this.logger.info("Started Twitch auth-watch self-heal loop", { intervalMs });
   }
 

--- a/lib/services/twitch/TwitchOAuthManager.ts
+++ b/lib/services/twitch/TwitchOAuthManager.ts
@@ -13,7 +13,7 @@ import { DatabaseService } from "../DatabaseService";
 import { SettingsService } from "../SettingsService";
 import { WebSocketHub } from "../WebSocketHub";
 import { generateCodeVerifier, generateCodeChallenge, generateState } from "../../utils/pkce";
-import { TWITCH } from "../../config/Constants";
+import { TWITCH, TWITCH_REFRESH_OWNER_ENV } from "../../config/Constants";
 import { APP_URL } from "../../config/urls";
 import {
   TwitchAuthStatus,
@@ -199,6 +199,24 @@ export class TwitchOAuthManager {
    */
   isAuthenticated(): boolean {
     return this.status.state === "authorized" && this.status.user !== null;
+  }
+
+  /**
+   * Whether this process currently owns (runs) the background refresh timer.
+   * Only the backend sets {@link TWITCH_REFRESH_OWNER_ENV}; the Next.js process
+   * never refreshes so the two can't race on the single-use refresh token.
+   * Read at call time so tests and late env setup are honored.
+   */
+  isBackgroundRefreshOwner(): boolean {
+    return process.env[TWITCH_REFRESH_OWNER_ENV] === "1";
+  }
+
+  /**
+   * Whether a background refresh timer is currently scheduled.
+   * Exposed for diagnostics and tests.
+   */
+  hasActiveRefreshTimer(): boolean {
+    return this.refreshTimer !== null;
   }
 
   /**
@@ -429,6 +447,15 @@ export class TwitchOAuthManager {
    * Start the background token refresh timer
    */
   private startRefreshTimer(): void {
+    // Only the owning process (the backend) drives token refresh. A non-owner
+    // (e.g. the Next.js process) must not schedule refreshes: both processes
+    // share one DB and Twitch rotates the refresh token on every use, so two
+    // timers would race and invalidate each other's token.
+    if (!this.isBackgroundRefreshOwner()) {
+      this.logger.debug("Not the refresh owner; skipping token refresh timer");
+      return;
+    }
+
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
     }
@@ -512,7 +539,14 @@ export class TwitchOAuthManager {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Token refresh failed: ${response.status} ${errorText}`);
+        // 400/401 mean the refresh token itself is invalid or revoked — a
+        // permanent failure only re-OAuth can fix. Other statuses (5xx) and
+        // network errors (which reject before reaching here) are transient.
+        const permanent = response.status === 400 || response.status === 401;
+        throw Object.assign(
+          new Error(`Token refresh failed: ${response.status} ${errorText}`),
+          { permanent }
+        );
       }
 
       const data = await response.json();
@@ -556,8 +590,19 @@ export class TwitchOAuthManager {
         error instanceof Error ? error.message : "Token refresh failed"
       );
 
-      // Clear tokens and disconnect
-      this.settingsService.saveTwitchOAuthTokens(null);
+      // Clear the stored tokens ONLY on a permanent failure (Twitch rejected the
+      // refresh token itself — 400/401). Then re-OAuth is genuinely required, and
+      // clearing stops the backend auth-watch from retrying a dead token forever.
+      // Transient failures (network, 5xx) keep the tokens: wiping them would log
+      // out BOTH processes (shared DB) over a blip, and the next timer/auth-watch
+      // tick will retry. The backend is the sole refresh owner, so a permanent
+      // rejection is real here, never a cross-process race.
+      const permanent = !!(
+        error && typeof error === "object" && (error as { permanent?: boolean }).permanent
+      );
+      if (permanent) {
+        this.settingsService.saveTwitchOAuthTokens(null);
+      }
       this.stopRefreshTimer();
     } finally {
       this.refreshInProgress = false;
@@ -726,7 +771,12 @@ export class TwitchOAuthManager {
     // Stop existing refresh timer
     this.stopRefreshTimer();
 
-    // Reset state
+    // Reset state. This is a forced reload, not a state-machine transition, so
+    // assign directly back to the disconnected baseline (bypassing the
+    // transition guard). Without this, a process stuck in "error" could never
+    // recover: error → authorized is rejected by VALID_AUTH_TRANSITIONS, so
+    // re-initialization from valid stored tokens would be silently dropped.
+    this.status = { ...DEFAULT_AUTH_STATUS };
     this.initialized = false;
     this.initializationPromise = null;
 

--- a/lib/services/twitch/TwitchOAuthManager.ts
+++ b/lib/services/twitch/TwitchOAuthManager.ts
@@ -447,6 +447,13 @@ export class TwitchOAuthManager {
    * Start the background token refresh timer
    */
   private startRefreshTimer(): void {
+    // Clear any existing timer first — even if we bail as a non-owner below — so
+    // a stale timer can't outlive an ownership change.
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+
     // Only the owning process (the backend) drives token refresh. A non-owner
     // (e.g. the Next.js process) must not schedule refreshes: both processes
     // share one DB and Twitch rotates the refresh token on every use, so two
@@ -456,13 +463,11 @@ export class TwitchOAuthManager {
       return;
     }
 
-    if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
-    }
-
     this.refreshTimer = setInterval(() => {
       this.checkAndRefreshToken();
     }, REFRESH_CHECK_INTERVAL_MS);
+    // Best-effort background work; don't keep the process alive on its own.
+    this.refreshTimer.unref?.();
 
     this.logger.debug("Started token refresh timer");
   }
@@ -503,6 +508,18 @@ export class TwitchOAuthManager {
    * Refresh the access token
    */
   async refreshToken(): Promise<void> {
+    // Only the owner performs refreshes. A non-owner (e.g. the Next.js process)
+    // must never hit Twitch's token endpoint — not via the background timer, nor
+    // via initializeFromStoredTokens() on an expired token, nor getValidAccessToken().
+    // The refresh token is single-use: a non-owner refresh could rotate it out
+    // from under the backend, making the backend's next refresh fail with 400 and
+    // wrongly clear the shared DB tokens. Non-owners instead pick up fresh tokens
+    // the backend wrote to the DB (via reloadFromDatabase()).
+    if (!this.isBackgroundRefreshOwner()) {
+      this.logger.debug("Not the refresh owner; skipping token refresh");
+      return;
+    }
+
     if (this.refreshInProgress) {
       this.logger.debug("Refresh already in progress, skipping");
       return;
@@ -583,6 +600,13 @@ export class TwitchOAuthManager {
       this.logger.info("Token refreshed successfully", {
         expiresIn: Math.round(newTokens.expires_in / 60) + " minutes",
       });
+
+      // Ensure the periodic refresh timer is running. Covers refreshing from the
+      // expired-token startup path (initializeFromStoredTokens), which otherwise
+      // returns without scheduling the timer.
+      if (!this.hasActiveRefreshTimer()) {
+        this.startRefreshTimer();
+      }
     } catch (error) {
       this.logger.error("Token refresh failed", error);
       this.createAndSetError(

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -42,6 +42,13 @@ import { createServerWithFallback } from "../lib/utils/CertificateManager";
 import { getPortConflictReport } from "../scripts/port-diagnostics.mjs";
 import { expressError } from "../lib/utils/apiError";
 import { MediaPlayerManager } from "../lib/services/MediaPlayerManager";
+import { TWITCH_REFRESH_OWNER_ENV } from "../lib/config/Constants";
+
+// This (the Express backend) is the single process that owns the Twitch OAuth
+// token-refresh timer. Set BEFORE any TwitchService.getInstance() so the
+// singleton constructs as the refresh owner. The Next.js process never sets
+// this, so the two can't race on Twitch's single-use refresh token.
+process.env[TWITCH_REFRESH_OWNER_ENV] = "1";
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -281,17 +288,26 @@ class BackendServer {
         this.logger.warn(`Streamerbot gateway connection failed (will retry): ${error instanceof Error ? error.message : error}`);
       }
 
-      // 5. Start Twitch integration polling
+      // 5. Start Twitch integration
       try {
         if (settingsService.isTwitchEnabled()) {
-          await this.twitchService.ensureInitialized();
-          this.twitchService.startPolling();
-          this.logger.info("✓ Twitch polling started");
+          // Reload from the DB with a WAL checkpoint so we pick up tokens written
+          // by the Next.js process (OAuth callback) even across a backend restart.
+          // reloadOAuth() starts polling if authentication succeeds.
+          await this.twitchService.reloadOAuth();
+          // Self-heal: if not yet authenticated, keep reloading from the DB so the
+          // backend recovers tokens later without a manual restart/reload.
+          this.twitchService.startAuthWatch();
+          this.logger.info(
+            this.twitchService.getProviderStatus().twitchApiAvailable
+              ? "✓ Twitch integration connected"
+              : "Twitch integration enabled (waiting for authentication)"
+          );
         } else {
           this.logger.info("Twitch integration disabled");
         }
       } catch (error) {
-        this.logger.warn("Twitch polling failed to start", error);
+        this.logger.warn("Twitch integration failed to start", error);
       }
 
       // 6. Start HTTP/HTTPS API server using centralized certificate manager


### PR DESCRIPTION
## Problème

Le panneau **Twitch du dashboard** affichait « Twitch non connecté » alors que la page **admin `/settings/twitch`** affichait « Connecté » (OAuth valide, renouvellement auto actif, permissions accordées).

## Cause racine

L'état OAuth Twitch est géré par **deux singletons indépendants dans deux processus** qui ne partagent que la base SQLite :

| Processus | Instance | Alimente |
|---|---|---|
| Next.js (:3000) | `TwitchOAuthManager` local | page admin `/settings/twitch` |
| Backend Express (:3002) | son propre `TwitchService` / `TwitchOAuthManager` | panneau dashboard, polling, chat, modération |

Le backend ne se re-synchronisait jamais après un redémarrage (fréquent avec `tsx watch` en dev, ou tout restart PM2 en prod) : il restait « non authentifié » alors que des tokens valides étaient en DB (`lastPollTime: null` → il n'avait jamais pollé). Diagnostic confirmé en direct : un `POST /api/twitch/auth/reload` rebasculait tout au vert.

Trois défauts aggravants :
1. **Course de refresh** : les deux processus lançaient chacun un timer de refresh sur le **refresh-token single-use** de Twitch ; le perdant échouait.
2. **Effacement destructif** : un échec de refresh faisait `saveTwitchOAuthTokens(null)`, déconnectant **les deux** processus → re-OAuth complet requis.
3. **Auto-guérison bloquée** : la transition `error → authorized` est interdite par la machine à états, donc un processus en `error` ne pouvait jamais se rétablir tout seul.

## Correctif (ciblé robuste)

- **Propriétaire unique du refresh** : seul le backend (env `TWITCH_REFRESH_OWNER=1`) lance le timer de refresh ; le process Next.js ne refresh plus → plus de course.
- **Auto-guérison** : `reloadFromDatabase()` réinitialise l'état mémoire à `disconnected` avant la ré-init (contourne le guard `error → authorized`). Le backend lance un **auth-watch** périodique qui recharge depuis la DB tant qu'il n'est pas authentifié, et utilise `reloadOAuth()` (checkpoint WAL) au démarrage pour voir les tokens écrits par l'autre process.
- **Échec de refresh non destructif** : les tokens ne sont effacés **que** sur un échec **permanent** (400/401 = refresh token mort → re-OAuth nécessaire) ; les échecs **transitoires** (réseau / 5xx) conservent les tokens et réessaient.
- **Cohérence admin** : la route settings source les champs sensibles au temps (expiry/scopes/user) depuis la DB, pour ne pas dériver maintenant que Next.js ne refresh plus.

## Tests

`__tests__/services/TwitchOAuthManager.test.ts` (5 tests, écrits en TDD — rouges avant, verts après) :
- propriétaire unique du timer (owner vs non-owner) ;
- échec transitoire → tokens conservés ;
- échec permanent 400 → tokens effacés (casse la boucle de retry) ;
- récupération depuis l'état `error` via `reloadFromDatabase()`.

## Vérifié en direct

Après reload du code par `tsx watch`, le backend s'**auto-authentifie au démarrage** (provider `twitch-api`, polling actif) sans intervention manuelle, et les deux interfaces concordent (`isConnected=true` / `twitchApiAvailable=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
