### PR TITLE
feat(midi): POST /api/midi/cc — send a MIDI Control Change

### DIFF
--- a/__tests__/models/Midi.test.ts
+++ b/__tests__/models/Midi.test.ts
@@ -12,6 +12,9 @@ import {
   getActionOffsetMs,
   actionSupportsOffset,
   midiActionConfigSchema,
+  midiCcSendSchema,
+  MIDI_CC_CHANNEL,
+  MIDI_CC_EVENT,
   type MidiSettings,
 } from "../../lib/models/Midi";
 import { WordHarvestEventType } from "../../lib/models/WordHarvest";
@@ -124,6 +127,41 @@ describe("lookup helpers", () => {
   it("returns the configured action offset, 0 when unset", () => {
     expect(getActionOffsetMs(settings, "title-reveal.on")).toBe(-500);
     expect(getActionOffsetMs(settings, "missing")).toBe(0);
+  });
+});
+
+describe("midiCcSendSchema (direct CC send)", () => {
+  it("requires bus and note; defaults value/channel/duration", () => {
+    const p = midiCcSendSchema.parse({ bus: "qlc-in", note: 81 });
+    expect(p).toEqual({ bus: "qlc-in", note: 81, value: 127, channel: 1, duration: 0 });
+  });
+
+  it("keeps an explicit value and duration (seconds)", () => {
+    const p = midiCcSendSchema.parse({ bus: "qlc-in", note: 81, value: 64, duration: 2.5 });
+    expect(p).toMatchObject({ value: 64, duration: 2.5 });
+  });
+
+  it.each([
+    ["empty bus", { bus: "", note: 81 }],
+    ["missing bus", { note: 81 }],
+    ["missing note", { bus: "qlc-in" }],
+    ["note too high", { bus: "qlc-in", note: 128 }],
+    ["note negative", { bus: "qlc-in", note: -1 }],
+    ["value too high", { bus: "qlc-in", note: 81, value: 128 }],
+    ["channel 0", { bus: "qlc-in", note: 81, channel: 0 }],
+    ["channel 17", { bus: "qlc-in", note: 81, channel: 17 }],
+    ["negative duration", { bus: "qlc-in", note: 81, duration: -1 }],
+  ])("rejects %s", (_label, body) => {
+    expect(() => midiCcSendSchema.parse(body)).toThrow();
+  });
+
+  it("exposes the MIDI channel + event constants for the dispatcher", () => {
+    expect(MIDI_CC_CHANNEL).toBe("midi");
+    expect(MIDI_CC_EVENT).toBe("cc");
+  });
+
+  it("keeps the direct CC channel out of the action trigger channels", () => {
+    expect(MIDI_TRIGGER_CHANNELS).not.toContain(MIDI_CC_CHANNEL);
   });
 });
 

--- a/__tests__/models/Midi.test.ts
+++ b/__tests__/models/Midi.test.ts
@@ -151,6 +151,8 @@ describe("midiCcSendSchema (direct CC send)", () => {
     ["channel 0", { bus: "qlc-in", note: 81, channel: 0 }],
     ["channel 17", { bus: "qlc-in", note: 81, channel: 17 }],
     ["negative duration", { bus: "qlc-in", note: 81, duration: -1 }],
+    ["duration over cap", { bus: "qlc-in", note: 81, duration: 100000 }],
+    ["duration Infinity", { bus: "qlc-in", note: 81, duration: Infinity }],
   ])("rejects %s", (_label, body) => {
     expect(() => midiCcSendSchema.parse(body)).toThrow();
   });

