### PR TITLE
feat(live-assist): clear all suggestions + "tout masquer" topbar button

### DIFF
--- a/__tests__/api/live-assist.backend.test.ts
+++ b/__tests__/api/live-assist.backend.test.ts
@@ -27,6 +27,19 @@ describe("live-assist backend router", () => {
     expect(res.status).toBe(400);
   });
 
+  it("clears all suggestions", async () => {
+    const clear = jest.fn();
+    const store = { list: () => [], setStatus: () => undefined, clear } as any;
+    const app = express()
+      .use(express.json())
+      .use(createLiveAssistRouter({ orchestrator: { getStatus: () => ({}) } as any, store, registry: { get: () => undefined } as any }));
+
+    const res = await request(app).post("/api/live-assist/suggestions/clear");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
   describe("authoritative apply", () => {
     const buildApp = (suggestion: any, apply: jest.Mock, registryGet = jest.fn()) => {
       const setStatus = jest.fn();

--- a/__tests__/api/live-assist.proxy.test.ts
+++ b/__tests__/api/live-assist.proxy.test.ts
@@ -15,14 +15,24 @@ describe("live-assist proxy", () => {
 
   it("proxies the clear POST to the backend", async () => {
     const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } }),
     );
     const res = await clearSuggestions(new Request("http://x/api/live-assist/suggestions/clear", { method: "POST" }));
     expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining("/api/live-assist/suggestions/clear"),
-      { method: "POST" },
+      expect.objectContaining({ method: "POST" }),
     );
+    fetchSpy.mockRestore();
+  });
+
+  it("forwards a backend error status instead of collapsing it to 422", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "boom" }), { status: 503, headers: { "content-type": "application/json" } }),
+    );
+    const res = await clearSuggestions(new Request("http://x/api/live-assist/suggestions/clear", { method: "POST" }));
+    expect(res.status).toBe(503);
     fetchSpy.mockRestore();
   });
 });

--- a/__tests__/api/live-assist.proxy.test.ts
+++ b/__tests__/api/live-assist.proxy.test.ts
@@ -1,5 +1,6 @@
 // __tests__/api/live-assist.proxy.test.ts
 import { GET as getSuggestions } from "@/app/api/live-assist/suggestions/route";
+import { POST as clearSuggestions } from "@/app/api/live-assist/suggestions/clear/route";
 
 describe("live-assist proxy", () => {
   it("proxies suggestions list from the backend", async () => {
@@ -9,6 +10,19 @@ describe("live-assist proxy", () => {
     const res = await getSuggestions(new Request("http://x/api/live-assist/suggestions"), { params: Promise.resolve({}) } as any);
     const body = await res.json();
     expect(body.suggestions).toHaveLength(1);
+    fetchSpy.mockRestore();
+  });
+
+  it("proxies the clear POST to the backend", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    const res = await clearSuggestions(new Request("http://x/api/live-assist/suggestions/clear", { method: "POST" }));
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/live-assist/suggestions/clear"),
+      { method: "POST" },
+    );
     fetchSpy.mockRestore();
   });
 });

--- a/__tests__/services/liveassist/SuggestionStore.test.ts
+++ b/__tests__/services/liveassist/SuggestionStore.test.ts
@@ -56,4 +56,15 @@ describe("SuggestionStore", () => {
     copy.push({} as never);
     expect(store.list()).toHaveLength(1);
   });
+
+  it("clear() empties the store and publishes suggestions:cleared", () => {
+    const events: any[] = [];
+    let n = 0;
+    const store = new SuggestionStore((e) => events.push(e), { now: () => 1, makeId: () => `id${n++}` });
+    store.add(built("A"));
+    store.add(built("B"));
+    store.clear();
+    expect(store.list()).toHaveLength(0);
+    expect(events.at(-1)).toEqual({ type: "suggestions:cleared", payload: {} });
+  });
 });

--- a/app/api/live-assist/suggestions/clear/route.ts
+++ b/app/api/live-assist/suggestions/clear/route.ts
@@ -1,0 +1,8 @@
+import { withSimpleErrorHandler, ApiResponses } from "@/lib/utils/ApiResponses";
+import { BACKEND_URL } from "@/lib/config/urls";
+
+export const POST = withSimpleErrorHandler(async () => {
+  const r = await fetch(`${BACKEND_URL}/api/live-assist/suggestions/clear`, { method: "POST" });
+  if (!r.ok) return ApiResponses.unprocessable("clear failed");
+  return ApiResponses.ok({ ok: true });
+}, "[LiveAssistProxy]");

