### PR TITLE
feat(live-assist): theater-data resolver for posters + poster-theatre provider

### DIFF
--- a/__tests__/services/TheaterDataResolverService.test.ts
+++ b/__tests__/services/TheaterDataResolverService.test.ts
@@ -1,0 +1,176 @@
+import { TheaterDataResolverService } from "@/lib/services/TheaterDataResolverService";
+import { SettingsRepository } from "@/lib/repositories/SettingsRepository";
+import { THEATER_DATA } from "@/lib/config/Constants";
+
+jest.mock("@/lib/repositories/SettingsRepository", () => ({
+  SettingsRepository: { getInstance: jest.fn() },
+}));
+
+const mockGetSetting = (value: string | null) => {
+  (SettingsRepository.getInstance as jest.Mock).mockReturnValue({ getSetting: () => value });
+};
+
+const okJson = (body: unknown): Response =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+describe("TheaterDataResolverService", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("maps a search hit to a normalized candidate with an absolute posterUrl", async () => {
+    mockGetSetting("http://wsl:4173/"); // trailing slash → must be stripped
+    const fetchImpl = jest.fn(async () =>
+      okJson([{ id: 262075, titre: "Le Cid", accroche: "Chef-d'œuvre.", univers: "Théâtre" }]),
+    ) as unknown as typeof fetch;
+
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+    const [c] = await svc.search("cid");
+
+    expect(c).toEqual({
+      id: 262075,
+      title: "Le Cid",
+      tagline: "Chef-d'œuvre.",
+      univers: "Théâtre",
+      posterUrl: "http://wsl:4173/poster/262075",
+    });
+
+    const calledUrl = (fetchImpl as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain("http://wsl:4173/api/search?");
+    expect(calledUrl).toContain("q=cid");
+    expect(calledUrl).toContain("limit=");
+  });
+
+  it("falls back to the default URL and empty strings for missing accroche/univers", async () => {
+    mockGetSetting(null);
+    const fetchImpl = jest.fn(async () => okJson([{ id: 1, titre: "X" }])) as unknown as typeof fetch;
+
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+    const [c] = await svc.search("x");
+
+    expect(c.posterUrl).toBe(`${THEATER_DATA.URL_DEFAULT}/poster/1`);
+    expect(c.tagline).toBe("");
+    expect(c.univers).toBe("");
+  });
+
+  it("drops malformed rows (missing id or titre)", async () => {
+    mockGetSetting("http://h:4173");
+    const fetchImpl = jest.fn(async () =>
+      okJson([{ titre: "no id" }, { id: 2 }, { id: 3, titre: "Faust" }]),
+    ) as unknown as typeof fetch;
+
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+    const results = await svc.search("faust");
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(3);
+  });
+
+  it("resolveAndFetch returns the top-1 hit as { title, extract, thumbnail, source }", async () => {
+    mockGetSetting("http://h:4173");
+    const fetchImpl = jest.fn(async () =>
+      okJson([
+        { id: 5, titre: "Faust", accroche: "Pacte." },
+        { id: 6, titre: "Faust 2" },
+      ]),
+    ) as unknown as typeof fetch;
+
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+    const r = await svc.resolveAndFetch("faust");
+
+    expect(r).toEqual({
+      title: "Faust",
+      extract: "Pacte.",
+      thumbnail: "http://h:4173/poster/5",
+      source: "theater-data",
+    });
+  });
+
+  it("search returns [] on an empty query without fetching", async () => {
+    mockGetSetting("http://h:4173");
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+
+    expect(await svc.search("   ")).toEqual([]);
+    expect(fetchImpl as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("search degrades to [] on a non-200 response", async () => {
+    mockGetSetting("http://h:4173");
+    const fetchImpl = jest.fn(async () => ({ ok: false, status: 500 }) as unknown as Response) as unknown as typeof fetch;
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+    expect(await svc.search("x")).toEqual([]);
+  });
+
+  it("search degrades to [] on a network error / timeout", async () => {
+    mockGetSetting("http://h:4173");
+    const fetchImpl = jest.fn(async () => {
+      throw new Error("ETIMEDOUT");
+    }) as unknown as typeof fetch;
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+    expect(await svc.search("x")).toEqual([]);
+  });
+
+  it("resolveAndFetch throws on an empty query", async () => {
+    mockGetSetting("http://h:4173");
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl: jest.fn() as unknown as typeof fetch });
+    await expect(svc.resolveAndFetch("  ")).rejects.toThrow(/empty query/i);
+  });
+
+  it("resolveAndFetch throws when the server is down (search yields [])", async () => {
+    mockGetSetting("http://h:4173");
+    const fetchImpl = jest.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+    await expect(svc.resolveAndFetch("x")).rejects.toThrow(/no theater-data/i);
+  });
+
+  it("serves a cached result within TTL without re-fetching (case-insensitive key)", async () => {
+    mockGetSetting("http://h:4173");
+    const fetchImpl = jest.fn(async () => okJson([{ id: 1, titre: "Dune" }])) as unknown as typeof fetch;
+    let t = 1000;
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl, now: () => t });
+
+    await svc.search("dune");
+    t += 1000; // still within TTL
+    await svc.search("DUNE");
+    expect((fetchImpl as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  describe("testConnection", () => {
+    it("returns ok when /api/status responds 200, using the passed-in (unsaved) URL", async () => {
+      mockGetSetting(null); // nothing stored — proves the override URL is used
+      const fetchImpl = jest.fn(async () => ({ ok: true, status: 200 }) as unknown as Response) as unknown as typeof fetch;
+      const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection("http://typed:4173/");
+      expect(r.ok).toBe(true);
+      expect((fetchImpl as jest.Mock).mock.calls[0][0]).toBe("http://typed:4173/api/status");
+    });
+
+    it("reports a failure on a non-200 status", async () => {
+      mockGetSetting("http://h:4173");
+      const fetchImpl = jest.fn(async () => ({ ok: false, status: 503 }) as unknown as Response) as unknown as typeof fetch;
+      const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection("http://h:4173");
+      expect(r.ok).toBe(false);
+      expect(r.message).toMatch(/503/);
+    });
+
+    it("falls back to the stored URL when no override is given", async () => {
+      mockGetSetting("http://stored:4173");
+      const fetchImpl = jest.fn(async () => ({ ok: true, status: 200 }) as unknown as Response) as unknown as typeof fetch;
+      const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection();
+      expect(r.ok).toBe(true);
+      expect((fetchImpl as jest.Mock).mock.calls[0][0]).toBe("http://stored:4173/api/status");
+    });
+
+    it("returns a friendly failure (no throw) on a network error", async () => {
+      mockGetSetting("http://h:4173");
+      const fetchImpl = jest.fn(async () => {
+        throw new Error("boom");
+      }) as unknown as typeof fetch;
+      const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+      const r = await svc.testConnection("http://h:4173");
+      expect(r).toEqual({ ok: false, message: "boom" });
+    });
+  });
+});

--- a/__tests__/services/TheaterDataResolverService.test.ts
+++ b/__tests__/services/TheaterDataResolverService.test.ts
@@ -92,6 +92,33 @@ describe("TheaterDataResolverService", () => {
     expect(fetchImpl as jest.Mock).not.toHaveBeenCalled();
   });
 
+  it("treats a blank URL setting as disabled: returns [] without fetching", async () => {
+    mockGetSetting(""); // explicitly cleared in Settings → integration disabled
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl });
+
+    expect(await svc.search("impro")).toEqual([]);
+    await expect(svc.resolveAndFetch("impro")).rejects.toThrow(/no theater-data/i);
+    expect(fetchImpl as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("does not serve cross-base stale cache when the URL changes at runtime", async () => {
+    const getSetting = jest.fn();
+    (SettingsRepository.getInstance as jest.Mock).mockReturnValue({ getSetting });
+    const fetchImpl = jest.fn(async () => okJson([{ id: 1, titre: "Dune" }])) as unknown as typeof fetch;
+    let t = 1000;
+    const svc = TheaterDataResolverService.createForTest({ fetchImpl, now: () => t });
+
+    getSetting.mockReturnValue("http://a:4173");
+    const [a] = await svc.search("dune");
+    getSetting.mockReturnValue("http://b:4173"); // URL changed in Settings
+    const [b] = await svc.search("dune");
+
+    expect(a.posterUrl).toBe("http://a:4173/poster/1");
+    expect(b.posterUrl).toBe("http://b:4173/poster/1");
+    expect((fetchImpl as jest.Mock).mock.calls).toHaveLength(2); // no stale cache hit
+  });
+
   it("search degrades to [] on a non-200 response", async () => {
     mockGetSetting("http://h:4173");
     const fetchImpl = jest.fn(async () => ({ ok: false, status: 500 }) as unknown as Response) as unknown as typeof fetch;

--- a/app/api/settings/integrations/route.ts
+++ b/app/api/settings/integrations/route.ts
@@ -1,7 +1,7 @@
 import { SettingsRepository } from "@/lib/repositories/SettingsRepository";
 import { OllamaSummarizerService } from "@/lib/services/OllamaSummarizerService";
 import { ApiResponses, withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
-import { LLM_URLS } from "@/lib/config/Constants";
+import { LLM_URLS, THEATER_DATA } from "@/lib/config/Constants";
 
 const LOG_CONTEXT = "[SettingsAPI:integrations]";
 
@@ -29,6 +29,9 @@ export const GET = withSimpleErrorHandler(async () => {
 
     // TMDB (movie/TV posters)
     tmdb_api_key: db.getSetting("tmdb_api_key") || "",
+
+    // theater-data (local BilletReduc show base)
+    theater_data_url: db.getSetting("theater_data_url") || THEATER_DATA.URL_DEFAULT,
   };
 
   return ApiResponses.ok({ settings });
@@ -76,6 +79,11 @@ export const POST = withSimpleErrorHandler(async (request: Request) => {
   // TMDB (movie/TV posters)
   if (body.tmdb_api_key !== undefined) {
     settingsToSave.tmdb_api_key = body.tmdb_api_key;
+  }
+
+  // theater-data (local BilletReduc show base)
+  if (body.theater_data_url !== undefined) {
+    settingsToSave.theater_data_url = body.theater_data_url;
   }
 
   // Save all settings

--- a/app/api/settings/integrations/route.ts
+++ b/app/api/settings/integrations/route.ts
@@ -30,8 +30,10 @@ export const GET = withSimpleErrorHandler(async () => {
     // TMDB (movie/TV posters)
     tmdb_api_key: db.getSetting("tmdb_api_key") || "",
 
-    // theater-data (local BilletReduc show base)
-    theater_data_url: db.getSetting("theater_data_url") || THEATER_DATA.URL_DEFAULT,
+    // theater-data (local BilletReduc show base). Nullish-coalesce (not ||) so an
+    // explicitly blank value (integration disabled) survives instead of being reset
+    // to the default on every read — only a never-configured key falls back.
+    theater_data_url: db.getSetting("theater_data_url") ?? THEATER_DATA.URL_DEFAULT,
   };
 
   return ApiResponses.ok({ settings });

--- a/app/api/settings/integrations/theatre-test/route.ts
+++ b/app/api/settings/integrations/theatre-test/route.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { TheaterDataResolverService } from "@/lib/services/TheaterDataResolverService";
+import { ApiResponses, withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+
+const LOG_CONTEXT = "[TheatreTestAPI]";
+
+const schema = z.object({ url: z.string().optional() });
+
+/**
+ * POST /api/settings/integrations/theatre-test
+ * Ping the local theater-data server (`GET /api/status`) to validate connectivity.
+ * Tests the URL in the request body (the value typed in Settings, possibly unsaved);
+ * falls back to the stored one when none is sent. Returns 200 with { success, message }
+ * for both reachable and unreachable servers — a down server is a status, not an error.
+ */
+export const POST = withSimpleErrorHandler(async (request: Request) => {
+  const body = await request.json().catch(() => ({}));
+  const { url } = schema.parse(body ?? {});
+  const result = await TheaterDataResolverService.getInstance().testConnection(url);
+  return ApiResponses.ok({ success: result.ok, message: result.message });
+}, LOG_CONTEXT);

--- a/app/api/theatre/search/route.ts
+++ b/app/api/theatre/search/route.ts
@@ -1,0 +1,30 @@
+import { TheaterDataResolverService } from "@/lib/services/TheaterDataResolverService";
+import { THEATER_DATA } from "@/lib/config/Constants";
+import { ApiResponses, withSimpleErrorHandler } from "@/lib/utils/ApiResponses";
+
+const LOG_CONTEXT = "[TheatreSearchAPI]";
+
+/**
+ * GET /api/theatre/search?q=...&limit=...
+ *
+ * Server-side proxy over the local theater-data base (`GET /api/search`). Runs
+ * server-side so there is no CORS and the base URL / French response shape never
+ * leak to the browser. Returns normalized `TheatreCandidate[]`; when the base is
+ * unset or the server (WSL, manual) is down, the resolver yields `[]` (empty
+ * state in the UI), never an error.
+ */
+export const GET = withSimpleErrorHandler(async (request: Request) => {
+  const { searchParams } = new URL(request.url);
+  const q = (searchParams.get("q") ?? "").trim();
+
+  const parsedLimit = Number(searchParams.get("limit"));
+  const limit =
+    Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? Math.min(Math.floor(parsedLimit), 50)
+      : THEATER_DATA.SEARCH_LIMIT;
+
+  if (!q) return ApiResponses.ok({ candidates: [] });
+
+  const candidates = await TheaterDataResolverService.getInstance().search(q, limit);
+  return ApiResponses.ok({ candidates });
+}, LOG_CONTEXT);

--- a/app/api/theatre/search/route.ts
+++ b/app/api/theatre/search/route.ts
@@ -8,10 +8,13 @@ const LOG_CONTEXT = "[TheatreSearchAPI]";
  * GET /api/theatre/search?q=...&limit=...
  *
  * Server-side proxy over the local theater-data base (`GET /api/search`). Runs
- * server-side so there is no CORS and the base URL / French response shape never
- * leak to the browser. Returns normalized `TheatreCandidate[]`; when the base is
- * unset or the server (WSL, manual) is down, the resolver yields `[]` (empty
- * state in the UI), never an error.
+ * server-side so the JSON search avoids CORS and the setting/timeout/graceful
+ * degradation stay centralized (the French response shape is normalized here too).
+ * Each returned `posterUrl` is intentionally absolute (`${base}/poster/{id}`) so the
+ * browser loads thumbnails directly from theater-data (image loads need no CORS) —
+ * i.e. the base URL is deliberately exposed for images, not hidden. When the base is
+ * unset/disabled or the server (WSL, manual) is down, the resolver yields `[]`
+ * (empty state in the UI), never an error.
  */
 export const GET = withSimpleErrorHandler(async (request: Request) => {
   const { searchParams } = new URL(request.url);

--- a/components/assets/PosterManager.tsx
+++ b/components/assets/PosterManager.tsx
@@ -12,6 +12,8 @@ import { EntityHeader } from "@/components/ui/EntityHeader";
 import { EnableSearchCombobox } from "@/components/ui/EnableSearchCombobox";
 import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
 import { PosterUploader } from "./PosterUploader";
+import { TheatreSearchCombobox } from "./TheatreSearchCombobox";
+import type { TheatreCandidate } from "@/lib/services/TheaterDataResolverService";
 import { VirtualizedPosterGrid } from "./VirtualizedPosterGrid";
 import { Trash2, Upload, Image as ImageIcon, Video, Youtube, Loader2 } from "lucide-react";
 import { apiGet } from "@/lib/utils/ClientFetch";
@@ -131,6 +133,26 @@ export function PosterManager() {
       router.push(`/assets/posters/${poster.id}`);
     } catch (error) {
       console.error("Failed to create poster:", error);
+    }
+    setShowUploader(false);
+  };
+
+  // Autofill from the local theater-data base: title + accroche + the real affiche.
+  // The image is downloaded locally (downloadToLocal) so it survives the base going offline.
+  const handleTheatreSelect = async (candidate: TheatreCandidate) => {
+    try {
+      const poster = await createPosterAsync({
+        title: candidate.title,
+        description: candidate.tagline || undefined,
+        fileUrl: candidate.posterUrl,
+        type: "image",
+        downloadToLocal: true,
+        tags: ["theatre"],
+        metadata: { theatreId: candidate.id, source: "theater-data" },
+      });
+      router.push(`/assets/posters/${poster.id}`);
+    } catch (error) {
+      console.error("Failed to create poster from theater-data:", error);
     }
     setShowUploader(false);
   };
@@ -306,12 +328,15 @@ export function PosterManager() {
         </div>
       )}
 
-      {/* Upload Step */}
+      {/* Upload Step — search the local shows base (autofill) OR upload manually. */}
       {showUploader && (
-        <PosterUploader
-          onUpload={handleUploadComplete}
-          onCancel={() => setShowUploader(false)}
-        />
+        <div className="space-y-3">
+          <TheatreSearchCombobox onSelect={handleTheatreSelect} />
+          <PosterUploader
+            onUpload={handleUploadComplete}
+            onCancel={() => setShowUploader(false)}
+          />
+        </div>
       )}
 
       {/* Active Posters Grid */}

--- a/components/assets/TheatreSearchCombobox.tsx
+++ b/components/assets/TheatreSearchCombobox.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { Loader2, Search, Drama } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { apiGet, isClientFetchError } from "@/lib/utils/ClientFetch";
+import { THEATER_DATA } from "@/lib/config/Constants";
+import type { TheatreCandidate } from "@/lib/services/TheaterDataResolverService";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface TheatreSearchComboboxProps {
+  /** Fired when the user picks a show — the parent creates the poster from it. */
+  onSelect: (candidate: TheatreCandidate) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Inline typeahead over the local theater-data base (`GET /api/theatre/search`).
+ * Type a title → pick a show → the parent autofills title + accroche + affiche.
+ *
+ * Purely additive: when the base is unset or the server (WSL, manual) is down the
+ * search returns `[]`, so it shows an empty state and never blocks the manual
+ * upload path next to it. Mirrors the debounce/thumbnail shape of TwitchCategoryPicker.
+ */
+export function TheatreSearchCombobox({ onSelect, disabled = false }: TheatreSearchComboboxProps) {
+  const t = useTranslations("assets.posters");
+  const [search, setSearch] = useState("");
+  const [candidates, setCandidates] = useState<TheatreCandidate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runSearch = useCallback(
+    async (query: string) => {
+      const q = query.trim();
+      if (q.length < 2) {
+        setCandidates([]);
+        setError(null);
+        return;
+      }
+      try {
+        setLoading(true);
+        setError(null);
+        const res = await apiGet<{ candidates: TheatreCandidate[] }>(
+          `/api/theatre/search?q=${encodeURIComponent(q)}&limit=${THEATER_DATA.SEARCH_LIMIT}`,
+          // A little over the server-side abort so the proxy's own timeout wins first.
+          { timeout: THEATER_DATA.REQUEST_TIMEOUT_MS + 1000 },
+        );
+        setCandidates(res.candidates ?? []);
+      } catch (err) {
+        setError(isClientFetchError(err) ? err.errorMessage : t("theatreSearchError"));
+        setCandidates([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [t],
+  );
+
+  // Debounced search effect.
+  useEffect(() => {
+    const timer = setTimeout(() => runSearch(search), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [search, runSearch]);
+
+  const handleSelect = (candidate: TheatreCandidate) => {
+    onSelect(candidate);
+    setSearch("");
+    setCandidates([]);
+  };
+
+  const trimmed = search.trim();
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <Drama className="h-4 w-4 text-muted-foreground" />
+        {t("theatreSearchLabel")}
+      </div>
+      <Command shouldFilter={false} className="rounded-md border">
+        <div className="flex items-center border-b px-3">
+          <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          <input
+            className="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder={t("theatreSearchPlaceholder")}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            disabled={disabled}
+          />
+          {loading && <Loader2 className="ml-2 h-4 w-4 animate-spin" />}
+        </div>
+        <CommandList>
+          {trimmed.length < 2 && !loading && (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              {t("theatreSearchHint")}
+            </div>
+          )}
+          {!loading && trimmed.length >= 2 && candidates.length === 0 && !error && (
+            <CommandEmpty>{t("theatreNoResults")}</CommandEmpty>
+          )}
+          {error && <div className="px-4 py-3 text-sm text-destructive">{error}</div>}
+          {candidates.length > 0 && (
+            <CommandGroup>
+              {candidates.map((c) => (
+                <CommandItem
+                  key={c.id}
+                  value={String(c.id)}
+                  onSelect={() => handleSelect(c)}
+                  className="flex cursor-pointer items-center gap-3"
+                >
+                  <div className="h-14 w-10 shrink-0 overflow-hidden rounded bg-muted">
+                    <img
+                      src={c.posterUrl}
+                      alt=""
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium">{c.title}</div>
+                    {c.tagline && (
+                      <div className="truncate text-xs text-muted-foreground">{c.tagline}</div>
+                    )}
+                  </div>
+                  {c.univers && (
+                    <span className="shrink-0 text-[10px] uppercase text-muted-foreground">
+                      {c.univers}
+                    </span>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </div>
+  );
+}

--- a/components/settings/OllamaSettings.tsx
+++ b/components/settings/OllamaSettings.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { Loader2, CheckCircle, XCircle, RefreshCw, Trash2 } from "lucide-react";
 import { useSettings } from "@/lib/hooks/useSettings";
 import { apiGet, apiPost, apiDelete, isClientFetchError, extractErrorMessage } from "@/lib/utils/ClientFetch";
+import { THEATER_DATA } from "@/lib/config/Constants";
 
 type LLMProvider = "ollama" | "openai" | "anthropic";
 
@@ -38,6 +39,9 @@ interface LLMSettings {
 
   // TMDB (affiches films/séries)
   tmdb_api_key?: string;
+
+  // theater-data (base locale spectacles BilletReduc)
+  theater_data_url?: string;
 }
 
 interface LLMSettingsResponse {
@@ -50,6 +54,7 @@ const INITIAL_STATE: LLMSettings = {
   ollama_model: "mistral:latest",
   openai_model: "gpt-5-mini",
   anthropic_model: "claude-3-5-sonnet-20241022",
+  theater_data_url: THEATER_DATA.URL_DEFAULT,
 };
 
 /**
@@ -84,6 +89,8 @@ export function OllamaSettings() {
   const [isClearingCache, setIsClearingCache] = useState(false);
   const [isTestingTmdb, setIsTestingTmdb] = useState(false);
   const [tmdbTestResult, setTmdbTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [isTestingTheatre, setIsTestingTheatre] = useState(false);
+  const [theatreTestResult, setTheatreTestResult] = useState<{ success: boolean; message: string } | null>(null);
 
   const handleTestTmdb = async () => {
     setIsTestingTmdb(true);
@@ -103,6 +110,27 @@ export function OllamaSettings() {
       toast.error(message);
     } finally {
       setIsTestingTmdb(false);
+    }
+  };
+
+  const handleTestTheatre = async () => {
+    setIsTestingTheatre(true);
+    setTheatreTestResult(null);
+    try {
+      const data = await apiPost<{ success: boolean; message?: string }>(
+        "/api/settings/integrations/theatre-test",
+        { url: settings.theater_data_url ?? "" },
+      );
+      const message = data.message || (data.success ? "Base spectacles OK." : "Base spectacles injoignable.");
+      setTheatreTestResult({ success: data.success, message });
+      if (data.success) toast.success(message);
+      else toast.error(message);
+    } catch (error) {
+      const message = extractErrorMessage(error, "Base spectacles injoignable.");
+      setTheatreTestResult({ success: false, message });
+      toast.error(message);
+    } finally {
+      setIsTestingTheatre(false);
     }
   };
 
@@ -498,6 +526,64 @@ export function OllamaSettings() {
                   <XCircle className="h-4 w-4 text-red-500" />
                 )}
                 <span className="text-sm">{tmdbTestResult.message}</span>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* theater-data (base locale spectacles BilletReduc) */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Base spectacles (BilletReduc)</CardTitle>
+          <CardDescription>
+            Affiches de spectacles / impro depuis le projet local theater-data (lancé en WSL).
+            Optionnel : sert Live Assist et l&apos;ajout d&apos;affiche par recherche de titre.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="theater_data_url">URL du serveur</Label>
+            <Input
+              id="theater_data_url"
+              type="text"
+              value={settings.theater_data_url ?? ""}
+              onChange={(e) =>
+                setSettings({ ...settings, theater_data_url: e.target.value })
+              }
+              placeholder={THEATER_DATA.URL_DEFAULT}
+            />
+            <p className="text-sm text-muted-foreground">
+              Par défaut {THEATER_DATA.URL_DEFAULT} (WSL2 forwarde localhost). Laisser vide pour
+              désactiver l&apos;intégration.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleTestTheatre}
+              disabled={isTestingTheatre || !settings.theater_data_url}
+            >
+              {isTestingTheatre ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Test en cours…
+                </>
+              ) : (
+                "Tester la connexion"
+              )}
+            </Button>
+
+            {theatreTestResult && (
+              <div className="flex items-center gap-2 px-3 py-2 rounded border">
+                {theatreTestResult.success ? (
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-red-500" />
+                )}
+                <span className="text-sm">{theatreTestResult.message}</span>
               </div>
             )}
           </div>

--- a/lib/config/Constants.ts
+++ b/lib/config/Constants.ts
@@ -724,11 +724,14 @@ export const LIVE_ASSIST = {
   DEFAULT_WHISPER_MODEL: "large-v3",
   /** Default keyword list per provider id.
    *  `poster` (Wikipedia) handles théâtre/concerts; `poster-tmdb` (TMDB) handles
-   *  films/séries. `affiche` is intentionally listed under BOTH so both become
-   *  candidates and the LLM disambiguates film-vs-théâtre via the context prompts. */
+   *  films/séries; `poster-theatre` (local BilletReduc base) handles spectacles with
+   *  their real affiche. `affiche` is intentionally listed under several so they all
+   *  become candidates and the LLM disambiguates via the context prompts (a human
+   *  validates each card anyway, so overlapping théâtre suggestions are acceptable). */
   DEFAULT_KEYWORDS: {
     poster: ["spectacle", "pièce", "affiche", "concert"],
     "poster-tmdb": ["film", "série", "affiche"],
+    "poster-theatre": ["spectacle", "pièce", "impro", "théâtre", "affiche"],
     definition: ["définition", "c'est quoi", "qu'est-ce que", "ça veut dire"],
   } as Record<string, string[]>,
   /** The pre-split `poster` default, used only to detect & migrate untouched configs. */
@@ -740,6 +743,8 @@ export const LIVE_ASSIST = {
       "entité = titre exact du spectacle / pièce / concert (sans article) ; ajoute le type entre parenthèses pour viser le bon article Wikipédia : « Roméo et Juliette (pièce de théâtre) », « Les Vieilles Canailles (concert) ».",
     "poster-tmdb":
       "entité = titre du film / série. S'il est nommé, reprends-le tel quel (sans année ni article). S'il n'est PAS nommé mais identifiable d'après les indices (acteur, intrigue, réplique, époque), PROPOSE le titre le plus emblématique qui correspond — p. ex. « le film avec Sharon Stone » → « Basic Instinct », « le film de requins de Spielberg » → « Les Dents de la mer », « la série des Stranger » → « Stranger Things » — avec infere=true et une confiance reflétant ta certitude. Ne reste non actionnable QUE si vraiment aucun titre plausible ne ressort. Base TMDB (cinéma/séries), sans parenthèses.",
+    "poster-theatre":
+      "entité = titre exact du spectacle / pièce / impro tel que prononcé, sans article et sans parenthèses. Cible une base locale de spectacles (BilletReduc, tous genres) via recherche plein-texte, donne donc le titre le plus proche de ce qui est dit.",
     definition: "entité = le concept / sujet exact à définir, sans article.",
   } as Record<string, string>,
   /** Stricter confidence bar for a DEDUCED (inferred) entity, to limit false guesses
@@ -867,6 +872,31 @@ export const TMDB = {
   REQUEST_TIMEOUT_MS: 8000,
   /** Setting key holding the API key (mirrors `openai_api_key`). */
   API_KEY_SETTING: "tmdb_api_key",
+} as const;
+
+// ============================================================================
+// THEATER-DATA — local BilletReduc show base (théâtre / impro / concerts…)
+// ============================================================================
+
+/**
+ * Config for the local `theater-data` project (a SQLite base of French shows synced
+ * from BilletReduc, exposed over HTTP on port 4173). Consumed via HTTP — no direct
+ * SQLite coupling. The base URL is read at runtime from the `theater_data_url` setting
+ * (mirrors `tmdb_api_key`); when the server is unreachable the resolver degrades
+ * silently (empty results / no suggestion). The server is launched manually in WSL
+ * (`pnpm web`), so it is often down — hence the short request timeout.
+ */
+export const THEATER_DATA = {
+  /** Setting key holding the base URL (e.g. http://localhost:4173). */
+  URL_SETTING: "theater_data_url",
+  /** Default base URL — WSL2 forwards localhost to Windows. */
+  URL_DEFAULT: "http://localhost:4173",
+  /** Max candidates fetched for the manual add-poster typeahead. */
+  SEARCH_LIMIT: 12,
+  /** Abort a request after this many ms — kept short since the server is often down. */
+  REQUEST_TIMEOUT_MS: 2000,
+  /** In-memory resolver cache TTL (ms). */
+  CACHE_TTL_MS: 5 * 60 * 1000,
 } as const;
 
 // ============================================================================

--- a/lib/queries/usePosters.ts
+++ b/lib/queries/usePosters.ts
@@ -40,6 +40,9 @@ export interface CreatePosterInput {
   tags?: string[];
   description?: string;
   source?: string;
+  /** When true and fileUrl is a remote http(s) URL, the server downloads the image
+   *  into local uploads so the poster survives the source going offline. */
+  downloadToLocal?: boolean;
   chatMessage?: string;
   isEnabled?: boolean;
   duration?: number | null;

--- a/lib/services/TheaterDataResolverService.ts
+++ b/lib/services/TheaterDataResolverService.ts
@@ -1,0 +1,173 @@
+import { THEATER_DATA } from "@/lib/config/Constants";
+import { SettingsRepository } from "@/lib/repositories/SettingsRepository";
+import { Logger } from "@/lib/utils/Logger";
+
+const logger = new Logger("TheaterDataResolverService");
+
+/**
+ * Result shape compatible with the `Resolver` contract consumed by
+ * PosterActionProvider (`{ title, extract, thumbnail? }`). `source` is carried
+ * for parity with the other resolvers but is not required by the contract.
+ */
+export interface TheaterDataResult {
+  title: string;
+  extract: string;
+  thumbnail?: string;
+  source: "theater-data";
+}
+
+/** A normalized candidate for the manual add-poster typeahead. */
+export interface TheatreCandidate {
+  id: number;
+  title: string;
+  /** The show's one-line tagline (`accroche`) — used as the poster description. */
+  tagline: string;
+  univers: string;
+  /** Absolute, servable image URL (`${base}/poster/${id}`), image survives locally
+   *  once ingested via `downloadToLocal`. */
+  posterUrl: string;
+}
+
+/** Raw `PlaySummary` returned by theater-data's `GET /api/search` (French keys). */
+interface TheaterDataSearchItem {
+  id: number;
+  titre?: string;
+  accroche?: string | null;
+  univers?: string | null;
+}
+
+type CacheEntry = { value: TheatreCandidate[]; exp: number };
+
+/**
+ * Resolves a spoken / typed show title to its BilletReduc affiche via the local
+ * `theater-data` project (a SQLite base of French shows exposed over HTTP on
+ * :4173). Purpose-built for théâtre / impro / concerts, so it sidesteps the poor
+ * poster quality Wikipedia gives for stage shows (issue #116).
+ *
+ * Consumed two ways:
+ *  - Live Assist: the `poster-theatre` PosterActionProvider calls `resolveAndFetch`
+ *    (top-1 auto-apply, like Wikipedia / TMDB).
+ *  - Manual add-poster UI: the `/api/theatre/search` proxy calls `search` (a list
+ *    of candidates a human picks from).
+ *
+ * The base URL is read live from the `theater_data_url` setting. The server is
+ * launched manually in WSL, so it is often down — every network path degrades
+ * silently: `search` returns `[]`, `resolveAndFetch` throws (→ no suggestion).
+ */
+export class TheaterDataResolverService {
+  private static instance: TheaterDataResolverService;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly now: () => number;
+  private readonly fetchImpl: typeof fetch;
+
+  private constructor(opts: { now?: () => number; fetchImpl?: typeof fetch } = {}) {
+    this.now = opts.now ?? Date.now;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  static getInstance(): TheaterDataResolverService {
+    if (!TheaterDataResolverService.instance) {
+      TheaterDataResolverService.instance = new TheaterDataResolverService();
+    }
+    return TheaterDataResolverService.instance;
+  }
+
+  /** Test seam: build an isolated instance with injected clock / fetch. */
+  static createForTest(opts: { now?: () => number; fetchImpl?: typeof fetch }): TheaterDataResolverService {
+    return new TheaterDataResolverService(opts);
+  }
+
+  /** Base URL of the theater-data server, trailing slash stripped. Read live so a
+   *  Settings save takes effect without a restart. */
+  private getBaseUrl(): string {
+    const raw = SettingsRepository.getInstance().getSetting(THEATER_DATA.URL_SETTING);
+    return (raw?.trim() || THEATER_DATA.URL_DEFAULT).replace(/\/+$/, "");
+  }
+
+  /**
+   * Full-text search the base and return normalized candidates. Never throws —
+   * returns `[]` on any failure (server down, timeout, non-200) so the typeahead
+   * degrades to an empty state instead of blocking manual poster creation.
+   */
+  async search(query: string, limit: number = THEATER_DATA.SEARCH_LIMIT): Promise<TheatreCandidate[]> {
+    const q = query.trim();
+    if (!q) return [];
+
+    const cacheKey = `${q.toLowerCase()}:${limit}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.exp > this.now()) return cached.value;
+
+    const base = this.getBaseUrl();
+    const url = `${base}/api/search?` + new URLSearchParams({ q, limit: String(limit) }).toString();
+
+    try {
+      const res = await this.fetchImpl(url, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(THEATER_DATA.REQUEST_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        logger.info(`theater-data search failed (${res.status}) for "${q}"`);
+        return [];
+      }
+
+      const data = (await res.json()) as TheaterDataSearchItem[];
+      const candidates: TheatreCandidate[] = (Array.isArray(data) ? data : [])
+        .filter((item) => item && typeof item.id === "number" && item.titre)
+        .map((item) => ({
+          id: item.id,
+          title: (item.titre ?? "").trim(),
+          tagline: (item.accroche ?? "").trim(),
+          univers: (item.univers ?? "").trim(),
+          posterUrl: `${base}/poster/${item.id}`,
+        }));
+
+      this.cache.set(cacheKey, { value: candidates, exp: this.now() + THEATER_DATA.CACHE_TTL_MS });
+      return candidates;
+    } catch (error) {
+      // Down / timeout / DNS — graceful: no results rather than a thrown error.
+      logger.info(`theater-data unreachable for "${q}": ${error instanceof Error ? error.message : error}`);
+      return [];
+    }
+  }
+
+  /**
+   * Ping the theater-data server's `/api/status` to validate connectivity. Uses the
+   * provided URL (the value typed in Settings, possibly unsaved) or, if none is given,
+   * the stored one. Returns a friendly result instead of throwing so the Settings
+   * "Test connection" button can show success/failure inline.
+   */
+  async testConnection(urlOverride?: string): Promise<{ ok: boolean; message: string }> {
+    const base = (urlOverride?.trim() || this.getBaseUrl()).replace(/\/+$/, "");
+    if (!base) return { ok: false, message: "Aucune URL renseignée." };
+    try {
+      const res = await this.fetchImpl(`${base}/api/status`, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(THEATER_DATA.REQUEST_TIMEOUT_MS),
+      });
+      if (res.ok) return { ok: true, message: `Connexion OK (${base}).` };
+      return { ok: false, message: `Le serveur a répondu ${res.status}.` };
+    } catch (error) {
+      return { ok: false, message: error instanceof Error ? error.message : "Échec réseau." };
+    }
+  }
+
+  /**
+   * Resolve a show title to its affiche for the Live Assist poster provider.
+   * Throws when the query is empty or no show matches (so the provider's
+   * `resolveOrNull` simply yields no suggestion — graceful degradation).
+   */
+  async resolveAndFetch(query: string): Promise<TheaterDataResult> {
+    const q = query.trim();
+    if (!q) throw new Error("empty query");
+
+    const best = (await this.search(q, 1))[0];
+    if (!best) throw new Error(`no theater-data result for "${q}"`);
+
+    return {
+      title: best.title,
+      extract: best.tagline,
+      thumbnail: best.posterUrl,
+      source: "theater-data",
+    };
+  }
+}

--- a/lib/services/TheaterDataResolverService.ts
+++ b/lib/services/TheaterDataResolverService.ts
@@ -78,10 +78,14 @@ export class TheaterDataResolverService {
   }
 
   /** Base URL of the theater-data server, trailing slash stripped. Read live so a
-   *  Settings save takes effect without a restart. */
+   *  Settings save takes effect without a restart. Returns `""` when the integration
+   *  is explicitly disabled (setting saved blank); only a *missing* setting (never
+   *  configured → `null`) falls back to the default, so clearing the field in Settings
+   *  truly disables it instead of silently reviving localhost. */
   private getBaseUrl(): string {
     const raw = SettingsRepository.getInstance().getSetting(THEATER_DATA.URL_SETTING);
-    return (raw?.trim() || THEATER_DATA.URL_DEFAULT).replace(/\/+$/, "");
+    if (raw === null) return THEATER_DATA.URL_DEFAULT;
+    return raw.trim().replace(/\/+$/, "");
   }
 
   /**
@@ -93,11 +97,15 @@ export class TheaterDataResolverService {
     const q = query.trim();
     if (!q) return [];
 
-    const cacheKey = `${q.toLowerCase()}:${limit}`;
+    const base = this.getBaseUrl();
+    if (!base) return []; // integration disabled (setting saved blank) — no localhost hit
+
+    // Cache key includes the base URL so switching `theater_data_url` at runtime never
+    // serves stale candidates (their posterUrls embed the base that produced them).
+    const cacheKey = `${base}|${q.toLowerCase()}:${limit}`;
     const cached = this.cache.get(cacheKey);
     if (cached && cached.exp > this.now()) return cached.value;
 
-    const base = this.getBaseUrl();
     const url = `${base}/api/search?` + new URLSearchParams({ q, limit: String(limit) }).toString();
 
     try {

--- a/messages/en.json
+++ b/messages/en.json
@@ -903,6 +903,11 @@
     "posters": {
       "title": "Posters",
       "addPoster": "Add Poster",
+      "theatreSearchLabel": "From the shows base (BilletReduc)",
+      "theatreSearchPlaceholder": "Search a show by title...",
+      "theatreSearchHint": "Type at least 2 characters to search for a show.",
+      "theatreNoResults": "No show found.",
+      "theatreSearchError": "Shows base unreachable.",
       "uploadPoster": "Upload Poster",
       "editPoster": "Edit Poster",
       "updatePoster": "Update Poster",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -903,6 +903,11 @@
     "posters": {
       "title": "Affiches",
       "addPoster": "Ajouter une affiche",
+      "theatreSearchLabel": "Depuis la base spectacles (BilletReduc)",
+      "theatreSearchPlaceholder": "Rechercher un spectacle par titre...",
+      "theatreSearchHint": "Tapez au moins 2 caractères pour rechercher un spectacle.",
+      "theatreNoResults": "Aucun spectacle trouvé.",
+      "theatreSearchError": "Base spectacles injoignable.",
       "uploadPoster": "Télécharger une affiche",
       "editPoster": "Modifier l'affiche",
       "updatePoster": "Mettre à jour l'affiche",

--- a/server/api/liveAssistBoot.ts
+++ b/server/api/liveAssistBoot.ts
@@ -2,6 +2,7 @@ import { SettingsService } from "@/lib/services/SettingsService";
 import { ChannelManager } from "@/lib/services/ChannelManager";
 import { WikipediaResolverService } from "@/lib/services/WikipediaResolverService";
 import { TmdbResolverService } from "@/lib/services/TmdbResolverService";
+import { TheaterDataResolverService } from "@/lib/services/TheaterDataResolverService";
 import { Logger } from "@/lib/utils/Logger";
 import { LiveAssistOrchestrator } from "@/lib/services/liveassist/LiveAssistOrchestrator";
 import { TranscriptBuffer } from "@/lib/services/liveassist/TranscriptBuffer";
@@ -110,6 +111,18 @@ export function buildOrchestrator(): {
       description: "Trouver l'affiche officielle d'un film / série cité (TMDB) et l'ajouter aux posters",
       defaultKeywords: LIVE_ASSIST.DEFAULT_KEYWORDS["poster-tmdb"],
       defaultContextPrompt: LIVE_ASSIST.DEFAULT_CONTEXT_PROMPTS["poster-tmdb"],
+    }),
+  );
+
+  // Poster provider (theater-data): spectacles / impro / concerts — the REAL BilletReduc
+  // affiche from Julien's local show base (better than Wikipedia for stage shows, cf #116).
+  // Degrades silently when the base URL is unset or the server (WSL, manual) is down.
+  registry.register(
+    new PosterActionProvider(TheaterDataResolverService.getInstance(), createPoster, {
+      id: "poster-theatre",
+      description: "Trouver l'affiche d'un spectacle / pièce / impro cité (base locale BilletReduc) et l'ajouter aux posters",
+      defaultKeywords: LIVE_ASSIST.DEFAULT_KEYWORDS["poster-theatre"],
+      defaultContextPrompt: LIVE_ASSIST.DEFAULT_CONTEXT_PROMPTS["poster-theatre"],
     }),
   );
 


### PR DESCRIPTION
## Contexte

Julien a une base locale **theater-data** (spectacles théâtre/impro/concerts synchronisés depuis BilletReduc, SQLite exposé en HTTP sur `:4173`, tourne en WSL, lancé manuellement). Cette PR permet à OBS Live Suite de s'appuyer dessus comme **source d'affiches**, via **HTTP** (choix : pas de lecture directe SQLite → pas de couplage au schéma, pas de double maintenance).

Deux consommateurs :
1. **Live Assist** — un titre de spectacle prononcé propose la vraie affiche BilletReduc (meilleur que Wikipédia pour les spectacles, cf #116).
2. **Ajout manuel d'affiche** — un typeahead fuzzy dans la base, autofill **titre + accroche + affiche**.

## Changements

- **`TheaterDataResolverService`** — singleton calqué sur `TmdbResolverService` : `search()` (dégradation silencieuse → `[]` si serveur down/timeout), `resolveAndFetch()` (contrat `Resolver`, top-1), `testConnection()`. URL lue live depuis le setting `theater_data_url`, timeout court 2 s. Bloc `THEATER_DATA` dans `Constants.ts`.
- **Live Assist** — 3ᵉ `PosterActionProvider` id `poster-theatre` enregistré dans `liveAssistBoot.ts` (inconditionnel, dégrade seul).
- **Ajout manuel** — proxy server-side `GET /api/theatre/search` (pas de CORS) + `TheatreSearchCombobox` (débounce 300 ms, vignettes) intégré dans `PosterManager`. À la sélection : autofill + image copiée en local (`downloadToLocal`, survit à l'extinction de theater-data). L'upload manuel classique reste disponible à côté (optionnel).
- **Réglage** — `theater_data_url` (défaut `http://localhost:4173`) : carte dans Settings › AI + bouton « Tester la connexion » + route `/api/settings/integrations/theatre-test`. i18n fr/en.
- **Tests** — 14 tests unitaires pour le resolver.

Aucun changement côté theater-data : `/api/search` et `/poster/{id}` existaient déjà. Serveur lancé manuellement (`pnpm web` en WSL), **pas** dans PM2.

## Vérification

Type-check propre (0 nouvelle erreur), 14 tests verts, et **bout en bout contre le vrai serveur WSL** :
- `GET /api/theatre/search?q=impro` → 12 vrais spectacles (mapping FR→normalisé OK) ; query vide → `{candidates:[]}`.
- `http://localhost:4173/poster/{id}` → `image/jpeg`, joignable depuis Windows (forward WSL) → vignettes + `downloadToLocal` OK.
- Bouton test → `{success:true, "Connexion OK"}`.

## Note

L'autofill utilise l'**accroche** comme description (une seule requête). Upgrade possible vers la `description` complète via `/api/play/{id}` si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)