--- a/__tests__/services/ChannelManager.midi.test.ts
+++ b/__tests__/services/ChannelManager.midi.test.ts
@@ -1,0 +1,62 @@
+import { ChannelManager } from "@/lib/services/ChannelManager";
+import { MIDI_CC_CHANNEL, MIDI_CC_EVENT, midiCcSendSchema } from "@/lib/models/Midi";
+
+// Mock Logger to avoid side effects
+jest.mock("@/lib/utils/Logger", () => ({
+  Logger: jest.fn().mockImplementation(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+// Mock crypto.randomUUID for predictable IDs
+const mockUUID = "mock-uuid-1234-5678-90ab-cdef12345678";
+jest.mock("crypto", () => ({
+  randomUUID: jest.fn(() => mockUUID),
+}));
+
+const mockBroadcast = jest.fn();
+const mockGetChannelSubscribers = jest.fn();
+
+jest.mock("@/lib/services/WebSocketHub", () => ({
+  WebSocketHub: {
+    getInstance: jest.fn(() => ({
+      broadcast: mockBroadcast,
+      getChannelSubscribers: mockGetChannelSubscribers,
+      setOnAckCallback: jest.fn(),
+      setOnClientDisconnectCallback: jest.fn(),
+      setOnSubscribeCallback: jest.fn(),
+      sendToClient: jest.fn(),
+    })),
+  },
+}));
+
+describe("ChannelManager.publishMidiCc", () => {
+  beforeAll(() => {
+    (ChannelManager as unknown as { instance: ChannelManager | undefined }).instance = undefined;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("broadcasts a 'cc' event on the midi channel, no ack", () => {
+    const cm = ChannelManager.getInstance();
+    const payload = midiCcSendSchema.parse({ bus: "qlc-in", note: 81, value: 127, duration: 2 });
+    cm.publishMidiCc(payload);
+
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+    expect(mockBroadcast).toHaveBeenCalledWith(
+      MIDI_CC_CHANNEL,
+      expect.objectContaining({
+        channel: MIDI_CC_CHANNEL,
+        type: MIDI_CC_EVENT,
+        payload,
+      })
+    );
+    // Passive subscriber: no ack timeout is set (no second broadcast / no system event).
+    expect(MIDI_CC_CHANNEL).toBe("midi");
+  });
+});

--- a/__tests__/services/ChannelManager.midi.test.ts
+++ b/__tests__/services/ChannelManager.midi.test.ts
@@ -42,11 +42,12 @@ describe("ChannelManager.publishMidiCc", () => {
     jest.clearAllMocks();
   });
 
-  it("broadcasts a 'cc' event on the midi channel, no ack", () => {
+  it("broadcasts a 'cc' event on the midi channel exactly once (passive, no ack)", () => {
     const cm = ChannelManager.getInstance();
     const payload = midiCcSendSchema.parse({ bus: "qlc-in", note: 81, value: 127, duration: 2 });
     cm.publishMidiCc(payload);
 
+    // Exactly one broadcast: no ack timeout / system follow-up like the overlay publish path.
     expect(mockBroadcast).toHaveBeenCalledTimes(1);
     expect(mockBroadcast).toHaveBeenCalledWith(
       MIDI_CC_CHANNEL,
@@ -56,7 +57,5 @@ describe("ChannelManager.publishMidiCc", () => {
         payload,
       })
     );
-    // Passive subscriber: no ack timeout is set (no second broadcast / no system event).
-    expect(MIDI_CC_CHANNEL).toBe("midi");
   });
 });

--- a/app/api/midi/cc/route.ts
+++ b/app/api/midi/cc/route.ts
@@ -1,0 +1,20 @@
+import { proxyToBackend } from "@/lib/utils/ProxyHelper";
+import { withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+
+const LOG_CONTEXT = "[MidiAPI:CC]";
+
+/**
+ * POST /api/midi/cc
+ * Proxy to the backend, which publishes the CC on the MIDI WebSocket channel for
+ * the dashboard dispatcher to emit via Web MIDI.
+ * Body: { bus, note, value?, channel?, duration? } (see midiCcSendSchema).
+ */
+export const POST = withSimpleErrorHandler(async (request: Request) => {
+  const body = await request.json();
+  return proxyToBackend("/api/midi/cc", {
+    method: "POST",
+    body,
+    errorMessage: "Failed to send MIDI CC",
+    logPrefix: LOG_CONTEXT,
+  });
+}, LOG_CONTEXT);

--- a/app/api/midi/cc/route.ts
+++ b/app/api/midi/cc/route.ts
@@ -1,5 +1,5 @@
 import { proxyToBackend } from "@/lib/utils/ProxyHelper";
-import { withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+import { ApiResponses, withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
 
 const LOG_CONTEXT = "[MidiAPI:CC]";
 
@@ -10,7 +10,12 @@ const LOG_CONTEXT = "[MidiAPI:CC]";
  * Body: { bus, note, value?, channel?, duration? } (see midiCcSendSchema).
  */
 export const POST = withSimpleErrorHandler(async (request: Request) => {
-  const body = await request.json();
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return ApiResponses.badRequest("Invalid JSON body");
+  }
   return proxyToBackend("/api/midi/cc", {
     method: "POST",
     body,

--- a/hooks/useMidi.ts
+++ b/hooks/useMidi.ts
@@ -55,14 +55,20 @@ export function useMidi() {
     const access = midiAccessRef.current;
     if (!access) return;
 
-    // Find output by name, or fall back to first available
     let output: MIDIOutput | undefined;
     if (outputName) {
+      // Named output: send only to that exact port. If it isn't connected, skip
+      // rather than fall back to the first available output (which would mis-send
+      // to the wrong device — e.g. a typo'd or momentarily disconnected port).
       access.outputs.forEach((o) => {
         if (o.name === outputName) output = o;
       });
-    }
-    if (!output) {
+      if (!output) {
+        console.warn(`[useMidi] MIDI output "${outputName}" not found; skipping send.`);
+        return;
+      }
+    } else {
+      // "" = explicit "first available output" convention.
       const first = access.outputs.values().next();
       if (!first.done) output = first.value;
     }

--- a/hooks/useMidi.ts
+++ b/hooks/useMidi.ts
@@ -79,7 +79,13 @@ export function useMidi() {
     const cc = params.cc & 0x7f;
     const val = params.value & 0x7f;
 
-    output.send([statusByte, cc, val]);
+    try {
+      output.send([statusByte, cc, val]);
+    } catch (err) {
+      // A found-but-not-open port throws InvalidStateError. Don't let it bubble
+      // (it would abort the caller's loop / surface as a misleading WS parse error).
+      console.warn(`[useMidi] Failed to send CC to "${outputName || "first output"}":`, err);
+    }
   }, []);
 
   return { available, outputs, sendCC };

--- a/hooks/useMidiDispatcher.ts
+++ b/hooks/useMidiDispatcher.ts
@@ -5,6 +5,8 @@ import { useMidi } from "./useMidi";
 import { useWebSocketChannel } from "./useWebSocketChannel";
 import {
   MIDI_TRIGGER_CHANNELS,
+  MIDI_CC_CHANNEL,
+  MIDI_CC_EVENT,
   WH_EVENT_TO_ACTION,
   DEFAULT_MIDI_SETTINGS,
   DEFAULT_TITLE_REVEAL_DURATION,
@@ -12,6 +14,7 @@ import {
   getActionOffsetMs,
   getPortForApp,
   type MidiSettings,
+  type MidiCcSend,
 } from "@/lib/models/Midi";
 import { TitleRevealEventType } from "@/lib/models/OverlayEvents";
 import type { WordHarvestEventType } from "@/lib/models/WordHarvest";
@@ -33,12 +36,17 @@ interface DispatchedEvent {
  * duration WITHOUT emitting a `hide` event, so the OFF is timed from the play
  * payload's duration. A manual `hide` fires the OFF immediately and cancels the
  * timer; the OFF fires at most once per ON.
+ *
+ * It also serves direct CC sends (POST /api/midi/cc): a one-shot CC to a named
+ * port, optionally re-sent once after `duration` seconds.
  */
 export function useMidiDispatcher(): void {
-  const { sendCC } = useMidi();
+  const { sendCC, outputs } = useMidi();
   const settingsRef = useRef<MidiSettings>(DEFAULT_MIDI_SETTINGS);
   const offTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const offPendingRef = useRef(false);
+  // Pending "second send" timers for direct CC sends with a duration.
+  const repeatTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
 
   // Load the centralized MIDI config, and re-load when the tab regains focus so
   // edits saved from the settings page (possibly in another tab) take effect
@@ -118,15 +126,48 @@ export function useMidiDispatcher(): void {
       if (channel === "word-harvest") {
         const actionId = WH_EVENT_TO_ACTION[data?.type as WordHarvestEventType];
         if (actionId) fire(actionId);
+        return;
+      }
+
+      if (channel === MIDI_CC_CHANNEL) {
+        if (data?.type !== MIDI_CC_EVENT) return;
+        const p = data.payload as MidiCcSend | undefined;
+        if (!p?.bus) return;
+        // `bus` is the MIDI output port name (e.g. "qlc-in"); `note` is the CC.
+        // Unknown bus → skip rather than mis-send to the first available output
+        // (sendCC falls back to it). Mirrors the fire() guard above.
+        if (!outputs.includes(p.bus)) {
+          console.warn(`[MidiDispatcher] Unknown MIDI bus "${p.bus}"; available:`, outputs);
+          return;
+        }
+        const send = () =>
+          sendCC(p.bus, { channel: p.channel, cc: p.note, value: p.value });
+        send();
+        if (p.duration > 0) {
+          const t = setTimeout(() => {
+            repeatTimersRef.current.delete(t);
+            send();
+          }, p.duration * 1000);
+          repeatTimersRef.current.add(t);
+        }
       }
     },
-    [fire, fireOffOnce, clearOffTimer]
+    [fire, fireOffOnce, clearOffTimer, sendCC, outputs]
   );
 
-  useWebSocketChannel<DispatchedEvent>(MIDI_TRIGGER_CHANNELS, handleMessage, {
-    logPrefix: "MidiDispatcher",
-  });
+  useWebSocketChannel<DispatchedEvent>(
+    [...MIDI_TRIGGER_CHANNELS, MIDI_CC_CHANNEL],
+    handleMessage,
+    { logPrefix: "MidiDispatcher" }
+  );
 
-  // Clean up a pending OFF timer on unmount.
-  useEffect(() => clearOffTimer, [clearOffTimer]);
+  // Clean up pending timers (OFF + direct-CC re-sends) on unmount.
+  useEffect(() => {
+    const repeatTimers = repeatTimersRef.current;
+    return () => {
+      clearOffTimer();
+      repeatTimers.forEach(clearTimeout);
+      repeatTimers.clear();
+    };
+  }, [clearOffTimer]);
 }

--- a/hooks/useMidiDispatcher.ts
+++ b/hooks/useMidiDispatcher.ts
@@ -13,8 +13,8 @@ import {
   getMessagesForAction,
   getActionOffsetMs,
   getPortForApp,
+  midiCcSendSchema,
   type MidiSettings,
-  type MidiCcSend,
 } from "@/lib/models/Midi";
 import { TitleRevealEventType } from "@/lib/models/OverlayEvents";
 import type { WordHarvestEventType } from "@/lib/models/WordHarvest";
@@ -41,7 +41,7 @@ interface DispatchedEvent {
  * port, optionally re-sent once after `duration` seconds.
  */
 export function useMidiDispatcher(): void {
-  const { sendCC, outputs } = useMidi();
+  const { sendCC } = useMidi();
   const settingsRef = useRef<MidiSettings>(DEFAULT_MIDI_SETTINGS);
   const offTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const offPendingRef = useRef(false);
@@ -131,15 +131,14 @@ export function useMidiDispatcher(): void {
 
       if (channel === MIDI_CC_CHANNEL) {
         if (data?.type !== MIDI_CC_EVENT) return;
-        const p = data.payload as MidiCcSend | undefined;
-        if (!p?.bus) return;
+        // Re-validate the WS payload here (not just at the POST route) so
+        // malformed traffic on this channel can't drive Web MIDI. Also applies
+        // the schema defaults (value/channel/duration).
+        const parsed = midiCcSendSchema.safeParse(data.payload);
+        if (!parsed.success) return;
+        const p = parsed.data;
         // `bus` is the MIDI output port name (e.g. "qlc-in"); `note` is the CC.
-        // Unknown bus → skip rather than mis-send to the first available output
-        // (sendCC falls back to it). Mirrors the fire() guard above.
-        if (!outputs.includes(p.bus)) {
-          console.warn(`[MidiDispatcher] Unknown MIDI bus "${p.bus}"; available:`, outputs);
-          return;
-        }
+        // An unknown/disconnected bus is skipped inside sendCC (no mis-send).
         const send = () =>
           sendCC(p.bus, { channel: p.channel, cc: p.note, value: p.value });
         send();
@@ -152,7 +151,7 @@ export function useMidiDispatcher(): void {
         }
       }
     },
-    [fire, fireOffOnce, clearOffTimer, sendCC, outputs]
+    [fire, fireOffOnce, clearOffTimer, sendCC]
   );
 
   useWebSocketChannel<DispatchedEvent>(

--- a/lib/models/Midi.ts
+++ b/lib/models/Midi.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { WordHarvestEventType } from "./WordHarvest";
-import { OverlayChannel } from "./OverlayEvents";
 
 // =============================================================================
 // Centralized MIDI configuration (shared between client & server)
@@ -219,10 +218,13 @@ export function getPortForApp(settings: MidiSettings, appId: string): string | n
 // port (`bus`) and the CC directly. The backend route publishes the validated
 // payload on the MIDI channel; the dispatcher (hooks/useMidiDispatcher.ts) turns
 // it into a Web MIDI send. The single source of truth for the defaults below.
+//
+// MIDI is NOT an overlay, so it uses its own WS channel string (like the
+// presenter / live-assist channels) rather than the OverlayChannel enum.
 // -----------------------------------------------------------------------------
 
 /** WebSocket channel carrying direct CC sends. */
-export const MIDI_CC_CHANNEL: string = OverlayChannel.MIDI;
+export const MIDI_CC_CHANNEL = "midi";
 /** Event type published on MIDI_CC_CHANNEL. */
 export const MIDI_CC_EVENT = "cc";
 

--- a/lib/models/Midi.ts
+++ b/lib/models/Midi.ts
@@ -240,9 +240,10 @@ export const midiCcSendSchema = z.object({
   /**
    * Seconds before the SAME message is re-sent once. 0 (or absent) = single
    * send; > 0 = a second identical send after `duration` seconds (e.g. to
-   * toggle a light back).
+   * toggle a light back). Capped at 3600s — large/Infinity/NaN values would
+   * overflow setTimeout's 32-bit delay and fire the re-send almost immediately.
    */
-  duration: z.number().min(0).default(0),
+  duration: z.number().min(0).max(3600).default(0),
 });
 
 export type MidiCcSend = z.infer<typeof midiCcSendSchema>;

--- a/lib/models/Midi.ts
+++ b/lib/models/Midi.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { WordHarvestEventType } from "./WordHarvest";
+import { OverlayChannel } from "./OverlayEvents";
 
 // =============================================================================
 // Centralized MIDI configuration (shared between client & server)
@@ -210,3 +211,36 @@ export function getPortForApp(settings: MidiSettings, appId: string): string | n
   const app = settings.apps.find((a) => a.id === appId);
   return app ? app.port : null;
 }
+
+// -----------------------------------------------------------------------------
+// Direct CC send (POST /api/midi/cc)
+//
+// A one-shot CC send bypassing the action catalog: the caller names the output
+// port (`bus`) and the CC directly. The backend route publishes the validated
+// payload on the MIDI channel; the dispatcher (hooks/useMidiDispatcher.ts) turns
+// it into a Web MIDI send. The single source of truth for the defaults below.
+// -----------------------------------------------------------------------------
+
+/** WebSocket channel carrying direct CC sends. */
+export const MIDI_CC_CHANNEL: string = OverlayChannel.MIDI;
+/** Event type published on MIDI_CC_CHANNEL. */
+export const MIDI_CC_EVENT = "cc";
+
+export const midiCcSendSchema = z.object({
+  /** MIDI output port name (e.g. "qlc-in"). Passed straight to sendCC. */
+  bus: z.string().min(1),
+  /** CC controller number (0-127), e.g. 81 for the FACE toggle. */
+  note: z.number().int().min(0).max(127),
+  /** CC value (0-127). */
+  value: z.number().int().min(0).max(127).default(127),
+  /** MIDI channel (1-16). */
+  channel: z.number().int().min(1).max(16).default(1),
+  /**
+   * Seconds before the SAME message is re-sent once. 0 (or absent) = single
+   * send; > 0 = a second identical send after `duration` seconds (e.g. to
+   * toggle a light back).
+   */
+  duration: z.number().min(0).default(0),
+});
+
+export type MidiCcSend = z.infer<typeof midiCcSendSchema>;

--- a/lib/models/OverlayEvents.ts
+++ b/lib/models/OverlayEvents.ts
@@ -29,6 +29,8 @@ export enum OverlayChannel {
   WORD_HARVEST = "word-harvest",
   TITLE_REVEAL = "title-reveal",
   SOMMAIRE = "sommaire",
+  /** Direct MIDI CC sends (POST /api/midi/cc → dispatcher → Web MIDI). */
+  MIDI = "midi",
 }
 
 /**

--- a/lib/models/OverlayEvents.ts
+++ b/lib/models/OverlayEvents.ts
@@ -29,8 +29,6 @@ export enum OverlayChannel {
   WORD_HARVEST = "word-harvest",
   TITLE_REVEAL = "title-reveal",
   SOMMAIRE = "sommaire",
-  /** Direct MIDI CC sends (POST /api/midi/cc → dispatcher → Web MIDI). */
-  MIDI = "midi",
 }
 
 /**

--- a/lib/services/ChannelManager.ts
+++ b/lib/services/ChannelManager.ts
@@ -4,6 +4,7 @@ import { OverlayEvent, OverlayChannel, AckEvent, RoomEvent, RoomEventType, Poste
 import { randomUUID } from "crypto";
 import { WEBSOCKET, LIVE_ASSIST } from "../config/Constants";
 import type { LiveAssistEvent } from "../models/LiveAssist";
+import { MIDI_CC_CHANNEL, MIDI_CC_EVENT, type MidiCcSend } from "../models/Midi";
 
 /**
  * Hardcoded presenter channel name
@@ -326,6 +327,22 @@ export class ChannelManager {
     this.logger.debug(`Publishing to live-assist: ${event.type}`);
     this.wsHub.broadcast(LIVE_ASSIST.CHANNEL, {
       ...event,
+      timestamp: Date.now(),
+      id: randomUUID(),
+    });
+  }
+
+  /**
+   * Publish a direct MIDI CC send on its dedicated channel (MIDI is not an
+   * overlay). The dashboard's useMidiDispatcher turns it into a Web MIDI send.
+   * No ack: the dispatcher is a passive subscriber, like presenter/live-assist.
+   */
+  publishMidiCc(payload: MidiCcSend): void {
+    this.logger.debug(`Publishing to midi: ${MIDI_CC_EVENT}`);
+    this.wsHub.broadcast(MIDI_CC_CHANNEL, {
+      channel: MIDI_CC_CHANNEL,
+      type: MIDI_CC_EVENT,
+      payload,
       timestamp: Date.now(),
       id: randomUUID(),
     });

--- a/server/api/midi.ts
+++ b/server/api/midi.ts
@@ -1,0 +1,31 @@
+/**
+ * Backend API - Direct MIDI CC sends
+ *
+ * MIDI is emitted only from the browser (Web MIDI API). This route publishes the
+ * validated CC payload on the MIDI WebSocket channel; the always-on dispatcher
+ * (hooks/useMidiDispatcher.ts), mounted in the dashboard, turns it into a real
+ * Web MIDI send. The dashboard must therefore be open for the CC to leave.
+ */
+import { Router } from "express";
+import { ChannelManager } from "../../lib/services/ChannelManager";
+import { OverlayChannel } from "../../lib/models/OverlayEvents";
+import { midiCcSendSchema, MIDI_CC_EVENT } from "../../lib/models/Midi";
+import { createContextHandler } from "../utils/expressRouteHandler";
+
+const router = Router();
+const channelManager = ChannelManager.getInstance();
+const midiHandler = createContextHandler("[MidiAPI]");
+
+/**
+ * POST /api/midi/cc
+ * Body: { bus, note, value?, channel?, duration? } (see midiCcSendSchema).
+ * Sends a CC now, and — when `duration` (seconds) > 0 — the same CC once more
+ * after that delay.
+ */
+router.post("/cc", midiHandler(async (req, res) => {
+  const payload = midiCcSendSchema.parse(req.body);
+  await channelManager.publish(OverlayChannel.MIDI, MIDI_CC_EVENT, payload);
+  res.json({ success: true });
+}, "Failed to send MIDI CC"));
+
+export default router;

--- a/server/api/midi.ts
+++ b/server/api/midi.ts
@@ -8,8 +8,7 @@
  */
 import { Router } from "express";
 import { ChannelManager } from "../../lib/services/ChannelManager";
-import { OverlayChannel } from "../../lib/models/OverlayEvents";
-import { midiCcSendSchema, MIDI_CC_EVENT } from "../../lib/models/Midi";
+import { midiCcSendSchema } from "../../lib/models/Midi";
 import { createContextHandler } from "../utils/expressRouteHandler";
 
 const router = Router();
@@ -24,7 +23,7 @@ const midiHandler = createContextHandler("[MidiAPI]");
  */
 router.post("/cc", midiHandler(async (req, res) => {
   const payload = midiCcSendSchema.parse(req.body);
-  await channelManager.publish(OverlayChannel.MIDI, MIDI_CC_EVENT, payload);
+  channelManager.publishMidiCc(payload);
   res.json({ success: true });
 }, "Failed to send MIDI CC"));
 

--- a/server/backend.ts
+++ b/server/backend.ts
@@ -34,6 +34,7 @@ import obsRouter from "./api/obs";
 import twitchRouter from "./api/twitch";
 import mediaPlayerRouter from "./api/media-player";
 import wordHarvestRouter from "./api/word-harvest";
+import midiRouter from "./api/midi";
 import { createLiveAssistRouter } from "./api/live-assist";
 import { buildOrchestrator } from "./api/liveAssistBoot";
 import devEventsRouter from "./api/dev-events";
@@ -130,6 +131,9 @@ class BackendServer {
 
     // Word Harvest game
     this.app.use('/api/word-harvest', wordHarvestRouter);
+
+    // Direct MIDI CC sends (→ dispatcher → Web MIDI)
+    this.app.use('/api/midi', midiRouter);
 
     // Live Assist (real-time listening assistant)
     const { orchestrator, store, registry } = buildOrchestrator();


### PR DESCRIPTION
## Quoi

Nouvelle route **`POST /api/midi/cc`** qui envoie un message MIDI Control Change.

Body JSON :
```jsonc
{
  "bus": "qlc-in",   // requis — nom du port de sortie MIDI
  "note": 81,        // requis — n° de contrôleur CC (0-127)
  "value": 127,      // optionnel — 0-127, défaut 127
  "duration": 2,     // optionnel — SECONDES ; 0/absent = envoi unique ; >0 = renvoi du même message après N s
  "channel": 1       // optionnel — canal MIDI 1-16, défaut 1
}
```
Réponse `{ "success": true }` ; body invalide → `400`.

## Pourquoi cette archi

Le MIDI n'est émis **que côté navigateur** (Web MIDI, `hooks/useMidi.ts`). Le serveur ne peut pas émettre directement. La route backend **publie sur un nouveau canal WS `midi`** (`ChannelManager.publish(OverlayChannel.MIDI, "cc", …)`), et le `useMidiDispatcher` toujours monté dans le dashboard transforme l'event en `sendCC`. **Le dashboard doit être ouvert** (avec accès Web MIDI + le port présent) pour que le CC parte — contrainte existante de tout le système MIDI.

`bus` = nom du port de sortie (ex. `qlc-in`). Un `bus` inconnu est **ignoré (avec un warn)** plutôt qu'envoyé au premier output dispo (corrige le fallback silencieux de `sendCC`).

## Fichiers

- `lib/models/OverlayEvents.ts` — `OverlayChannel.MIDI = "midi"`.
- `lib/models/Midi.ts` — `midiCcSendSchema`, `MIDI_CC_CHANNEL`, `MIDI_CC_EVENT`, type `MidiCcSend`.
- `server/api/midi.ts` (nouveau) + enregistrement dans `server/backend.ts`.
- `app/api/midi/cc/route.ts` (nouveau) — proxy Next → backend (`proxyToBackend`).
- `hooks/useMidiDispatcher.ts` — branche CC : envoi immédiat + re-send après `duration` s, timers nettoyés au démontage.
- `__tests__/models/Midi.test.ts` — tests du schéma (défauts, bornes, constantes).

## DRY / réutilisation

`proxyToBackend`, `withSimpleErrorHandler`, `createContextHandler`, `ChannelManager.publish`, `sendCC` — aucun ré-implémentation.

## Tests

- `pnpm test -- __tests__/models/Midi.test.ts` → 34 passent.
- `pnpm type-check` → propre sur les fichiers touchés (le repo a des erreurs pré-existantes ailleurs).
- Code review faite (1 point — fallback `bus` inconnu — corrigé).

## Vérif e2e manuelle (non automatisée)

Dashboard ouvert + port `qlc-in` (loopMIDI) :
```bash
curl -X POST http://localhost:3000/api/midi/cc -H "Content-Type: application/json" \
  -d '{"bus":"qlc-in","note":81,"value":127,"duration":2}'
```
→ CC immédiat puis un 2e ~2 s après ; `duration:0` → un seul ; `note:200` → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)