--- a/app/api/live-assist/suggestions/clear/route.ts
+++ b/app/api/live-assist/suggestions/clear/route.ts
@@ -1,8 +1,17 @@
-import { withSimpleErrorHandler, ApiResponses } from "@/lib/utils/ApiResponses";
-import { BACKEND_URL } from "@/lib/config/urls";
+import { withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+import { proxyToBackend } from "@/lib/utils/ProxyHelper";
 
-export const POST = withSimpleErrorHandler(async () => {
-  const r = await fetch(`${BACKEND_URL}/api/live-assist/suggestions/clear`, { method: "POST" });
-  if (!r.ok) return ApiResponses.unprocessable("clear failed");
-  return ApiResponses.ok({ ok: true });
-}, "[LiveAssistProxy]");
+const LOG_CONTEXT = "[LiveAssistProxy]";
+
+// Forward the backend's real status/payload (proxyToBackend) instead of collapsing
+// every non-2xx into a 422 — a 500/503 from the backend must not look like a 422.
+export const POST = withSimpleErrorHandler(
+  async () =>
+    proxyToBackend("/api/live-assist/suggestions/clear", {
+      method: "POST",
+      body: {},
+      errorMessage: "Failed to clear suggestions",
+      logPrefix: LOG_CONTEXT,
+    }),
+  LOG_CONTEXT,
+);

--- a/components/dashboard/panels/LiveAssistPanel.tsx
+++ b/components/dashboard/panels/LiveAssistPanel.tsx
@@ -58,10 +58,13 @@ export function LiveAssistPanel(_props: IDockviewPanelProps) {
     );
   }, []);
   const onClearAll = useCallback(() => {
-    apiPost("/api/live-assist/suggestions/clear", {}).catch((e) =>
-      toast.error(extractErrorMessage(e, t("clearFailed"))),
-    );
-  }, [t]);
+    // Empty locally as soon as the server confirms, so the operator isn't left
+    // staring at stale cards if the WS round-trip is slow/down. The broadcast
+    // `suggestions:cleared` event still arrives to sync the other dashboards.
+    apiPost("/api/live-assist/suggestions/clear", {})
+      .then(() => clearAll())
+      .catch((e) => toast.error(extractErrorMessage(e, t("clearFailed"))));
+  }, [clearAll, t]);
 
   return (
     <BasePanelWrapper config={config}>

--- a/components/dashboard/panels/LiveAssistPanel.tsx
+++ b/components/dashboard/panels/LiveAssistPanel.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { useCallback, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { type IDockviewPanelProps } from "dockview-react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { BasePanelWrapper, type PanelConfig } from "@/components/panels";
 import { useWebSocketChannel } from "@/hooks/useWebSocketChannel";
 import { toast } from "sonner";
@@ -14,7 +17,8 @@ import type { LiveAssistEvent, Suggestion } from "@/lib/models/LiveAssist";
 const config: PanelConfig = { id: "liveAssist", context: "dashboard" };
 
 export function LiveAssistPanel(_props: IDockviewPanelProps) {
-  const { suggestions, transcripts, setAll, upsert, updateStatus, setStatusBar, addTranscript } =
+  const t = useTranslations("dashboard.liveAssist");
+  const { suggestions, transcripts, setAll, upsert, updateStatus, clearAll, setStatusBar, addTranscript } =
     useLiveAssistStore();
 
   useEffect(() => {
@@ -33,10 +37,11 @@ export function LiveAssistPanel(_props: IDockviewPanelProps) {
     (e: LiveAssistEvent) => {
       if (e.type === "suggestion:new") upsert(e.payload.suggestion);
       else if (e.type === "suggestion:update") updateStatus(e.payload.id, e.payload.status);
+      else if (e.type === "suggestions:cleared") clearAll();
       else if (e.type === "stt:status") setStatusBar(e.payload.connected, e.payload.device);
       else if (e.type === "transcript") addTranscript(e.payload.text);
     },
-    [upsert, updateStatus, setStatusBar, addTranscript],
+    [upsert, updateStatus, clearAll, setStatusBar, addTranscript],
   );
   useWebSocketChannel<LiveAssistEvent>("live-assist", handleEvent, { logPrefix: "LiveAssistPanel" });
 
@@ -52,6 +57,11 @@ export function LiveAssistPanel(_props: IDockviewPanelProps) {
       toast.error(extractErrorMessage(e, "Échec du rejet de la suggestion")),
     );
   }, []);
+  const onClearAll = useCallback(() => {
+    apiPost("/api/live-assist/suggestions/clear", {}).catch((e) =>
+      toast.error(extractErrorMessage(e, t("clearFailed"))),
+    );
+  }, [t]);
 
   return (
     <BasePanelWrapper config={config}>
@@ -59,7 +69,20 @@ export function LiveAssistPanel(_props: IDockviewPanelProps) {
         {/* Header: STT status (left) + quick listening/transcript kill switches (right). */}
         <div className="flex items-center justify-between gap-2 px-3 py-2 border-b">
           <SttStatusBar />
-          <LiveAssistControls />
+          <div className="flex items-center gap-2">
+            <LiveAssistControls />
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 gap-1.5 px-2 text-xs"
+              onClick={onClearAll}
+              disabled={suggestions.length === 0}
+              title={t("clearAll")}
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+              {t("clearAll")}
+            </Button>
+          </div>
         </div>
         <div className="flex flex-col gap-2 p-3 overflow-auto flex-1">
           {suggestions.map((s) => (

--- a/components/shell/ContentTopBar.tsx
+++ b/components/shell/ContentTopBar.tsx
@@ -9,7 +9,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Maximize, Minimize, Loader2, Check, MonitorOff, FolderOpen } from "lucide-react";
+import { Maximize, Minimize, Loader2, Check, MonitorOff, FolderOpen, EyeOff } from "lucide-react";
+import { toast } from "sonner";
+import { apiPost, extractErrorMessage } from "@/lib/utils/ClientFetch";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { AiChatButton } from "@/components/ai-chat/AiChatButton";
 import { useAppMode } from "@/components/shell/AppModeContext";
@@ -108,6 +110,21 @@ export function ContentTopBar() {
 
       {/* AI Chat */}
       <AiChatButton />
+
+      {/* Hide all on-air overlays at once (panic). One click, no confirmation. */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() =>
+          apiPost("/api/actions/panic", {}).catch((e) =>
+            toast.error(extractErrorMessage(e, t("hideAllFailed"))),
+          )
+        }
+        title={t("hideAll")}
+        className="h-8 w-8 p-0"
+      >
+        <EyeOff className="w-4 h-4" />
+      </Button>
 
       {/* Fullscreen Toggle */}
       <Button

--- a/components/shell/ContentTopBar.tsx
+++ b/components/shell/ContentTopBar.tsx
@@ -121,6 +121,7 @@ export function ContentTopBar() {
           )
         }
         title={t("hideAll")}
+        aria-label={t("hideAll")}
         className="h-8 w-8 p-0"
       >
         <EyeOff className="w-4 h-4" />

--- a/lib/models/LiveAssist.ts
+++ b/lib/models/LiveAssist.ts
@@ -90,5 +90,6 @@ export function migrateLiveAssistSettings(s: LiveAssistSettings): LiveAssistSett
 export type LiveAssistEvent =
   | { type: "suggestion:new"; payload: { suggestion: Suggestion } }
   | { type: "suggestion:update"; payload: { id: string; status: Suggestion["status"] } }
+  | { type: "suggestions:cleared"; payload: Record<string, never> }
   | { type: "stt:status"; payload: { connected: boolean; device: string | null } }
   | { type: "transcript"; payload: { text: string; t0: number; t1: number } };

--- a/lib/services/liveassist/SuggestionStore.ts
+++ b/lib/services/liveassist/SuggestionStore.ts
@@ -54,4 +54,10 @@ export class SuggestionStore {
     this.publish({ type: "suggestion:update", payload: { id, status } });
     return s;
   }
+
+  /** Drop every stored suggestion (panic "vider"). Broadcast so all dashboards empty in sync. */
+  clear(): void {
+    this.items.length = 0;
+    this.publish({ type: "suggestions:cleared", payload: {} });
+  }
 }

--- a/lib/stores/liveAssistStore.ts
+++ b/lib/stores/liveAssistStore.ts
@@ -19,6 +19,7 @@ interface LiveAssistState {
   setAll: (s: Suggestion[]) => void;
   upsert: (s: Suggestion) => void;
   updateStatus: (id: string, status: Suggestion["status"]) => void;
+  clearAll: () => void;
   setStatusBar: (connected: boolean, device: string | null) => void;
   addTranscript: (text: string) => void;
 }
@@ -35,6 +36,7 @@ export const useLiveAssistStore = create<LiveAssistState>((set) => ({
     })),
   updateStatus: (id, status) =>
     set((st) => ({ suggestions: st.suggestions.map((x) => (x.id === id ? { ...x, status } : x)) })),
+  clearAll: () => set({ suggestions: [] }),
   setStatusBar: (connected, device) => set({ status: { connected, device } }),
   addTranscript: (text) =>
     set((st) => {

--- a/messages/en.json
+++ b/messages/en.json
@@ -32,6 +32,8 @@
       "noProfile": "No Profile",
       "fullscreen": "Fullscreen",
       "exitFullscreen": "Exit Fullscreen",
+      "hideAll": "Hide all",
+      "hideAllFailed": "Failed to hide overlays",
       "switchToAdmin": "Switch to ADMIN Mode",
       "switchToLive": "Switch to LIVE Mode",
       "onAirDialogTitle": "You are currently ON AIR",
@@ -426,7 +428,9 @@
       "disconnected": "STT disconnected",
       "listening": "Listening",
       "transcript": "Transcript",
-      "toggleFailed": "Failed to update Live Assist"
+      "toggleFailed": "Failed to update Live Assist",
+      "clearAll": "Clear",
+      "clearFailed": "Failed to clear suggestions"
     }
   },
   "navigation": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -32,6 +32,8 @@
       "noProfile": "Aucun profil",
       "fullscreen": "Plein écran",
       "exitFullscreen": "Quitter le plein écran",
+      "hideAll": "Tout masquer",
+      "hideAllFailed": "Échec du masquage des overlays",
       "switchToAdmin": "Passer en mode ADMIN",
       "switchToLive": "Passer en mode LIVE",
       "onAirDialogTitle": "Vous êtes actuellement ON AIR",
@@ -426,7 +428,9 @@
       "disconnected": "STT déconnecté",
       "listening": "Écoute",
       "transcript": "Transcript",
-      "toggleFailed": "Échec de la mise à jour de l'Assistant Live"
+      "toggleFailed": "Échec de la mise à jour de l'Assistant Live",
+      "clearAll": "Vider",
+      "clearFailed": "Échec du vidage des suggestions"
     }
   },
   "navigation": {

--- a/server/api/live-assist.ts
+++ b/server/api/live-assist.ts
@@ -19,6 +19,7 @@ interface RouterDeps {
     list: () => unknown[];
     get: (id: string) => { intent: string; applyPayload: Record<string, unknown> } | undefined;
     setStatus: (id: string, status: "applied" | "dismissed") => unknown;
+    clear: () => void;
   };
   registry: { get: (id: string) => { apply: (p: Record<string, unknown>) => Promise<ApplyResult> } | undefined };
 }
@@ -55,6 +56,13 @@ export function createLiveAssistRouter(deps: RouterDeps): Router {
 
   router.get("/api/live-assist/suggestions", (_req, res) => {
     return res.json({ suggestions: deps.store.list(), sttStatus: deps.orchestrator.getStatus() });
+  });
+
+  // Declared before the `:id/...` routes: `/suggestions/clear` is a literal segment, so
+  // Express must not let `:id` swallow it. (Path depth already differs, but be explicit.)
+  router.post("/api/live-assist/suggestions/clear", (_req, res) => {
+    deps.store.clear();
+    return res.json({ ok: true });
   });
 
   router.post("/api/live-assist/suggestions/:id/apply", async (req, res) => {


### PR DESCRIPTION
## Quoi

Deux ajouts indépendants de confort opérateur, demandés pour le live.

### 1. Vider les suggestions Live Assist
Pendant un live, les cartes de suggestions s''accumulent ; il n''existait qu''un rejet carte-par-carte. Ce PR ajoute un **« Vider »** qui efface tout d''un coup.

- **Côté serveur** (source de vérité) : `SuggestionStore.clear()` vide le store et diffuse un nouvel event `suggestions:cleared` sur le canal WS `live-assist`. Tous les dashboards connectés se vident en synchro, et un rechargement de page reste vide.
- Route `POST /api/live-assist/suggestions/clear` (+ proxy Next), action `clearAll()` du store client, gestion de l''event, et un bouton **« Vider »** (icône poubelle) dans l''en-tête du panneau, désactivé quand la liste est vide.
- Suit exactement le pattern du « dismiss » unitaire existant (UI → proxy → route backend → store → broadcast WS → store client → re-render).

### 2. Bouton « Tout masquer » dans la barre du haut
Bouton `EyeOff` dans `ContentTopBar`, **1 clic, sans confirmation**, câblé à l''action **panic existante** (`/api/actions/panic` → `/api/overlays/clear-all`). Masque affiche (+ big picture), lower third / invité, compte à rebours (reset), chat highlight, title reveal et sommaire. **Aucune modif backend.**

## Réutilisation (DRY)
- Feature 1 : pattern dismiss existant (`ChannelManager.publishLiveAssist`, `apiPost`/`extractErrorMessage`, `ApiResponses`, proxy `[id]/dismiss`).
- Feature 2 : action panic existante, `apiPost`, `toast`, `useTranslations` déjà en place.

## Tests
- `SuggestionStore.test.ts` — `clear()` vide la liste et publie `suggestions:cleared`.
- `live-assist.backend.test.ts` — `POST /suggestions/clear` → 200 et appelle `store.clear()`.
- `live-assist.proxy.test.ts` — le proxy forwarde bien vers le backend.
- ✅ 15/15 sur les fichiers touchés ; type-check sans nouvelle erreur sur mes fichiers.

## Vérification manuelle restante
- Afficher poster + lower third → cliquer `EyeOff` → tout se masque.
- Avec des cartes dans le panneau Live Assist → « Vider » → panneau vide ; 2e onglet se vide aussi (WS) ; reload reste vide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)